### PR TITLE
Fix reTerminal E1004 showing greyscale instead of color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New
 
 - **Mandelbrot screen** (`mandelbrot`): Renders a random, aesthetically-pleasing region of the Mandelbrot set on each refresh. Picks from a curated list of well-known locations (Seahorse Valley, Elephant Valley, Mini Mandelbrot, Feigenbaum Point, ...), jitters the centre and zoom, computes escape-time in Lua with smooth iteration count, run-length encodes horizontal pixel runs for compact SVG output, and labels the view with location name, zoom factor, and complex centre coordinates. Builds the escape-time gradient from the panel's own `layout.colors` (sorted by Rec. 709 luminance), so greyscale panels get a black→white ramp and colour panels get a natural through-the-palette ramp (e.g. black→red→yellow→white on a 4-colour TRMNL OG).
+- **reTerminal E1004 panel profile** (`reterminal_e1004`): 1200×1600, 6-color Spectra 6 palette. Added to the bundled `config.yaml`.
 ### Changed
+
+- **Panel auto-detection now also matches the `Model` header.** Previously a panel's `match:` was only compared against the firmware `Board` header. The reTerminal E1004 reports its panel identity in `Model` (and sends no `Board` header), so it could never auto-detect a panel and fell back to the greyscale default. Matching now tries `Board` first, then `Model`.
+- The "Device not registered" log line now includes the device's `Board`, `Model`, `Colors` headers and resolved `width`/`height`. This makes it possible to author a matching panel profile (`match:`, `colors:`) for a brand-new device directly from the server log, before it has been registered.
 
 ### Fixed
 

--- a/config.yaml
+++ b/config.yaml
@@ -103,7 +103,22 @@ panels:
       sierra-light:
         error_clamp: 0.11
         noise_scale: 5
-        
+  reterminal_e1004:
+    name: "reTerminal E1004 (6-color, 13.3\")"
+    # E1004 firmware reports its identity in the `Model` header (not `Board`),
+    # which the panel matcher now also checks.
+    match: "reterminal_e1004"
+    width: 1200
+    height: 1600
+    colors: "#000000,#FFFFFF,#FF0000,#FFFF00,#0000FF,#00FF00"
+    # Seeded from the E1002's measured Spectra 6 values (same color technology).
+    # Re-calibrate with the `calibrator` screen for this specific panel if needed.
+    colors_actual: "#000000,#FFFFFF,#B50303,#FFEE00,#205497,#0D876B"
+    dither:
+      sierra-light:
+        error_clamp: 0.11
+        noise_scale: 5
+
 screens:
   # Default screen - shows time and a message
   default:
@@ -175,6 +190,11 @@ devices:
     params:
       station: "Trans, Dorf"
       limit: 8
+  # reTerminal E1004 (13.3" 6-color Spectra 6).
+  # No explicit `panel:` — the reterminal_e1004 panel auto-detects via the Model header.
+  "44:1B:F6:83:93:38":
+    screen: default
+    params: {}
   "QHUTU-REZWE":
     panel: reterminal_e1001
     screen: gphoto

--- a/config.yaml
+++ b/config.yaml
@@ -111,9 +111,8 @@ panels:
     width: 1200
     height: 1600
     colors: "#000000,#FFFFFF,#FF0000,#FFFF00,#0000FF,#00FF00"
-    # Seeded from the E1002's measured Spectra 6 values (same color technology).
-    # Re-calibrate with the `calibrator` screen for this specific panel if needed.
-    colors_actual: "#000000,#FFFFFF,#B50303,#FFEE00,#205497,#0D876B"
+    # Measured on the physical E1004 panel via the dev-mode calibrator.
+    colors_actual: "#000000,#FFFFFF,#C20000,#FFE042,#2160C4,#00994D"
     dither:
       sierra-light:
         error_clamp: 0.11
@@ -193,8 +192,12 @@ devices:
   # reTerminal E1004 (13.3" 6-color Spectra 6).
   # No explicit `panel:` — the reterminal_e1004 panel auto-detects via the Model header.
   "44:1B:F6:83:93:38":
-    screen: default
-    params: {}
+    screen: gphoto
+    dither: sierra-light
+    params:
+      album_url: "https://photos.app.goo.gl/xS9tWGRShAzf3YCg6"
+      show_status: false
+      refresh_rate: 300
   "QHUTU-REZWE":
     panel: reterminal_e1001
     screen: gphoto

--- a/src/api/display.rs
+++ b/src/api/display.rs
@@ -254,6 +254,11 @@ pub async fn handle_display<R: DeviceRegistry>(
                 device_id = device_id_str,
                 registration_code = %registration_code,
                 custom_screen = config.registration.screen.as_deref(),
+                board = ?headers.get_str("Board"),
+                model = ?headers.get_str("Model"),
+                colors = ?headers.get_str("Colors"),
+                width = width,
+                height = height,
                 "Device not registered, showing registration screen"
             );
             let code = registration_code.as_str();
@@ -450,6 +455,10 @@ pub async fn handle_display<R: DeviceRegistry>(
         .and_then(|b| config.find_panel_for_board(b))
     {
         (Some(p), Some(format!("board_header:{}", name)))
+    } else if let Some((name, p)) = config.find_panel_for_board(model_str) {
+        // Some devices (e.g. reTerminal E1004) report their panel identity in the
+        // `Model` header rather than `Board`; fall back to matching against it.
+        (Some(p), Some(format!("model_header:{}", name)))
     } else {
         (None, None)
     };

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -182,7 +182,8 @@ pub struct AppConfig {
 pub struct PanelConfig {
     /// Human-readable display name (e.g. "TRMNL OG (4-grey)")
     pub name: String,
-    /// Exact string match against firmware Board header
+    /// Exact string match against the firmware `Board` header (or the `Model`
+    /// header as a fallback, for devices that report panel identity there).
     #[serde(rename = "match")]
     pub match_pattern: Option<String>,
     pub width: Option<u32>,


### PR DESCRIPTION
## Problem

The reTerminal **E1004** (13.3" 6-color Spectra 6) displayed in greyscale instead of color.

Two stacked causes:
1. **It wasn't registered** → it was stuck on the registration screen, which returns before any panel/color resolution and serves the 4-grey default palette.
2. **Panel auto-detection only matched the `Board` header.** The E1004 reports its panel identity in the **`Model`** header (`reterminal_e1004`) and sends *no* `Board` header (and no `Colors` header) — so it never matched a panel and fell back to greyscale.

## Changes

- **Panel matching falls back to the `Model` header** when the `Board` header yields no match (`src/api/display.rs`).
- **New `reterminal_e1004` panel profile** in `config.yaml`: 1200×1600, 6-color Spectra 6 palette, with `colors_actual` measured on the physical panel via the dev-mode calibrator.
- **Registered the device** (`44:1B:F6:83:93:38`) and pointed it at the `gphoto` screen with `sierra-light` dither.
- **Enriched the "Device not registered" log** with `Board`/`Model`/`Colors`/`width`/`height`, so a brand-new device's panel can be authored straight from the server log.
- Doc comment + `CHANGES.md` updated.

## Verification

Confirmed from live device polls:
- `panel_source = model_header:reterminal_e1004`
- Resolved palette = 6-color; `colors_actual` = measured values; `measured_source = panel.colors_actual`
- Screen resolves to `gphoto`, dither to `sierra-light`
- Owner confirmed color renders correctly on the physical panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)