### PR TITLE
Phase 1: Byonk admin/management API (HA foundation)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Mandelbrot screen** (`mandelbrot`): Renders a random, aesthetically-pleasing region of the Mandelbrot set on each refresh. Picks from a curated list of well-known locations (Seahorse Valley, Elephant Valley, Mini Mandelbrot, Feigenbaum Point, ...), jitters the centre and zoom, computes escape-time in Lua with smooth iteration count, run-length encodes horizontal pixel runs for compact SVG output, and labels the view with location name, zoom factor, and complex centre coordinates. Builds the escape-time gradient from the panel's own `layout.colors` (sorted by Rec. 709 luminance), so greyscale panels get a black→white ramp and colour panels get a natural through-the-palette ramp (e.g. black→red→yellow→white on a 4-colour TRMNL OG).
 - **reTerminal E1004 panel profile** (`reterminal_e1004`): 1200×1600, 6-color Spectra 6 palette. Added to the bundled `config.yaml`.
+- **Admin/management API** (`/api/admin/*`), gated by a bearer token
+  (`BYONK_ADMIN_TOKEN` env or `admin.token` in config; disabled = returns 404):
+  read device telemetry, pending/unregistered devices, effective config, and
+  screen param schemas; create/update/delete device mappings and update global
+  settings (`registration_enabled`, `auth_mode`, `default_screen`).
+- **Per-screen parameter schemas** via a parsed (not executed) `@params` header in
+  each screen's `.lua`, with UI hints (label, min/max/step/unit/mode, enum
+  options, sensitive/multiline/hidden/advanced). Bundled screens now declare
+  their params.
+- **Config hot-reload**: admin writes update `config.yaml` in place (preserving
+  comments and formatting via targeted YAML path patching) and take effect
+  without a restart.
 ### Changed
 
 - **Panel auto-detection now also matches the `Model` header.** Previously a panel's `match:` was only compared against the firmware `Board` header. The reTerminal E1004 reports its panel identity in `Model` (and sends no `Board` header), so it could never auto-detect a panel and fell back to the greyscale default. Matching now tries `Board` first, then `Model`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Config hot-reload**: admin writes update `config.yaml` in place (preserving
   comments and formatting via targeted YAML path patching) and take effect
   without a restart.
+
 ### Changed
 
 - **Panel auto-detection now also matches the `Model` header.** Previously a panel's `match:` was only compared against the firmware `Board` header. The reTerminal E1004 reports its panel identity in `Model` (and sends no `Board` header), so it could never auto-detect a panel and fell back to the greyscale default. Matching now tries `Board` first, then `Model`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +309,7 @@ name = "byonk"
 version = "0.15.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "base64",
@@ -348,6 +358,8 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "wiremock",
+ "yamlpatch",
+ "yamlpath",
 ]
 
 [[package]]
@@ -1660,6 +1672,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
+name = "line-index"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e27e0ed5a392a7f5ba0b3808a2afccff16c64933312c84b57618b49d1209bd2"
+dependencies = [
+ "nohash-hasher",
+ "text-size",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1880,12 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "notify"
@@ -2717,6 +2751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2798,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2944,6 +2985,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3029,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subfeature"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e685ca3f1f2cd09b04ada9642ea26a0dd7bcf52f963ace408b0279f192f7465f"
+dependencies = [
+ "memchr",
+ "regex",
+ "serde",
+]
 
 [[package]]
 name = "subtle"
@@ -3081,6 +3139,12 @@ dependencies = [
  "slug",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -3360,6 +3424,45 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-iter"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa36a1486a196f8de9ded8047a5c6e42d8b9d83a530a67e8316ba8468a325d4"
+dependencies = [
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -3962,6 +4065,49 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "yamlpatch"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919764173d845c2b685a44ca9a028534ef1127bcf713edc6b69787430f18b030"
+dependencies = [
+ "indexmap",
+ "line-index",
+ "serde_json",
+ "subfeature",
+ "thiserror",
+ "yaml_serde",
+ "yamlpath",
+]
+
+[[package]]
+name = "yamlpath"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eed75b3170866fd4ad5848fb7e19ce9344f3dbc12238d9b175ef0632d27779"
+dependencies = [
+ "line-index",
+ "self_cell",
+ "serde",
+ "thiserror",
+ "tree-sitter",
+ "tree-sitter-iter",
+ "tree-sitter-yaml",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "wiremock",
+ "yaml_serde",
  "yamlpatch",
  "yamlpath",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ clap = { version = "4", features = ["derive"] }
 arc-swap = "1"
 yamlpath = "1"
 yamlpatch = "1"
+# Must stay in sync with the yaml_serde version yamlpatch depends on:
+# Op values are yaml_serde::Value, so a mismatched major/minor would not unify.
 yaml_serde = "0.10"
 
 # Utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ clap = { version = "4", features = ["derive"] }
 arc-swap = "1"
 yamlpath = "1"
 yamlpatch = "1"
+yaml_serde = "0.10"
 
 # Utilities
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ anyhow = "1"
 # CLI
 clap = { version = "4", features = ["derive"] }
 
+# Config hot-reload + comment-preserving YAML edits
+arc-swap = "1"
+yamlpath = "1"
+yamlpatch = "1"
+
 # Utilities
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Report privately using one of:
+
+1. **GitHub private vulnerability reporting (preferred)** — go to the repository's
+   **Security** tab → **Report a vulnerability**
+   (<https://github.com/oetiker/byonk/security/advisories/new>). This keeps the report
+   confidential and lets us collaborate on a fix and advisory.
+2. **Email** — <oetiker@gmail.com>, with `byonk security` in the subject line.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof-of-concept, affected endpoint/config, request samples).
+- The byonk version (`byonk --version`) and how it is deployed (binary, Docker image, etc.).
+- Any suggested remediation, if you have one.
+
+### What to expect
+
+- **Acknowledgement** within a few days.
+- An assessment and, for confirmed issues, a fix in the latest release.
+- Credit in the release notes / advisory if you would like it (let us know how to attribute you).
+
+This is a volunteer-maintained project; please allow reasonable time for a fix before any
+public disclosure. We aim to coordinate disclosure with you.
+
+## Supported Versions
+
+Byonk is pre-1.0; only the **latest release** receives security fixes. Please upgrade to the
+current release before reporting, and expect fixes to land in a new release rather than as a
+backport.
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | ✅ |
+| Older releases | ❌ |
+
+## Scope & deployment notes
+
+Byonk is a **self-hosted** content server for TRMNL e-ink devices. A few things worth knowing
+when assessing or deploying it securely:
+
+- **Admin/management API** (`/api/admin/*`) is **disabled by default** and returns `404` unless
+  an admin token is configured via the `BYONK_ADMIN_TOKEN` environment variable or `admin.token`
+  in `config.yaml`. When enabled it requires an `Authorization: Bearer <token>` header. Use a
+  strong, random token and prefer the environment variable over the config file.
+- **Device authentication** uses per-device API keys (`api_key` mode) or Ed25519 signatures
+  (`ed25519` mode), advertised via `/api/setup`.
+- **Lua screens** are server-side scripts you provide; treat screen scripts and their data
+  sources as trusted code running on your server.
+- Byonk is typically deployed on a **trusted LAN** alongside the e-ink devices. If you expose it
+  beyond your network, place it behind TLS and restrict access; do not expose the admin API to
+  untrusted networks.
+
+In-scope reports include (non-exhaustively): authentication/authorization bypass, admin-API
+token leakage, SSRF via screen data fetching, path traversal in asset/config handling, and
+remote code execution. Issues that require already-trusted access (e.g. the contents of screen
+scripts you author yourself) are generally out of scope.

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,0 +1,70 @@
+# Handover — Byonk ↔ Home Assistant
+
+_Last updated: 2026-06-28_
+
+## Goal (the whole effort)
+
+Make byonk runnable and **fully manageable from Home Assistant**, in two user-facing deliverables:
+- **HA Add-on** — runs byonk as a Supervisor container (reuses the prebuilt `ghcr.io/oetiker/byonk` multi-arch image) with persistent config.
+- **HA Integration** (`custom_components/byonk/`) — manages byonk via **HA-idiomatic UI** (select/switch/number/text entities + native config forms): device telemetry, full read-write of device→screen mappings and global settings, and device onboarding.
+
+Both live as folders in this repo and talk to a byonk **admin API**. Byonk stays the source of truth and persists everything to `config.yaml`.
+
+### Phase plan (each phase = its own spec → plan → implementation)
+1. **Phase 1 — Byonk admin/management API. ✅ DONE** (see below).
+2. **Phase 2 — HA Add-on** packaging (`homeassistant/` add-on repo structure, prebuilt image, persistent `addon_config`, options, optional Ingress for the `/dev` preview). NEXT.
+3. **Phase 3 — HA Integration** (`custom_components/byonk/`): config flow, HA Device per TRMNL, sensors, diagnostic entities, select/number/switch/text controls, subentry-based device add/edit, registration onboarding. Consumes the Phase 1 API.
+4. **Phase 4 — Release & docs** (multi-arch publishing aligned to add-on versions, mdBook docs, HACS metadata).
+
+## Current status
+
+- **Phase 1 is complete and in review:** PR **#19** → https://github.com/oetiker/byonk/pull/19
+  - Branch: `feat/homeassistant-admin-api` (cut from `chore/update-dependencies`, so it also carries that dep-update commit; base of the PR is `main`).
+  - Built task-by-task with TDD; every task individually reviewed + a final whole-branch review (verdict: ready to merge, no Critical/Important). Full suite green; `make docs` clean.
+- Nothing else started yet. Phases 2–4 are not begun.
+
+## What Phase 1 delivered (the API Phase 3 will consume)
+
+Token-gated `/api/admin/*` (bearer token from `BYONK_ADMIN_TOKEN` env or `admin.token` in config; **404 when no token configured**, 401 when wrong):
+
+| Method + path | Purpose |
+|---|---|
+| `GET /api/admin/devices` | configured + seen devices, telemetry + resolved active screen |
+| `GET /api/admin/pending` | connected-but-unregistered devices (+ registration code) |
+| `GET /api/admin/config` | effective config as JSON (admin token stripped) |
+| `GET /api/admin/screens` | screens + per-screen param schemas + panels + dither algorithms |
+| `POST /api/admin/devices` | add a device→screen mapping |
+| `PATCH /api/admin/devices/:key` | update mapping (top-level fields merge; **`params` is a full replacement**) |
+| `DELETE /api/admin/devices/:key` | remove a mapping |
+| `PATCH /api/admin/settings` | registration on/off, auth_mode, default_screen |
+
+Supporting features: per-screen **`@params`** schema (parsed-not-executed YAML header in each screen `.lua`), **comment-preserving** `config.yaml` writes (yamlpath/yamlpatch), **config hot-reload** (arc-swap; atomic write + reparse + rollback; writes serialized by a mutex).
+
+Key source: `src/api/admin/{mod,read,write}.rs`, `src/models/param_schema.rs`, `src/services/config_writer.rs`, `src/server.rs` (`SharedConfig`, `AppState`, `reload_config`). User docs: `docs/src/api/admin-api.md`.
+
+## Where to pick up next
+
+**Start Phase 2 (HA Add-on).** Run the `brainstorming` skill to produce a Phase 2 spec, then `writing-plans`, then execute (subagent-driven-development). Likely contents:
+- `homeassistant/` add-on repository structure (repository.yaml + one add-on folder with `config.yaml`/`Dockerfile` or `image:` referencing `ghcr.io/oetiker/byonk`).
+- Map a persistent config dir (`addon_config`); set env `CONFIG_FILE`/`SCREENS_DIR`/`FONTS_DIR`/`BIND_ADDR` and `BYONK_ADMIN_TOKEN`.
+- Add-on options: token (auto-generate?), port, log level, run mode (serve vs dev), optional Ingress for `/dev`.
+- TRMNL devices reach byonk directly on the LAN (host port), not via Ingress.
+
+## Reference docs (read these before continuing)
+
+- Phase 1 spec: `docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase1-admin-api-design.md` (also contains the umbrella vision + phase summaries)
+- Phase 1 plan: `docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase1-admin-api.md`
+- SDD progress ledger (git-ignored): `.superpowers/sdd/progress.md` — per-task commit ranges + deferred findings.
+
+## Deferred / fast-follow items (non-blocking, from the final review)
+
+1. Convert the per-handler `require_admin` call into a nested-router **middleware layer** so a future admin endpoint can't silently skip auth.
+2. Reconcile write-path screen validation (config-only) with `ContentPipeline::resolve_screen`'s filesystem auto-discovery — or document that admin writes require a configured `screens:` entry.
+3. Minor hardening: `extract_params_block` should require the `@params` marker inside a `--[[ ]]` comment; surface `persist` rollback-write failures; `config_writer` insert assumes 2-space indent and a non-flow `devices:` map.
+4. Test coverage gaps (all behavior is integration-tested, but some unit gaps): per-screen `@params` parse tests (floerli), more no-param screens, more device-write branch unit tests.
+
+## Build / verify
+
+- `make check` — fmt + clippy + tests (all green as of Phase 1).
+- `make docs` — mdBook build (clean).
+- `make build` / `make release`.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,4 +25,5 @@
 # API Reference
 
 - [HTTP API](api/http-api.md)
+- [Admin API](api/admin-api.md)
 - [Lua API](api/lua-api.md)

--- a/docs/src/api/admin-api.md
+++ b/docs/src/api/admin-api.md
@@ -74,6 +74,8 @@ config mapping, plus any configured devices that have never connected yet.
 Field notes:
 - `key` — the config map key for this device (MAC or registration code).
 - `registered` — `true` if the device appears in the `devices:` config section.
+- `registration_code` is an empty string for devices that appear in config but have never
+  connected (it is never `null`).
 - Telemetry fields (`model`, `firmware_version`, `last_seen`, `battery_voltage`, `rssi`) are
   `null` for devices that are configured but have never connected.
 - `screen`, `dither`, `panel`, `colors`, `params` reflect the resolved config mapping; they
@@ -175,6 +177,7 @@ supported dither algorithms.
 Field notes:
 - `schema_error` is `null` when the schema parsed successfully, or a string describing the
   error when the `@params` block is malformed or the script file cannot be read.
+- `width` and `height` may be `null` for panels without explicit dimensions.
 - Optional `ParamField` keys (`label`, `description`, `min`, `max`, `step`, `unit`, `mode`,
   `options`) are omitted from the JSON when not set.
 
@@ -211,9 +214,16 @@ Required fields: `key`, `screen`. All other fields are optional.
 
 ### PATCH /api/admin/devices/:key
 
-Update an existing device mapping. Only the provided fields are changed; omitted fields
-keep their current values. The `:key` in the URL must match an existing entry in the
+Update an existing device mapping. The `:key` in the URL must match an existing entry in the
 `devices:` config section.
+
+The top-level fields (`screen`, `panel`, `dither`, `colors`) merge individually: omitted
+ones keep their current values.
+
+**`params` is a full replacement:** when the `params` key is present in the request body, it
+replaces the device's entire param map. To change a single param, send the complete set of
+params including any unchanged ones. Omit the `params` key entirely to leave existing params
+untouched.
 
 **Request body** (all fields optional):
 
@@ -221,7 +231,7 @@ keep their current values. The `:key` in the URL must match an existing entry in
 {
   "screen": "transit",
   "dither": "floyd-steinberg",
-  "params": { "limit": 5 }
+  "params": { "station": "Bern, Bahnhof", "limit": 5 }
 }
 ```
 

--- a/docs/src/api/admin-api.md
+++ b/docs/src/api/admin-api.md
@@ -1,0 +1,396 @@
+# Admin API
+
+Byonk exposes a token-gated management API under `/api/admin/*`. It lets you read device
+telemetry, manage device-to-screen mappings, inspect the effective config, and update
+global settings — all without restarting the server.
+
+## Enabling the API
+
+The admin API is disabled by default. If no token is configured, **every** `/api/admin/*`
+request returns `404 Not Found` — the route is invisible to unauthenticated callers.
+
+To enable it, provide a secret token in either of these ways (the environment variable takes
+precedence):
+
+```
+BYONK_ADMIN_TOKEN=mysecrettoken   # environment variable
+```
+
+or in `config.yaml`:
+
+```yaml
+admin:
+  token: mysecrettoken
+```
+
+## Authentication
+
+Every request must include the token as a Bearer credential:
+
+```
+Authorization: Bearer mysecrettoken
+```
+
+| Situation | HTTP status |
+|-----------|-------------|
+| No token configured (admin disabled) | `404 Not Found` |
+| `Authorization` header missing or wrong token | `401 Unauthorized` |
+| Token correct | request proceeds |
+
+The comparison is constant-time to avoid timing side-channels.
+
+---
+
+## Endpoints
+
+### GET /api/admin/devices
+
+Return all known devices: every device that has been seen (with telemetry) merged with its
+config mapping, plus any configured devices that have never connected yet.
+
+**Response 200** — array of device objects:
+
+```json
+[
+  {
+    "key": "AA:BB:CC:DD:EE:FF",
+    "mac": "AA:BB:CC:DD:EE:FF",
+    "registration_code": "ABCD-1234",
+    "registered": true,
+    "model": "og",
+    "firmware_version": "1.7.1",
+    "last_seen": "2026-06-28T10:15:00+00:00",
+    "battery_voltage": 4.12,
+    "rssi": -58,
+    "screen": "transit",
+    "dither": "atkinson",
+    "panel": null,
+    "colors": null,
+    "params": { "station": "Olten, Südwest", "limit": 8 }
+  }
+]
+```
+
+Field notes:
+- `key` — the config map key for this device (MAC or registration code).
+- `registered` — `true` if the device appears in the `devices:` config section.
+- Telemetry fields (`model`, `firmware_version`, `last_seen`, `battery_voltage`, `rssi`) are
+  `null` for devices that are configured but have never connected.
+- `screen`, `dither`, `panel`, `colors`, `params` reflect the resolved config mapping; they
+  are `null` when the device has no mapping.
+
+---
+
+### GET /api/admin/pending
+
+Return devices that have contacted the server but are not yet registered (i.e., they appear
+in the device registry but have no matching entry in the `devices:` config section).
+
+**Response 200** — array of pending-device objects:
+
+```json
+[
+  {
+    "mac": "AA:BB:CC:DD:EE:FF",
+    "registration_code": "ABCD-1234",
+    "model": "og",
+    "firmware_version": "1.7.1",
+    "last_seen": "2026-06-28T09:00:00+00:00"
+  }
+]
+```
+
+Use `registration_code` or `mac` as the `key` when calling `POST /api/admin/devices`.
+
+---
+
+### GET /api/admin/config
+
+Return the effective configuration as JSON, parsed from the on-disk `config.yaml`. The
+`admin.token` field is stripped from the response.
+
+**Response 200** — the full config as a JSON object (structure mirrors `config.yaml`).
+
+---
+
+### GET /api/admin/screens
+
+Return the list of known screens (with their parameter schemas), panel profiles, and
+supported dither algorithms.
+
+**Response 200**:
+
+```json
+{
+  "screens": [
+    {
+      "name": "transit",
+      "params": [
+        {
+          "name": "station",
+          "type": "string",
+          "required": false,
+          "default": "Olten, Südwest",
+          "label": "Stop name",
+          "description": "Stop name as used by the transport API"
+        },
+        {
+          "name": "limit",
+          "type": "int",
+          "required": false,
+          "default": 8,
+          "label": "Departures",
+          "description": "Number of departures to show",
+          "min": 1.0,
+          "max": 30.0,
+          "mode": "box"
+        }
+      ],
+      "schema_error": null
+    }
+  ],
+  "panels": [
+    {
+      "name": "trmnl_og",
+      "width": 800,
+      "height": 480,
+      "colors": "bw"
+    }
+  ],
+  "dither_algorithms": [
+    "floyd-steinberg",
+    "atkinson",
+    "atkinson-hybrid",
+    "jarvis-judice-ninke",
+    "sierra",
+    "sierra-two-row",
+    "sierra-lite",
+    "sierra-light",
+    "stucki",
+    "burkes"
+  ]
+}
+```
+
+Field notes:
+- `schema_error` is `null` when the schema parsed successfully, or a string describing the
+  error when the `@params` block is malformed or the script file cannot be read.
+- Optional `ParamField` keys (`label`, `description`, `min`, `max`, `step`, `unit`, `mode`,
+  `options`) are omitted from the JSON when not set.
+
+---
+
+### POST /api/admin/devices
+
+Create a new device mapping in `config.yaml`.
+
+**Request body**:
+
+```json
+{
+  "key": "AA:BB:CC:DD:EE:FF",
+  "screen": "transit",
+  "panel": null,
+  "dither": "atkinson",
+  "colors": null,
+  "params": { "station": "Bern, Bahnhof", "limit": 10 }
+}
+```
+
+Required fields: `key`, `screen`. All other fields are optional.
+
+**Responses**:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Created — `{"key": "AA:BB:CC:DD:EE:FF", "screen": "transit"}` |
+| `400` | Validation error (missing `key`/`screen`, unknown screen, param type mismatch, out-of-range value) |
+| `409` | Device key already exists, or config is embedded/read-only (`set CONFIG_FILE` env var) |
+
+---
+
+### PATCH /api/admin/devices/:key
+
+Update an existing device mapping. Only the provided fields are changed; omitted fields
+keep their current values. The `:key` in the URL must match an existing entry in the
+`devices:` config section.
+
+**Request body** (all fields optional):
+
+```json
+{
+  "screen": "transit",
+  "dither": "floyd-steinberg",
+  "params": { "limit": 5 }
+}
+```
+
+**Responses**:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Updated — `{"key": "AA:BB:CC:DD:EE:FF", "screen": "transit"}` |
+| `400` | Validation error |
+| `404` | No device with that key |
+| `409` | Config is embedded/read-only |
+
+---
+
+### DELETE /api/admin/devices/:key
+
+Remove a device mapping from `config.yaml`.
+
+**Responses**:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Deleted — `{"deleted": "AA:BB:CC:DD:EE:FF"}` |
+| `404` | No device with that key |
+| `409` | Config is embedded/read-only |
+
+---
+
+### PATCH /api/admin/settings
+
+Update global settings in `config.yaml`. All fields are optional; only provided fields are
+changed.
+
+**Request body**:
+
+```json
+{
+  "registration_enabled": true,
+  "auth_mode": "api_key",
+  "default_screen": "transit"
+}
+```
+
+| Field | Type | Allowed values |
+|-------|------|---------------|
+| `registration_enabled` | boolean | `true` / `false` |
+| `auth_mode` | string | `"api_key"` or `"ed25519"` |
+| `default_screen` | string | any screen name listed in `GET /api/admin/screens` |
+
+**Responses**:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Applied — `{"ok": true}` |
+| `400` | Validation error (unknown screen, invalid auth_mode) |
+| `409` | Config is embedded/read-only |
+
+---
+
+## Comment-preserving writes and hot-reload
+
+All write endpoints (`POST`, `PATCH`, `DELETE`) modify `config.yaml` in place using a
+targeted YAML path patch. Existing comments and formatting in the file are preserved — only
+the specific keys that changed are rewritten.
+
+After a successful write the server reloads the config atomically (via an ARC swap) so the
+change takes effect **without a restart**. The next `/api/display` request for an affected
+device will use the updated mapping immediately. If the reloaded YAML fails to parse, the
+write is rolled back to the previous file contents.
+
+Writes require a file-backed config. If the server was started with an embedded/bundled
+config (no `CONFIG_FILE` environment variable), write endpoints return `409 Conflict` with
+the message `"config is embedded/read-only; set CONFIG_FILE"`.
+
+---
+
+## @params schema format
+
+Screens can declare their accepted parameters in a Lua block comment at the top of the
+`.lua` file. Byonk parses this block as YAML — it is never executed. The result is returned
+by `GET /api/admin/screens` and validated on every write.
+
+### Syntax
+
+```lua
+--[[ @params
+<param-name>:
+  type: <type>
+  # … other keys …
+]]
+```
+
+The block must appear before the first `]]` that follows `@params`. Everything else in the
+file is ignored for schema purposes.
+
+### Field reference
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `type` | string | — | **Required.** One of `string`, `int`, `float`, `bool`, `enum`, `color`, `url`. |
+| `required` | bool | `false` | When `true`, the param must be present in every device mapping. |
+| `default` | any | — | Default value shown in UI when param is absent. |
+| `label` | string | — | Human-readable name for UI display. |
+| `description` | string | — | Longer hint shown in tooltips or help text. |
+| `min` | number | — | Minimum value (applies to `int` and `float`). |
+| `max` | number | — | Maximum value (applies to `int` and `float`). |
+| `step` | number | — | Increment step for UI sliders. |
+| `unit` | string | — | Unit label shown next to the value (e.g., `"px"`, `"°C"`). |
+| `mode` | string | — | UI hint for input style (e.g., `"box"` for a numeric input box). |
+| `options` | list | — | Required for `enum` type. A list of bare strings (`[a, b]`) or `{value, label}` objects. |
+| `sensitive` | bool | `false` | Treat value as a secret (mask in UI). |
+| `multiline` | bool | `false` | Use a textarea instead of a single-line input. |
+| `hidden` | bool | `false` | Do not show in UI (still accepted in API). |
+| `advanced` | bool | `false` | Collapse into an "advanced" section in UI. |
+
+### Example — transit screen
+
+The bundled `transit` screen uses this `@params` block:
+
+```lua
+--[[ @params
+station:
+  type: string
+  label: "Stop name"
+  default: "Olten, Südwest"
+  description: "Stop name as used by the transport API"
+limit:
+  type: int
+  label: "Departures"
+  default: 8
+  min: 1
+  max: 30
+  mode: box
+  description: "Number of departures to show"
+]]
+```
+
+Field order is preserved in the schema response. The script accesses these values via the
+`params` Lua table (`params.station`, `params.limit`).
+
+### Enum options
+
+Enum options can be plain strings (where `label` defaults to the value):
+
+```yaml
+theme:
+  type: enum
+  options: [light, dark, auto]
+```
+
+Or objects with explicit labels:
+
+```yaml
+theme:
+  type: enum
+  options:
+    - { value: light, label: "Light mode" }
+    - { value: dark,  label: "Dark mode" }
+    - { value: auto,  label: "Follow system" }
+```
+
+### Validation
+
+When a device mapping is created or updated via the API, Byonk validates every provided
+param against the screen's schema:
+
+- Missing required params → `400 Bad Request`
+- Wrong type (e.g., string where `int` expected) → `400 Bad Request`
+- Value outside `min`/`max` range → `400 Bad Request`
+- Value not in `enum` options → `400 Bad Request`
+
+Extra params not listed in the schema are silently accepted (ignored by validation).

--- a/docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase1-admin-api.md
+++ b/docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase1-admin-api.md
@@ -1,0 +1,2600 @@
+# Byonk HA Phase 1 — Admin/Management API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a token-gated `/api/admin/*` HTTP API to byonk that exposes device
+telemetry and supports full read-write management of device→screen mappings and global
+settings, backed by per-screen `@params` schemas, comment-preserving config writes, and
+config hot-reload — so the future Home Assistant integration has a clean contract to build on.
+
+**Architecture:** New admin handlers live under `src/api/admin/`. Config becomes a
+hot-swappable `Arc<ArcSwap<AppConfig>>` shared by `AppState` and `ContentPipeline`. Writes
+go through a `config_writer` module that patches `config.yaml` text surgically with
+`yamlpath`/`yamlpatch` (preserving comments), then reloads the in-memory config. Screen
+parameter schemas are parsed (not executed) from a `@params` block in each screen's `.lua`.
+
+**Tech Stack:** Rust, axum 0.7, serde/serde_yaml/serde_json, tokio, `arc-swap`,
+`yamlpath`, `yamlpatch`, chrono.
+
+## Global Constraints
+
+- Rust edition 2021; workspace builds with `make check` (fmt + clippy + tests) clean.
+- Follow existing patterns: handlers in `src/api/`, errors via `ApiError`, tests in
+  `tests/` using `tests/common::TestApp`.
+- Error JSON shape is fixed: `{ "status": <u16>, "error": <string> }` (see `src/error.rs`).
+- Admin auth: `Authorization: Bearer <token>`. Token source = env `BYONK_ADMIN_TOKEN`,
+  else `admin.token` in config. **No token configured ⇒ every `/api/admin/*` returns 404.**
+  Wrong/missing token (when configured) ⇒ 401. Use constant-time comparison.
+- Writes require a file-backed config (a real `config.yaml` path). Embedded-only ⇒ 409.
+- Config writes MUST preserve comments/formatting outside the touched region.
+- Config changes take effect with no restart (hot-reload).
+- TDD: write the failing test first; commit after each green task.
+- Every code change updates `CHANGES.md` (Unreleased) in its task where user-visible.
+- Commit message footer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `src/error.rs` (modify) | Add `Unauthorized`, `BadRequest(String)`, `Conflict(String)` variants + status mapping |
+| `src/models/config.rs` (modify) | Add `AdminConfig { token }` + `admin` field on `AppConfig` |
+| `src/models/param_schema.rs` (create) | `@params` types, textual extractor, parser, value validator |
+| `src/services/device_registry.rs` (modify) | `list_all()` on trait + impl |
+| `src/services/config_writer.rs` (create) | Comment-preserving YAML patch ops + reload helper |
+| `src/server.rs` (modify) | `SharedConfig` type; `AppState` gains `asset_loader`, `admin_token`; arc-swap wiring; mount admin router |
+| `src/assets.rs` (modify) | `config_path()` getter |
+| `src/services/content_pipeline.rs` (modify) | Hold `SharedConfig`, `.load_full()` per use |
+| `src/api/admin/mod.rs` (create) | Auth guard, router, shared DTOs |
+| `src/api/admin/read.rs` (create) | `GET devices/pending/config/screens` |
+| `src/api/admin/write.rs` (create) | `POST/PATCH/DELETE devices`, `PATCH settings` |
+| `src/api/mod.rs` (modify) | `pub mod admin;` |
+| `screens/*.lua` (modify) | Add `@params` headers |
+| `tests/admin_*_test.rs` (create) | Integration tests per endpoint group |
+| `tests/common/app.rs` (modify) | Admin test constructors + `patch_json`/`delete` helpers |
+| `docs/src/...` + `CHANGES.md` (modify) | Docs + changelog |
+
+---
+
+## Task 1: Foundation — dependencies, error variants, admin config field
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/error.rs`
+- Modify: `src/models/config.rs`
+- Test: inline `#[cfg(test)]` in `src/error.rs` and `src/models/config.rs`
+
+**Interfaces:**
+- Produces: `ApiError::Unauthorized`, `ApiError::BadRequest(String)`, `ApiError::Conflict(String)`.
+- Produces: `AppConfig.admin: AdminConfig` where `pub struct AdminConfig { pub token: Option<String> }`.
+- Produces: new deps `arc-swap`, `yamlpath`, `yamlpatch` available to the crate.
+
+- [ ] **Step 1: Add dependencies**
+
+Add to `Cargo.toml` under `[dependencies]` (after the existing utility deps):
+
+```toml
+# Config hot-reload + comment-preserving YAML edits
+arc-swap = "1"
+yamlpath = "1"
+yamlpatch = "1"
+```
+
+Run `cargo fetch` to pull them.
+
+- [ ] **Step 2: Write failing tests for new error variants**
+
+Add to the `#[cfg(test)] mod tests` block in `src/error.rs`:
+
+```rust
+#[test]
+fn test_api_error_unauthorized_status() {
+    let resp = ApiError::Unauthorized.into_response();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn test_api_error_bad_request_status() {
+    let resp = ApiError::BadRequest("nope".into()).into_response();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn test_api_error_conflict_status() {
+    let resp = ApiError::Conflict("dup".into()).into_response();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test --lib error::tests`
+Expected: FAIL — `no variant named Unauthorized` etc.
+
+- [ ] **Step 4: Implement the variants**
+
+In `src/error.rs`, add to the `ApiError` enum:
+
+```rust
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
+    #[error("Conflict: {0}")]
+    Conflict(String),
+```
+
+And add to the `match &self` in `IntoResponse for ApiError`:
+
+```rust
+            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
+            ApiError::BadRequest(m) => (StatusCode::BAD_REQUEST, m.clone()),
+            ApiError::Conflict(m) => (StatusCode::CONFLICT, m.clone()),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --lib error::tests`
+Expected: PASS.
+
+- [ ] **Step 6: Write failing test for admin config field**
+
+Add to the `#[cfg(test)] mod tests` block in `src/models/config.rs`:
+
+```rust
+#[test]
+fn test_admin_token_parses_and_defaults() {
+    let yaml = "admin:\n  token: secret123\nscreens: {}\n";
+    let cfg: AppConfig = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(cfg.admin.token.as_deref(), Some("secret123"));
+
+    let cfg2: AppConfig = serde_yaml::from_str("screens: {}\n").unwrap();
+    assert_eq!(cfg2.admin.token, None);
+}
+```
+
+- [ ] **Step 7: Run test to verify it fails**
+
+Run: `cargo test --lib config::tests::test_admin_token_parses_and_defaults`
+Expected: FAIL — `no field admin`.
+
+- [ ] **Step 8: Implement AdminConfig**
+
+In `src/models/config.rs`, add the struct near `RegistrationConfig`:
+
+```rust
+/// Admin/management API settings.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct AdminConfig {
+    /// Bearer token gating `/api/admin/*`. If unset (and `BYONK_ADMIN_TOKEN` is
+    /// unset), the admin API is disabled (returns 404).
+    #[serde(default)]
+    pub token: Option<String>,
+}
+```
+
+Add the field to `AppConfig`:
+
+```rust
+    /// Admin/management API settings
+    #[serde(default)]
+    pub admin: AdminConfig,
+```
+
+Add `admin: AdminConfig::default(),` to the `AppConfig` literal in
+`impl Default for AppConfig` (the test `config.rs` block around the existing default).
+Export it in `src/models/mod.rs`:
+
+```rust
+pub use config::{
+    normalize_algorithm_name, AdminConfig, AppConfig, DeviceConfig, DitherTuningValues,
+    PanelDitherConfig, RegistrationConfig, ScreenConfig,
+};
+```
+
+- [ ] **Step 9: Run test + clippy**
+
+Run: `cargo test --lib config::tests::test_admin_token_parses_and_defaults && cargo clippy --all-targets`
+Expected: PASS, no clippy errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/error.rs src/models/config.rs src/models/mod.rs
+git commit -m "feat(admin): add deps, error variants, and admin config field
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Registry — list all devices
+
+**Files:**
+- Modify: `src/services/device_registry.rs`
+- Test: inline `#[cfg(test)]` in same file
+
+**Interfaces:**
+- Produces: `DeviceRegistry::list_all(&self) -> Result<Vec<Device>, ApiError>` (trait method)
+  implemented by `InMemoryRegistry`.
+
+- [ ] **Step 1: Write failing test**
+
+Add to the `#[cfg(test)] mod tests` in `src/services/device_registry.rs`:
+
+```rust
+#[tokio::test]
+async fn test_list_all_returns_all_devices() {
+    let registry = InMemoryRegistry::new();
+    let d1 = Device::new(DeviceId::new("AA:AA:AA:AA:AA:AA"), DeviceModel::OG, "1".into());
+    let d2 = Device::new(DeviceId::new("BB:BB:BB:BB:BB:BB"), DeviceModel::X, "2".into());
+    registry.upsert(d1).await.unwrap();
+    registry.upsert(d2).await.unwrap();
+
+    let all = registry.list_all().await.unwrap();
+    assert_eq!(all.len(), 2);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib device_registry::tests::test_list_all_returns_all_devices`
+Expected: FAIL — `no method named list_all`.
+
+- [ ] **Step 3: Implement**
+
+In the `pub trait DeviceRegistry` add:
+
+```rust
+    /// List all known devices.
+    async fn list_all(&self) -> Result<Vec<Device>, ApiError>;
+```
+
+In `impl DeviceRegistry for InMemoryRegistry` add:
+
+```rust
+    async fn list_all(&self) -> Result<Vec<Device>, ApiError> {
+        let devices = self.devices.read().await;
+        Ok(devices.values().cloned().collect())
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --lib device_registry::tests::test_list_all_returns_all_devices`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/device_registry.rs
+git commit -m "feat(admin): add DeviceRegistry::list_all
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Param schema — types, extractor, parser
+
+**Files:**
+- Create: `src/models/param_schema.rs`
+- Modify: `src/models/mod.rs`
+- Test: inline `#[cfg(test)]` in `src/models/param_schema.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub enum ParamType { String, Int, Float, Bool, Enum, Color, Url }` (serde snake_case, `Default = String`)
+  - `pub struct EnumOption { pub value: String, pub label: String }`
+  - `pub struct ParamField { pub name: String, pub param_type: ParamType, pub required: bool, pub default: Option<serde_json::Value>, pub label: Option<String>, pub description: Option<String>, pub min: Option<f64>, pub max: Option<f64>, pub step: Option<f64>, pub unit: Option<String>, pub mode: Option<String>, pub options: Vec<EnumOption>, pub sensitive: bool, pub multiline: bool, pub hidden: bool, pub advanced: bool }`
+  - `pub struct ParamSchema { pub fields: Vec<ParamField> }`
+  - `pub fn extract_params_block(lua_source: &str) -> Option<String>`
+  - `pub fn parse_schema(yaml: &str) -> Result<ParamSchema, String>`
+  - `pub fn schema_for_script(lua_source: &str) -> Result<Option<ParamSchema>, String>` (None when no `@params` block; `Err` when present but malformed)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/models/param_schema.rs` with tests at the bottom:
+
+```rust
+//! Per-screen `@params` schema: types, textual extraction from `.lua`, and parsing.
+//!
+//! The schema is declared inside a Lua block comment at the top of a screen script:
+//! ```lua
+//! --[[ @params
+//! station:
+//!   type: string
+//!   required: true
+//! ]]
+//! ```
+//! It is parsed as YAML — never executed.
+
+use serde::{Deserialize, Serialize};
+
+// (implementation added in later steps)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_block_present() {
+        let lua = "--[[ @params\nstation:\n  type: string\n]]\nlocal x = 1\n";
+        let block = extract_params_block(lua).unwrap();
+        assert!(block.contains("station:"));
+        assert!(block.contains("type: string"));
+        assert!(!block.contains("local x"));
+    }
+
+    #[test]
+    fn test_extract_block_absent() {
+        assert!(extract_params_block("local x = 1\n").is_none());
+    }
+
+    #[test]
+    fn test_parse_minimal_field() {
+        let schema = parse_schema("station:\n  type: string\n  required: true\n").unwrap();
+        assert_eq!(schema.fields.len(), 1);
+        let f = &schema.fields[0];
+        assert_eq!(f.name, "station");
+        assert_eq!(f.param_type, ParamType::String);
+        assert!(f.required);
+    }
+
+    #[test]
+    fn test_parse_preserves_order() {
+        let schema = parse_schema("b:\n  type: int\na:\n  type: string\n").unwrap();
+        assert_eq!(schema.fields[0].name, "b");
+        assert_eq!(schema.fields[1].name, "a");
+    }
+
+    #[test]
+    fn test_parse_enum_options_objects_and_bare() {
+        let obj = parse_schema(
+            "k:\n  type: enum\n  options:\n    - {value: a, label: Apple}\n    - {value: b, label: Banana}\n",
+        )
+        .unwrap();
+        assert_eq!(obj.fields[0].options.len(), 2);
+        assert_eq!(obj.fields[0].options[0].label, "Apple");
+
+        let bare = parse_schema("k:\n  type: enum\n  options: [a, b]\n").unwrap();
+        assert_eq!(bare.fields[0].options[0].value, "a");
+        assert_eq!(bare.fields[0].options[0].label, "a"); // label defaults to value
+    }
+
+    #[test]
+    fn test_parse_enum_without_options_is_error() {
+        assert!(parse_schema("k:\n  type: enum\n").is_err());
+    }
+
+    #[test]
+    fn test_parse_unknown_type_is_error() {
+        assert!(parse_schema("k:\n  type: banana\n").is_err());
+    }
+
+    #[test]
+    fn test_schema_for_script_none_when_no_block() {
+        assert!(schema_for_script("local x = 1\n").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_schema_for_script_err_when_malformed() {
+        let lua = "--[[ @params\nk:\n  type: banana\n]]\n";
+        assert!(schema_for_script(lua).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib param_schema`
+Expected: FAIL — module not declared / functions missing.
+
+- [ ] **Step 3: Declare the module**
+
+In `src/models/mod.rs` add `pub mod param_schema;` and extend the re-export:
+
+```rust
+pub use param_schema::{
+    extract_params_block, parse_schema, schema_for_script, EnumOption, ParamField, ParamSchema,
+    ParamType,
+};
+```
+
+- [ ] **Step 4: Implement types**
+
+Add above the `#[cfg(test)]` block in `src/models/param_schema.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ParamType {
+    #[default]
+    String,
+    Int,
+    Float,
+    Bool,
+    Enum,
+    Color,
+    Url,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnumOption {
+    pub value: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ParamField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub param_type: ParamType,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<EnumOption>,
+    #[serde(default)]
+    pub sensitive: bool,
+    #[serde(default)]
+    pub multiline: bool,
+    #[serde(default)]
+    pub hidden: bool,
+    #[serde(default)]
+    pub advanced: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+pub struct ParamSchema {
+    pub fields: Vec<ParamField>,
+}
+```
+
+- [ ] **Step 5: Implement extractor**
+
+```rust
+/// Extract the YAML text inside a `--[[ @params ... ]]` block. Returns `None`
+/// if no `@params` marker is present.
+pub fn extract_params_block(lua_source: &str) -> Option<String> {
+    let marker = lua_source.find("@params")?;
+    // Start after the rest of the marker line.
+    let after_marker = &lua_source[marker + "@params".len()..];
+    let body_start = after_marker.find('\n').map(|i| i + 1).unwrap_or(0);
+    let body = &after_marker[body_start..];
+    let end = body.find("]]")?;
+    Some(body[..end].to_string())
+}
+```
+
+- [ ] **Step 6: Implement parser**
+
+```rust
+/// Raw descriptor as written in YAML (without the `name`, which is the map key).
+#[derive(Deserialize)]
+struct RawField {
+    #[serde(rename = "type")]
+    param_type: ParamType,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    default: Option<serde_json::Value>,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    min: Option<f64>,
+    #[serde(default)]
+    max: Option<f64>,
+    #[serde(default)]
+    step: Option<f64>,
+    #[serde(default)]
+    unit: Option<String>,
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    options: Option<serde_yaml::Value>,
+    #[serde(default)]
+    sensitive: bool,
+    #[serde(default)]
+    multiline: bool,
+    #[serde(default)]
+    hidden: bool,
+    #[serde(default)]
+    advanced: bool,
+}
+
+fn parse_options(raw: serde_yaml::Value) -> Result<Vec<EnumOption>, String> {
+    let seq = raw
+        .as_sequence()
+        .ok_or_else(|| "enum `options` must be a list".to_string())?;
+    let mut out = Vec::new();
+    for item in seq {
+        if let Some(s) = item.as_str() {
+            out.push(EnumOption { value: s.to_string(), label: s.to_string() });
+        } else if let Some(map) = item.as_mapping() {
+            let value = map
+                .get(serde_yaml::Value::from("value"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "enum option object needs a string `value`".to_string())?
+                .to_string();
+            let label = map
+                .get(serde_yaml::Value::from("label"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| value.clone());
+            out.push(EnumOption { value, label });
+        } else {
+            return Err("enum option must be a scalar or {value,label} map".to_string());
+        }
+    }
+    Ok(out)
+}
+
+/// Parse a `@params` YAML body into a schema. Preserves field order.
+pub fn parse_schema(yaml: &str) -> Result<ParamSchema, String> {
+    // Empty body ⇒ empty schema (screen takes no params).
+    if yaml.trim().is_empty() {
+        return Ok(ParamSchema::default());
+    }
+    let mapping: serde_yaml::Mapping =
+        serde_yaml::from_str(yaml).map_err(|e| format!("invalid @params YAML: {e}"))?;
+
+    let mut fields = Vec::new();
+    for (k, v) in mapping {
+        let name = k
+            .as_str()
+            .ok_or_else(|| "param keys must be strings".to_string())?
+            .to_string();
+        let raw: RawField = serde_yaml::from_value(v)
+            .map_err(|e| format!("param `{name}`: {e}"))?;
+
+        let options = match raw.options {
+            Some(o) => parse_options(o)?,
+            None => Vec::new(),
+        };
+        if raw.param_type == ParamType::Enum && options.is_empty() {
+            return Err(format!("param `{name}`: enum requires non-empty `options`"));
+        }
+
+        fields.push(ParamField {
+            name,
+            param_type: raw.param_type,
+            required: raw.required,
+            default: raw.default,
+            label: raw.label,
+            description: raw.description,
+            min: raw.min,
+            max: raw.max,
+            step: raw.step,
+            unit: raw.unit,
+            mode: raw.mode,
+            options,
+            sensitive: raw.sensitive,
+            multiline: raw.multiline,
+            hidden: raw.hidden,
+            advanced: raw.advanced,
+        });
+    }
+    Ok(ParamSchema { fields })
+}
+
+/// Extract + parse a screen's schema. `Ok(None)` when there is no `@params`
+/// block; `Err` when a block is present but malformed.
+pub fn schema_for_script(lua_source: &str) -> Result<Option<ParamSchema>, String> {
+    match extract_params_block(lua_source) {
+        None => Ok(None),
+        Some(body) => parse_schema(&body).map(Some),
+    }
+}
+```
+
+> Note: `serde_yaml::from_value` deserializing `ParamType` requires the unknown-type case
+> to error — it does, because `ParamType` has no catch-all variant. `serde_yaml::Mapping`
+> preserves insertion order, giving stable field order.
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo test --lib param_schema && cargo clippy --all-targets`
+Expected: PASS, clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/models/param_schema.rs src/models/mod.rs
+git commit -m "feat(admin): add @params screen schema types, extractor, and parser
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Param value validation
+
+**Files:**
+- Modify: `src/models/param_schema.rs`
+- Test: inline `#[cfg(test)]`
+
+**Interfaces:**
+- Consumes: `ParamSchema`, `ParamType` (Task 3).
+- Produces: `pub fn validate_params(schema: &ParamSchema, params: &std::collections::HashMap<String, serde_yaml::Value>) -> Result<(), Vec<String>>`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the test module in `src/models/param_schema.rs`:
+
+```rust
+use std::collections::HashMap;
+
+fn params(pairs: &[(&str, serde_yaml::Value)]) -> HashMap<String, serde_yaml::Value> {
+    pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+}
+
+#[test]
+fn test_validate_missing_required() {
+    let schema = parse_schema("station:\n  type: string\n  required: true\n").unwrap();
+    let errs = validate_params(&schema, &params(&[])).unwrap_err();
+    assert!(errs.iter().any(|e| e.contains("station")));
+}
+
+#[test]
+fn test_validate_type_mismatch() {
+    let schema = parse_schema("limit:\n  type: int\n").unwrap();
+    let errs = validate_params(&schema, &params(&[("limit", "abc".into())])).unwrap_err();
+    assert!(errs.iter().any(|e| e.contains("limit")));
+}
+
+#[test]
+fn test_validate_min_max() {
+    let schema = parse_schema("limit:\n  type: int\n  min: 1\n  max: 30\n").unwrap();
+    assert!(validate_params(&schema, &params(&[("limit", 50i64.into())])).is_err());
+    assert!(validate_params(&schema, &params(&[("limit", 8i64.into())])).is_ok());
+}
+
+#[test]
+fn test_validate_enum_membership() {
+    let schema = parse_schema("k:\n  type: enum\n  options: [a, b]\n").unwrap();
+    assert!(validate_params(&schema, &params(&[("k", "c".into())])).is_err());
+    assert!(validate_params(&schema, &params(&[("k", "a".into())])).is_ok());
+}
+
+#[test]
+fn test_validate_ok_when_optional_absent() {
+    let schema = parse_schema("station:\n  type: string\n").unwrap();
+    assert!(validate_params(&schema, &params(&[])).is_ok());
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib param_schema::tests::test_validate`
+Expected: FAIL — `validate_params` not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/models/param_schema.rs` (above tests):
+
+```rust
+use std::collections::HashMap;
+
+/// Validate a params map against a schema. Returns all problems found (not just
+/// the first). Params not described by the schema are allowed (ignored).
+pub fn validate_params(
+    schema: &ParamSchema,
+    params: &HashMap<String, serde_yaml::Value>,
+) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+
+    for field in &schema.fields {
+        match params.get(&field.name) {
+            None => {
+                if field.required {
+                    errors.push(format!("missing required param `{}`", field.name));
+                }
+            }
+            Some(value) => {
+                if let Err(e) = check_value(field, value) {
+                    errors.push(e);
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
+}
+
+fn check_value(field: &ParamField, value: &serde_yaml::Value) -> Result<(), String> {
+    let name = &field.name;
+    match field.param_type {
+        ParamType::String | ParamType::Color | ParamType::Url => {
+            if !value.is_string() {
+                return Err(format!("param `{name}` must be a string"));
+            }
+        }
+        ParamType::Bool => {
+            if !value.is_bool() {
+                return Err(format!("param `{name}` must be a boolean"));
+            }
+        }
+        ParamType::Int => {
+            let n = value
+                .as_i64()
+                .ok_or_else(|| format!("param `{name}` must be an integer"))?;
+            check_range(field, n as f64)?;
+        }
+        ParamType::Float => {
+            let n = value
+                .as_f64()
+                .ok_or_else(|| format!("param `{name}` must be a number"))?;
+            check_range(field, n)?;
+        }
+        ParamType::Enum => {
+            let s = value
+                .as_str()
+                .ok_or_else(|| format!("param `{name}` must be one of the enum values"))?;
+            if !field.options.iter().any(|o| o.value == s) {
+                return Err(format!("param `{name}` value `{s}` is not an allowed option"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_range(field: &ParamField, n: f64) -> Result<(), String> {
+    if let Some(min) = field.min {
+        if n < min {
+            return Err(format!("param `{}` must be >= {min}", field.name));
+        }
+    }
+    if let Some(max) = field.max {
+        if n > max {
+            return Err(format!("param `{}` must be <= {max}", field.name));
+        }
+    }
+    Ok(())
+}
+```
+
+Export it in `src/models/mod.rs` (extend the `param_schema` re-export with `validate_params`).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib param_schema && cargo clippy --all-targets`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/param_schema.rs src/models/mod.rs
+git commit -m "feat(admin): validate device params against screen schema
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Hot-reload — SharedConfig (arc-swap) + AppState wiring
+
+This is the riskiest refactor: it touches every `state.config` consumer. After it, the
+full suite must still pass.
+
+**Files:**
+- Modify: `src/server.rs`
+- Modify: `src/services/content_pipeline.rs`
+- Modify: `src/assets.rs`
+- Test: inline + run full suite
+
+**Interfaces:**
+- Produces: `pub type SharedConfig = std::sync::Arc<arc_swap::ArcSwap<AppConfig>>;` (in `server.rs`, re-exported).
+- Produces: `AppState { pub config: SharedConfig, pub asset_loader: Arc<AssetLoader>, pub admin_token: Option<String>, .. }` (existing fields retained).
+- Produces: `AssetLoader::config_path(&self) -> Option<&std::path::Path>`.
+- Produces: `ContentPipeline::new(config: SharedConfig, asset_loader, renderer)` (signature change).
+- Produces: `pub fn reload_config(state: &AppState) -> anyhow::Result<()>` (in `server.rs`).
+
+- [ ] **Step 1: Add `config_path` getter to AssetLoader (test first)**
+
+Add a test to `src/assets.rs` `#[cfg(test)]`:
+
+```rust
+#[test]
+fn test_config_path_getter() {
+    let loader = AssetLoader::new(None, None, Some(PathBuf::from("/tmp/x.yaml")));
+    assert_eq!(loader.config_path(), Some(std::path::Path::new("/tmp/x.yaml")));
+    let embedded = AssetLoader::new(None, None, None);
+    assert_eq!(embedded.config_path(), None);
+}
+```
+
+Run `cargo test --lib assets::tests::test_config_path_getter` → FAIL.
+
+Implement on `impl AssetLoader`:
+
+```rust
+    /// Path to the external config file, if one is configured.
+    pub fn config_path(&self) -> Option<&std::path::Path> {
+        self.config_file.as_deref()
+    }
+```
+
+Run the test → PASS.
+
+- [ ] **Step 2: Define `SharedConfig` and update `AppState`**
+
+In `src/server.rs`, add near the top:
+
+```rust
+use arc_swap::ArcSwap;
+
+/// Hot-swappable application config shared by the server and the content pipeline.
+pub type SharedConfig = std::sync::Arc<ArcSwap<AppConfig>>;
+```
+
+Change `AppState`:
+
+```rust
+#[derive(Clone)]
+pub struct AppState {
+    pub config: SharedConfig,
+    pub asset_loader: Arc<AssetLoader>,
+    pub admin_token: Option<String>,
+    /// Serializes admin config writes so concurrent requests can't interleave file patches.
+    pub write_lock: Arc<tokio::sync::Mutex<()>>,
+    pub registry: Arc<InMemoryRegistry>,
+    pub renderer: Arc<RenderService>,
+    pub content_pipeline: Arc<ContentPipeline>,
+    pub content_cache: Arc<ContentCache>,
+    pub dev_overrides: DevOverrides,
+}
+```
+
+- [ ] **Step 3: Update the state constructors**
+
+Rewrite `create_app_state` and `create_app_state_with_overrides` in `src/server.rs`:
+
+```rust
+pub fn create_app_state(asset_loader: Arc<AssetLoader>) -> anyhow::Result<AppState> {
+    let config = AppConfig::load_from_assets(&asset_loader)?;
+    create_app_state_with_config(asset_loader, Arc::new(config))
+}
+
+pub fn create_app_state_with_config(
+    asset_loader: Arc<AssetLoader>,
+    config: Arc<AppConfig>,
+) -> anyhow::Result<AppState> {
+    create_app_state_with_overrides(asset_loader, config, DevOverrides::default())
+}
+
+pub fn create_app_state_with_overrides(
+    asset_loader: Arc<AssetLoader>,
+    config: Arc<AppConfig>,
+    dev_overrides: DevOverrides,
+) -> anyhow::Result<AppState> {
+    let admin_token = std::env::var("BYONK_ADMIN_TOKEN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| config.admin.token.clone());
+
+    let shared_config: SharedConfig = Arc::new(ArcSwap::from(config));
+
+    let registry = Arc::new(InMemoryRegistry::new());
+    let renderer = Arc::new(RenderService::new(&asset_loader)?);
+    let content_pipeline = Arc::new(
+        ContentPipeline::new(shared_config.clone(), asset_loader.clone(), renderer.clone())
+            .map_err(|e| anyhow::anyhow!("Failed to create content pipeline: {e}"))?,
+    );
+    let content_cache = Arc::new(ContentCache::new());
+
+    Ok(AppState {
+        config: shared_config,
+        asset_loader,
+        admin_token,
+        write_lock: Arc::new(tokio::sync::Mutex::new(())),
+        registry,
+        renderer,
+        content_pipeline,
+        content_cache,
+        dev_overrides,
+    })
+}
+```
+
+> The existing `create_app_state_with_config` signature (taking `Arc<AppConfig>`) is kept so
+> `TestApp::new_without_registration` and other callers compile unchanged.
+
+- [ ] **Step 4: Update the wrapper handlers to load the current config**
+
+In `src/server.rs`, the wrapper handlers currently pass `state.config` into the inner TRMNL
+handlers that expect `State<Arc<AppConfig>>`. Replace each `axum::extract::State(state.config)`
+with `axum::extract::State(state.config.load_full())`. `load_full()` returns `Arc<AppConfig>`,
+so the inner handlers (`handle_setup`, `handle_display`) stay unchanged.
+
+- [ ] **Step 5: Update `ContentPipeline` to hold `SharedConfig`**
+
+In `src/services/content_pipeline.rs`:
+
+- Change the struct field `config: Arc<AppConfig>` → `config: crate::server::SharedConfig`.
+- Change `ContentPipeline::new` first parameter to `config: crate::server::SharedConfig`.
+- At the start of every method that reads `self.config` (the methods around lines 138, 165,
+  182), take a snapshot: `let config = self.config.load();` and replace `self.config.` with
+  `config.`. `load()` returns a `Guard` that derefs to `AppConfig`.
+
+For example, the body that did:
+
+```rust
+self.config.screens.get(screen_name).cloned().or_else(|| { ... })
+```
+
+becomes:
+
+```rust
+let config = self.config.load();
+config.screens.get(screen_name).cloned().or_else(|| { ... })
+```
+
+- [ ] **Step 6: Update `src/api/dev.rs` consumers**
+
+`DevState.config` is `Arc<AppConfig>` and is built elsewhere (dev server). Where `DevState`
+is constructed (in `src/main.rs run_dev_server`), it already has an `Arc<AppConfig>`; keep
+`DevState.config` as `Arc<AppConfig>` (a point-in-time snapshot is fine for dev mode). No
+change needed in `dev.rs` itself. Confirm `cargo build` still resolves dev mode.
+
+- [ ] **Step 7: Add the `reload_config` helper**
+
+In `src/server.rs`:
+
+```rust
+/// Reparse the config file via the asset loader and atomically swap it in.
+pub fn reload_config(state: &AppState) -> anyhow::Result<()> {
+    let fresh = AppConfig::load_from_assets(&state.asset_loader)?;
+    state.config.store(Arc::new(fresh));
+    Ok(())
+}
+```
+
+- [ ] **Step 8: Fix any remaining call sites + run the FULL suite**
+
+Known direct call site: `src/main.rs` `run_render_command` (~line 201) builds
+`ContentPipeline::new(config.clone(), ...)` with an `Arc<AppConfig>`. Wrap it for the new
+signature:
+
+```rust
+    let shared: byonk::server::SharedConfig = std::sync::Arc::new(arc_swap::ArcSwap::from(config.clone()));
+    let content_pipeline = ContentPipeline::new(shared, asset_loader, renderer.clone())
+```
+
+(`config` is still used later in that function as `Arc<AppConfig>`, so keep it.) Then:
+
+Run: `cargo build --all-targets 2>&1 | head -40`
+Fix every remaining compile error (mechanical: snapshot `load()`/`load_full()` where an
+`&AppConfig` or `Arc<AppConfig>` is needed). Then:
+
+Run: `cargo test`
+Expected: the entire existing suite PASSES (no behavior change yet).
+
+- [ ] **Step 9: Add a hot-reload unit test**
+
+Add to `src/server.rs` `#[cfg(test)] mod tests` (create the module if absent):
+
+```rust
+#[cfg(test)]
+mod reload_tests {
+    use super::*;
+
+    #[test]
+    fn test_config_swap_is_visible() {
+        let loader = Arc::new(AssetLoader::new(None, None, None));
+        let state = create_app_state(loader).unwrap();
+        assert!(state.config.load().screens.contains_key("default"));
+
+        // Swap in a config with a sentinel screen and confirm the snapshot updates.
+        let mut cfg = (**state.config.load()).clone();
+        cfg.default_screen = Some("sentinel".to_string());
+        state.config.store(Arc::new(cfg));
+        assert_eq!(state.config.load().default_screen.as_deref(), Some("sentinel"));
+    }
+}
+```
+
+Run: `cargo test --lib server::reload_tests` → PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/server.rs src/services/content_pipeline.rs src/assets.rs
+git commit -m "refactor(admin): make config hot-swappable via arc-swap
+
+AppState.config becomes Arc<ArcSwap<AppConfig>>, shared with the content
+pipeline; adds asset_loader + admin_token to AppState and a reload_config
+helper. No behavior change to existing endpoints.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Admin auth guard + router + `GET /api/admin/devices`
+
+**Files:**
+- Create: `src/api/admin/mod.rs`
+- Create: `src/api/admin/read.rs`
+- Modify: `src/api/mod.rs`
+- Modify: `src/server.rs` (mount router)
+- Modify: `tests/common/app.rs` (admin test constructor + helpers)
+- Test: create `tests/admin_devices_test.rs`
+
+**Interfaces:**
+- Consumes: `AppState`, `SharedConfig`, `DeviceRegistry::list_all` (Task 2, 5).
+- Produces: `pub fn admin_router() -> axum::Router<AppState>` (in `src/api/admin/mod.rs`).
+- Produces: auth guard `require_admin(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError>`.
+- Produces: `AdminDevice` DTO (serialized JSON for device list).
+
+- [ ] **Step 1: Add the admin test harness helpers**
+
+In `tests/common/app.rs`, add constructors and request helpers:
+
+```rust
+impl TestApp {
+    /// Admin app whose config is EMBEDDED only (writes will return 409),
+    /// with the given admin token enabled.
+    pub fn new_admin(token: &str) -> Self {
+        let asset_loader = Arc::new(AssetLoader::new(None, None, None));
+        let mut config = AppConfig::load_from_assets(&asset_loader).expect("load config");
+        config.admin.token = Some(token.to_string());
+        let state = create_app_state_with_config(asset_loader, Arc::new(config))
+            .expect("create state");
+        let registry = state.registry.clone();
+        let content_cache = state.content_cache.clone();
+        let router = build_router(state);
+        Self { router, registry, content_cache }
+    }
+
+    /// Admin app backed by a real config FILE seeded from the embedded default
+    /// (writes succeed). Returns (app, config_path). `dir` must outlive the app.
+    pub fn new_admin_with_file(token: &str, dir: &std::path::Path) -> (Self, std::path::PathBuf) {
+        let config_path = dir.join("config.yaml");
+        let embedded = AssetLoader::new(None, None, None);
+        let yaml = embedded.read_config_string().expect("read embedded config");
+        std::fs::write(&config_path, format!("admin:\n  token: {token}\n{yaml}"))
+            .expect("write config file");
+
+        let asset_loader = Arc::new(AssetLoader::new(None, None, Some(config_path.clone())));
+        let config = AppConfig::load_from_assets(&asset_loader).expect("load config");
+        let state = create_app_state_with_config(asset_loader, Arc::new(config))
+            .expect("create state");
+        let registry = state.registry.clone();
+        let content_cache = state.content_cache.clone();
+        let router = build_router(state);
+        (Self { router, registry, content_cache }, config_path)
+    }
+
+    pub async fn patch_json(&self, path: &str, headers: &[(&str, &str)], body: &str) -> TestResponse {
+        let mut builder = Request::patch(path).header("Content-Type", "application/json");
+        for (n, v) in headers { builder = builder.header(*n, *v); }
+        self.request(builder.body(Body::from(body.to_string())).unwrap()).await
+    }
+
+    pub async fn delete(&self, path: &str, headers: &[(&str, &str)]) -> TestResponse {
+        let mut builder = Request::delete(path);
+        for (n, v) in headers { builder = builder.header(*n, *v); }
+        self.request(builder.body(Body::empty()).unwrap()).await
+    }
+}
+```
+
+(Add `use byonk::server::create_app_state_with_config;` etc. as needed — already imported.)
+
+- [ ] **Step 2: Write failing integration tests**
+
+Create `tests/admin_devices_test.rs`:
+
+```rust
+//! Tests for GET /api/admin/devices and admin auth.
+
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+#[tokio::test]
+async fn test_admin_disabled_returns_404() {
+    // Default TestApp has no admin token configured.
+    let app = TestApp::new();
+    let resp = app.get_with_headers("/api/admin/devices", &[("Authorization", "Bearer x")]).await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_admin_wrong_token_returns_401() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get_with_headers("/api/admin/devices", &[("Authorization", "Bearer nope")]).await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_admin_missing_token_returns_401() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get("/api/admin/devices").await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_admin_devices_lists_seen_device() {
+    let app = TestApp::new_admin("secret");
+    // Make a device appear in the registry via the normal setup flow.
+    app.register_device("AA:BB:CC:DD:EE:FF").await;
+
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer secret")])
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let json: serde_json::Value = resp.json();
+    let arr = json.as_array().expect("array");
+    assert!(arr.iter().any(|d| d["mac"] == "AA:BB:CC:DD:EE:FF"));
+}
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `cargo test --test admin_devices_test`
+Expected: FAIL — routes don't exist (currently 404 for all, so the 401 tests fail).
+
+- [ ] **Step 4: Implement the auth guard + DTOs in `src/api/admin/mod.rs`**
+
+```rust
+//! Admin/management API (`/api/admin/*`), gated by a bearer token.
+
+pub mod read;
+
+use axum::{http::HeaderMap, routing::get, Router};
+
+use crate::error::ApiError;
+use crate::server::AppState;
+
+/// Enforce admin auth. Returns 404 when admin is disabled (no token configured),
+/// 401 when the token is missing or wrong.
+pub fn require_admin(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError> {
+    let Some(expected) = state.admin_token.as_deref() else {
+        return Err(ApiError::NotFound); // admin disabled ⇒ invisible
+    };
+    let provided = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    match provided {
+        Some(tok) if constant_time_eq(tok.as_bytes(), expected.as_bytes()) => Ok(()),
+        _ => Err(ApiError::Unauthorized),
+    }
+}
+
+/// Constant-time byte comparison (avoids token-length/timing leaks).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// All admin routes, to be nested under `/api/admin`.
+pub fn admin_router() -> Router<AppState> {
+    Router::new().route("/devices", get(read::list_devices))
+    // read.rs/write.rs add more routes in later tasks
+}
+```
+
+> `require_admin` is the single auth entry point; every handler calls it first.
+> The unused `State`/`Json`/`State` imports in the `use` block above can be trimmed to just
+> what `admin_router` needs (`axum::{routing::get, Router}`); add `post`/`patch`/`delete`
+> in Tasks 10–11. `ApiError::NotFound` already maps to 404, so the disabled case is correct.
+
+- [ ] **Step 5: Implement `GET /devices` in `src/api/admin/read.rs`**
+
+```rust
+//! Admin read endpoints.
+
+use axum::{extract::State, http::HeaderMap, Json};
+use serde::Serialize;
+
+use crate::error::ApiError;
+use crate::server::AppState;
+use crate::services::DeviceRegistry;
+
+use super::require_admin;
+
+#[derive(Serialize)]
+pub struct AdminDevice {
+    /// Config key (MAC or registration code) if configured, else the MAC.
+    pub key: String,
+    pub mac: String,
+    pub registration_code: String,
+    pub registered: bool,
+    // telemetry (None when never seen)
+    pub model: Option<String>,
+    pub firmware_version: Option<String>,
+    pub last_seen: Option<String>,
+    pub battery_voltage: Option<f32>,
+    pub rssi: Option<i32>,
+    // resolved active config (None when no mapping)
+    pub screen: Option<String>,
+    pub dither: Option<String>,
+    pub panel: Option<String>,
+    pub colors: Option<String>,
+    pub params: serde_json::Value,
+}
+
+pub async fn list_devices(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<AdminDevice>>, ApiError> {
+    require_admin(&state, &headers)?;
+
+    let config = state.config.load();
+    let seen = state.registry.list_all().await?;
+
+    let mut out: Vec<AdminDevice> = Vec::new();
+
+    // 1) Every device the registry has seen, merged with its config mapping.
+    for d in &seen {
+        let mac = d.device_id.to_string();
+        let code = d.api_key.registration_code();
+        let dc = config
+            .get_device_config(&mac)
+            .or_else(|| config.get_device_config_for_code(&code));
+        let registered = config.is_device_registered(&mac, Some(&code));
+        out.push(AdminDevice {
+            key: mac.clone(),
+            mac,
+            registration_code: code,
+            registered,
+            model: Some(d.model.to_string()),
+            firmware_version: Some(d.firmware_version.clone()),
+            last_seen: Some(d.last_seen.to_rfc3339()),
+            battery_voltage: d.battery_voltage,
+            rssi: d.rssi,
+            screen: dc.map(|c| c.screen.clone()),
+            dither: dc.and_then(|c| c.dither.clone()),
+            panel: dc.and_then(|c| c.panel.clone()),
+            colors: dc.and_then(|c| c.colors.clone()),
+            params: dc
+                .map(|c| serde_json::to_value(&c.params).unwrap_or(serde_json::Value::Null))
+                .unwrap_or(serde_json::Value::Null),
+        });
+    }
+
+    // 2) Configured devices that have NOT been seen yet (telemetry = None).
+    let seen_macs: std::collections::HashSet<String> =
+        seen.iter().map(|d| d.device_id.to_string()).collect();
+    for (key, dc) in &config.devices {
+        // Skip if this config entry corresponds to a seen device (by MAC key).
+        if seen_macs.contains(key) {
+            continue;
+        }
+        out.push(AdminDevice {
+            key: key.clone(),
+            mac: key.clone(),
+            registration_code: String::new(),
+            registered: true,
+            model: None,
+            firmware_version: None,
+            last_seen: None,
+            battery_voltage: None,
+            rssi: None,
+            screen: Some(dc.screen.clone()),
+            dither: dc.dither.clone(),
+            panel: dc.panel.clone(),
+            colors: dc.colors.clone(),
+            params: serde_json::to_value(&dc.params).unwrap_or(serde_json::Value::Null),
+        });
+    }
+
+    Ok(Json(out))
+}
+```
+
+- [ ] **Step 6: Wire up the module and mount the router**
+
+In `src/api/mod.rs` add: `pub mod admin;`
+
+In `src/server.rs` `build_router`, before `.with_state(state)`, nest the admin router:
+
+```rust
+        .nest("/api/admin", crate::api::admin::admin_router())
+```
+
+- [ ] **Step 7: Run the tests**
+
+Run: `cargo test --test admin_devices_test`
+Expected: PASS (all four).
+
+- [ ] **Step 8: Run full suite + clippy**
+
+Run: `make check`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/api/admin/ src/api/mod.rs src/server.rs tests/common/app.rs tests/admin_devices_test.rs
+git commit -m "feat(admin): bearer-gated GET /api/admin/devices
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `GET /api/admin/pending` and `GET /api/admin/config`
+
+**Files:**
+- Modify: `src/api/admin/read.rs`, `src/api/admin/mod.rs`
+- Test: create `tests/admin_read_test.rs`
+
+**Interfaces:**
+- Consumes: `AppState`, `require_admin`, `AssetLoader::read_config_string`.
+- Produces: handlers `pending(...)`, `get_config(...)`; routes `/pending`, `/config`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/admin_read_test.rs`:
+
+```rust
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
+
+#[tokio::test]
+async fn test_pending_lists_unregistered_seen_device() {
+    let app = TestApp::new_admin("secret");
+    // A freshly-set-up device with no config mapping is "pending".
+    app.register_device("11:22:33:44:55:66").await;
+
+    let resp = app.get_with_headers("/api/admin/pending", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let arr: serde_json::Value = resp.json();
+    let list = arr.as_array().unwrap();
+    assert!(list.iter().any(|d| d["mac"] == "11:22:33:44:55:66"));
+    assert!(list[0]["registration_code"].as_str().unwrap().len() == 10);
+}
+
+#[tokio::test]
+async fn test_config_returns_json_without_token() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get_with_headers("/api/admin/config", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let json: serde_json::Value = resp.json();
+    assert!(json["screens"].is_object());
+    // admin.token must be stripped.
+    assert!(json["admin"]["token"].is_null());
+}
+
+#[tokio::test]
+async fn test_config_requires_auth() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get("/api/admin/config").await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --test admin_read_test`
+Expected: FAIL — routes not found (401-disabled path returns 404 since routes absent).
+
+- [ ] **Step 3: Implement handlers**
+
+Add to `src/api/admin/read.rs`:
+
+```rust
+#[derive(Serialize)]
+pub struct PendingDevice {
+    pub mac: String,
+    pub registration_code: String,
+    pub model: String,
+    pub firmware_version: String,
+    pub last_seen: String,
+}
+
+pub async fn pending(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<PendingDevice>>, ApiError> {
+    require_admin(&state, &headers)?;
+
+    let config = state.config.load();
+    let mut out = Vec::new();
+    for d in state.registry.list_all().await? {
+        let mac = d.device_id.to_string();
+        let code = d.api_key.registration_code();
+        if config.is_device_registered(&mac, Some(&code)) {
+            continue;
+        }
+        out.push(PendingDevice {
+            mac,
+            registration_code: code,
+            model: d.model.to_string(),
+            firmware_version: d.firmware_version.clone(),
+            last_seen: d.last_seen.to_rfc3339(),
+        });
+    }
+    Ok(Json(out))
+}
+
+pub async fn get_config(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+
+    let text = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(format!("read config: {e}")))?;
+    let mut value: serde_yaml::Value =
+        serde_yaml::from_str(&text).map_err(|e| ApiError::Internal(format!("parse config: {e}")))?;
+
+    // Strip admin.token from the response.
+    if let Some(map) = value.as_mapping_mut() {
+        if let Some(admin) = map
+            .get_mut(serde_yaml::Value::from("admin"))
+            .and_then(|a| a.as_mapping_mut())
+        {
+            admin.remove(serde_yaml::Value::from("token"));
+        }
+    }
+
+    let json = serde_json::to_value(&value)
+        .map_err(|e| ApiError::Internal(format!("to json: {e}")))?;
+    Ok(Json(json))
+}
+```
+
+- [ ] **Step 4: Add routes**
+
+In `src/api/admin/mod.rs` `admin_router`:
+
+```rust
+    Router::new()
+        .route("/devices", get(read::list_devices))
+        .route("/pending", get(read::pending))
+        .route("/config", get(read::get_config))
+```
+
+- [ ] **Step 5: Run tests + full suite**
+
+Run: `cargo test --test admin_read_test && make check`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/admin/ tests/admin_read_test.rs
+git commit -m "feat(admin): GET /api/admin/pending and /config
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `GET /api/admin/screens` (param schemas + enumerations)
+
+**Files:**
+- Modify: `src/api/admin/read.rs`, `src/api/admin/mod.rs`
+- Test: create `tests/admin_screens_test.rs`
+
+**Interfaces:**
+- Consumes: `AppState`, `schema_for_script` (Task 3), `AssetLoader::read_screen_string`.
+- Produces: handler `screens(...)`; route `/screens`. Response shape:
+  `{ "screens": [{name, params:[ParamField], schema_error:Option<String>}], "panels": [{name,width,height,colors}], "dither_algorithms": [String] }`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/admin_screens_test.rs`:
+
+```rust
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
+
+#[tokio::test]
+async fn test_screens_lists_screens_and_enums() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get_with_headers("/api/admin/screens", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let json: serde_json::Value = resp.json();
+
+    let screens = json["screens"].as_array().unwrap();
+    assert!(screens.iter().any(|s| s["name"] == "transit"));
+    assert!(json["panels"].as_array().unwrap().iter().any(|p| p["name"] == "trmnl_og"));
+    assert!(json["dither_algorithms"].as_array().unwrap().iter().any(|d| d == "atkinson"));
+}
+
+#[tokio::test]
+async fn test_transit_has_station_param_after_headers_added() {
+    // After Task 12 adds @params headers, transit exposes a `station` param.
+    let app = TestApp::new_admin("secret");
+    let resp = app.get_with_headers("/api/admin/screens", &[AUTH]).await;
+    let json: serde_json::Value = resp.json();
+    let transit = json["screens"]
+        .as_array().unwrap()
+        .iter()
+        .find(|s| s["name"] == "transit")
+        .unwrap();
+    let params = transit["params"].as_array().unwrap();
+    assert!(params.iter().any(|p| p["name"] == "station"));
+}
+```
+
+> The second test depends on Task 12 (the `@params` header for `transit`). It is written
+> now but will pass only after Task 12. If executing strictly task-by-task, mark it
+> `#[ignore]` here and remove the attribute in Task 12.
+
+- [ ] **Step 2: Run to verify the first test fails**
+
+Run: `cargo test --test admin_screens_test test_screens_lists`
+Expected: FAIL — route not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/api/admin/read.rs`:
+
+```rust
+use crate::models::param_schema::{schema_for_script, ParamField};
+
+#[derive(Serialize)]
+pub struct ScreenInfo {
+    pub name: String,
+    pub params: Vec<ParamField>,
+    pub schema_error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct PanelInfo {
+    pub name: String,
+    pub width: u32,
+    pub height: u32,
+    pub colors: String,
+}
+
+#[derive(Serialize)]
+pub struct ScreensResponse {
+    pub screens: Vec<ScreenInfo>,
+    pub panels: Vec<PanelInfo>,
+    pub dither_algorithms: Vec<String>,
+}
+
+/// Canonical dither algorithm names byonk understands.
+const DITHER_ALGORITHMS: &[&str] = &[
+    "floyd-steinberg",
+    "atkinson",
+    "atkinson-hybrid",
+    "jarvis-judice-ninke",
+    "sierra",
+    "sierra-two-row",
+    "sierra-lite",
+    "sierra-light",
+    "stucki",
+    "burkes",
+];
+
+pub async fn screens(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<ScreensResponse>, ApiError> {
+    require_admin(&state, &headers)?;
+    let config = state.config.load();
+
+    let mut screens = Vec::new();
+    for (name, sc) in &config.screens {
+        let (params, schema_error) = match state.asset_loader.read_screen_string(&sc.script) {
+            Err(e) => (Vec::new(), Some(format!("cannot read script: {e}"))),
+            Ok(src) => match schema_for_script(&src) {
+                Ok(Some(schema)) => (schema.fields, None),
+                Ok(None) => (Vec::new(), None),
+                Err(e) => {
+                    tracing::warn!(screen = %name, error = %e, "invalid @params schema");
+                    (Vec::new(), Some(e))
+                }
+            },
+        };
+        screens.push(ScreenInfo { name: name.clone(), params, schema_error });
+    }
+
+    let panels = config
+        .panels
+        .iter()
+        .map(|(name, p)| PanelInfo {
+            name: name.clone(),
+            width: p.width,
+            height: p.height,
+            colors: p.colors.clone(),
+        })
+        .collect();
+
+    Ok(Json(ScreensResponse {
+        screens,
+        panels,
+        dither_algorithms: DITHER_ALGORITHMS.iter().map(|s| s.to_string()).collect(),
+    }))
+}
+```
+
+> Confirm `PanelConfig` field names (`width`, `height`, `colors`) by checking
+> `src/models/config.rs` around line 182; adjust if the struct differs.
+
+- [ ] **Step 4: Add route + run**
+
+In `admin_router`: `.route("/screens", get(read::screens))`.
+
+Run: `cargo test --test admin_screens_test test_screens_lists && make check`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/admin/ tests/admin_screens_test.rs
+git commit -m "feat(admin): GET /api/admin/screens with param schemas + enums
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Comment-preserving config writer (yamlpath/yamlpatch adapter)
+
+This task binds the one external API (`yamlpatch`). **Implement it against the installed
+crate first** — the public contract and tests below are fixed; the body uses
+`yamlpatch`/`yamlpath`, whose exact `Value`/`Route` construction must be confirmed via
+`cargo doc -p yamlpatch -p yamlpath`.
+
+**Files:**
+- Create: `src/services/config_writer.rs`
+- Modify: `src/services/mod.rs`
+- Test: inline `#[cfg(test)]` in `src/services/config_writer.rs`
+
+**Interfaces:**
+- Produces (the stable contract other tasks call):
+  - `pub fn set_scalar(yaml: &str, path: &[&str], value: serde_yaml::Value) -> Result<String, ConfigWriteError>`
+  - `pub fn upsert_device(yaml: &str, key: &str, block: &serde_yaml::Mapping) -> Result<String, ConfigWriteError>`
+  - `pub fn remove_device(yaml: &str, key: &str) -> Result<String, ConfigWriteError>`
+  - `pub enum ConfigWriteError { NotFound(String), Patch(String) }` (impl `Display`)
+- Each function takes the current YAML text and returns new YAML text with comments outside
+  the touched region preserved.
+
+- [ ] **Step 1: Write failing tests (these define the contract)**
+
+Create `src/services/config_writer.rs`:
+
+```rust
+//! Comment-preserving edits to `config.yaml`, built on `yamlpath`/`yamlpatch`.
+//!
+//! Strategy (avoids yamlpatch's weak spots on sequences/flow lists):
+//! - global scalar settings → in-place scalar replace
+//! - device add/edit/remove → remove the device subtree + append a freshly
+//!   block-serialized subtree (device blocks are machine-managed, so no user
+//!   comments live inside them).
+
+// implementation added below
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+# top comment
+registration:
+  enabled: true   # inline comment
+auth_mode: api_key
+devices:
+  \"AA:BB\":
+    screen: transit
+    params:
+      station: Olten
+# trailing comment
+";
+
+    #[test]
+    fn test_set_scalar_preserves_comments() {
+        let out = set_scalar(SAMPLE, &["registration", "enabled"], false.into()).unwrap();
+        assert!(out.contains("# top comment"));
+        assert!(out.contains("# trailing comment"));
+        assert!(out.contains("enabled: false"));
+    }
+
+    #[test]
+    fn test_remove_device_keeps_other_comments() {
+        let out = remove_device(SAMPLE, "AA:BB").unwrap();
+        assert!(!out.contains("station: Olten"));
+        assert!(out.contains("# top comment"));
+        assert!(out.contains("# trailing comment"));
+    }
+
+    #[test]
+    fn test_upsert_adds_new_device() {
+        let mut block = serde_yaml::Mapping::new();
+        block.insert("screen".into(), "hello".into());
+        let out = upsert_device(SAMPLE, "CC:DD", &block).unwrap();
+        // Re-parse and confirm the new device exists with the right screen.
+        let v: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(v["devices"]["CC:DD"]["screen"], serde_yaml::Value::from("hello"));
+        assert!(out.contains("# top comment"));
+    }
+
+    #[test]
+    fn test_upsert_edits_existing_device() {
+        let mut block = serde_yaml::Mapping::new();
+        block.insert("screen".into(), "graytest".into());
+        let out = upsert_device(SAMPLE, "AA:BB", &block).unwrap();
+        let v: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(v["devices"]["AA:BB"]["screen"], serde_yaml::Value::from("graytest"));
+        assert!(out.contains("# top comment"));
+    }
+
+    #[test]
+    fn test_remove_missing_device_errors() {
+        assert!(matches!(remove_device(SAMPLE, "ZZ:ZZ"), Err(ConfigWriteError::NotFound(_))));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib config_writer`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement the error type + helpers**
+
+```rust
+use yamlpatch::{apply_yaml_patches, Op, Patch};
+use yamlpath::Document;
+
+#[derive(Debug)]
+pub enum ConfigWriteError {
+    NotFound(String),
+    Patch(String),
+}
+
+impl std::fmt::Display for ConfigWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigWriteError::NotFound(s) => write!(f, "not found: {s}"),
+            ConfigWriteError::Patch(s) => write!(f, "patch failed: {s}"),
+        }
+    }
+}
+impl std::error::Error for ConfigWriteError {}
+
+/// Build a `yamlpatch` value from a serde_yaml value by round-tripping through
+/// a YAML string (keeps us decoupled from yamlpatch's internal value type).
+///
+/// CONFIRM: the exact constructor for `Op::Replace`/`Op::Add` values against the
+/// installed `yamlpatch` version (`cargo doc -p yamlpatch`). The crate exposes a
+/// `yaml_serde::Value`; build it by parsing `serde_yaml::to_string(value)`.
+fn to_patch_value(value: &serde_yaml::Value) -> Result<yamlpatch::yaml_serde::Value, ConfigWriteError> {
+    let s = serde_yaml::to_string(value).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    yamlpatch::yaml_serde::from_str(&s).map_err(|e| ConfigWriteError::Patch(e.to_string()))
+}
+
+fn render(doc: Document) -> String {
+    doc.source().to_string()
+}
+
+fn document(yaml: &str) -> Result<Document, ConfigWriteError> {
+    Document::new(yaml).map_err(|e| ConfigWriteError::Patch(e.to_string()))
+}
+```
+
+- [ ] **Step 4: Implement `set_scalar`**
+
+```rust
+/// Replace a scalar value at `path` (e.g. `["registration","enabled"]`).
+pub fn set_scalar(
+    yaml: &str,
+    path: &[&str],
+    value: serde_yaml::Value,
+) -> Result<String, ConfigWriteError> {
+    let doc = document(yaml)?;
+    // Build a route to the scalar. CONFIRM exact route-builder API; using with_key.
+    let mut route = yamlpath::Route::root();
+    for key in path {
+        route = route.with_key(*key);
+    }
+    let patch = Patch {
+        route,
+        operation: Op::Replace(to_patch_value(&value)?),
+    };
+    let new_doc = apply_yaml_patches(&doc, &[patch])
+        .map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    Ok(render(new_doc))
+}
+```
+
+- [ ] **Step 5: Implement `remove_device` and `upsert_device`**
+
+```rust
+/// Remove `devices.<key>` entirely.
+pub fn remove_device(yaml: &str, key: &str) -> Result<String, ConfigWriteError> {
+    // Confirm presence first for a clean NotFound error.
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(yaml).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let exists = parsed
+        .get("devices")
+        .and_then(|d| d.get(key))
+        .is_some();
+    if !exists {
+        return Err(ConfigWriteError::NotFound(format!("device {key}")));
+    }
+
+    let doc = document(yaml)?;
+    let route = yamlpath::Route::root().with_key("devices").with_key(key);
+    let patch = Patch { route, operation: Op::Remove };
+    let new_doc = apply_yaml_patches(&doc, &[patch])
+        .map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    Ok(render(new_doc))
+}
+
+/// Add a new device or replace an existing one with `block`.
+pub fn upsert_device(
+    yaml: &str,
+    key: &str,
+    block: &serde_yaml::Mapping,
+) -> Result<String, ConfigWriteError> {
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(yaml).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let exists = parsed.get("devices").and_then(|d| d.get(key)).is_some();
+
+    // Edit = remove then add (robust against sequence/flow-list params).
+    let base = if exists { remove_device(yaml, key)? } else { yaml.to_string() };
+
+    let doc = document(&base)?;
+    let route = yamlpath::Route::root().with_key("devices");
+    let value = to_patch_value(&serde_yaml::Value::Mapping(block.clone()))?;
+    let patch = Patch {
+        route,
+        operation: Op::Add { key: key.to_string(), value },
+    };
+    let new_doc = apply_yaml_patches(&doc, &[patch])
+        .map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    Ok(render(new_doc))
+}
+```
+
+> If the installed `yamlpath` exposes a different route builder (e.g. the `route!` macro or
+> `Route::from(...)`), adapt the three `Route::root().with_key(..)` chains accordingly. The
+> tests in Step 1 are the source of truth — make them green without changing their
+> assertions.
+
+- [ ] **Step 6: Declare module + run tests**
+
+In `src/services/mod.rs` add `pub mod config_writer;` and
+`pub use config_writer::{remove_device, set_scalar, upsert_device, ConfigWriteError};`.
+
+Run: `cargo test --lib config_writer`
+Expected: PASS (all five). If a route/value API mismatch appears, fix the adapter internals
+only.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/services/config_writer.rs src/services/mod.rs
+git commit -m "feat(admin): comment-preserving config writer (yamlpath/yamlpatch)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Device write endpoints (`POST`/`PATCH`/`DELETE /api/admin/devices`)
+
+**Files:**
+- Create: `src/api/admin/write.rs`
+- Modify: `src/api/admin/mod.rs`
+- Test: create `tests/admin_write_test.rs`
+
+**Interfaces:**
+- Consumes: `config_writer` (Task 9), `validate_params`/`schema_for_script` (Task 3/4),
+  `reload_config` (Task 5), `AssetLoader::config_path`/`read_config_string`.
+- Produces: handlers `add_device`, `patch_device`, `delete_device`; routes
+  `POST /devices`, `PATCH /devices/:key`, `DELETE /devices/:key`.
+- Request body shape (POST): `{ "key": String, "screen": String, "panel"?: String, "dither"?: String, "colors"?: String, "params"?: object }`.
+  PATCH body: same fields, all optional, no `key`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/admin_write_test.rs`:
+
+```rust
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
+
+#[tokio::test]
+async fn test_write_on_embedded_config_returns_409() {
+    let app = TestApp::new_admin("secret"); // embedded-only
+    let body = r#"{"key":"CC:DD:EE:FF:00:11","screen":"hello"}"#;
+    let resp = app.post_json("/api/admin/devices", &[AUTH], body).await;
+    assert_eq!(resp.status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_add_device_persists_and_hot_reloads() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, path) = TestApp::new_admin_with_file("secret", dir.path());
+
+    let body = r#"{"key":"CC:DD:EE:FF:00:11","screen":"hello"}"#;
+    let resp = app.post_json("/api/admin/devices", &[AUTH], body).await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    // File updated + comment preserved.
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(on_disk.contains("CC:DD:EE:FF:00:11"));
+
+    // Hot-reload: GET /devices shows it without restart.
+    let listed = app.get_with_headers("/api/admin/devices", &[AUTH]).await;
+    let json: serde_json::Value = listed.json();
+    assert!(json.as_array().unwrap().iter().any(|d| d["mac"] == "CC:DD:EE:FF:00:11"));
+}
+
+#[tokio::test]
+async fn test_add_unknown_screen_returns_400() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, _) = TestApp::new_admin_with_file("secret", dir.path());
+    let body = r#"{"key":"CC:DD:EE:FF:00:11","screen":"does-not-exist"}"#;
+    let resp = app.post_json("/api/admin/devices", &[AUTH], body).await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_patch_then_delete_device() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, _) = TestApp::new_admin_with_file("secret", dir.path());
+    app.post_json("/api/admin/devices", &[AUTH], r#"{"key":"CC:DD","screen":"hello"}"#).await;
+
+    let patch = app.patch_json("/api/admin/devices/CC:DD", &[AUTH], r#"{"screen":"graytest"}"#).await;
+    assert_eq!(patch.status, StatusCode::OK);
+
+    let del = app.delete("/api/admin/devices/CC:DD", &[AUTH]).await;
+    assert_eq!(del.status, StatusCode::OK);
+    let del_again = app.delete("/api/admin/devices/CC:DD", &[AUTH]).await;
+    assert_eq!(del_again.status, StatusCode::NOT_FOUND);
+}
+```
+
+Add `tempfile = "3"` to `[dev-dependencies]` in `Cargo.toml` if not already present
+(check first).
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --test admin_write_test`
+Expected: FAIL — routes not found.
+
+- [ ] **Step 3: Implement the write handlers**
+
+Create `src/api/admin/write.rs`:
+
+```rust
+//! Admin write endpoints: device mappings + global settings.
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::error::ApiError;
+use crate::models::param_schema::{schema_for_script, validate_params};
+use crate::server::{reload_config, AppState};
+use crate::services::config_writer;
+
+use super::require_admin;
+
+#[derive(Deserialize)]
+pub struct DeviceWrite {
+    pub key: Option<String>, // required for POST, ignored for PATCH (taken from URL)
+    pub screen: Option<String>,
+    pub panel: Option<String>,
+    pub dither: Option<String>,
+    pub colors: Option<String>,
+    pub params: Option<HashMap<String, serde_yaml::Value>>,
+}
+
+/// Guard: writes require a file-backed config.
+fn require_file_config(state: &AppState) -> Result<std::path::PathBuf, ApiError> {
+    state
+        .asset_loader
+        .config_path()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| ApiError::Conflict("config is embedded/read-only; set CONFIG_FILE".into()))
+}
+
+/// Validate the screen exists and (if it has a schema) the params pass it.
+fn validate_screen_and_params(
+    state: &AppState,
+    screen: &str,
+    params: &HashMap<String, serde_yaml::Value>,
+) -> Result<(), ApiError> {
+    let config = state.config.load();
+    let sc = config
+        .screens
+        .get(screen)
+        .ok_or_else(|| ApiError::BadRequest(format!("unknown screen `{screen}`")))?;
+    if let Ok(src) = state.asset_loader.read_screen_string(&sc.script) {
+        if let Ok(Some(schema)) = schema_for_script(&src) {
+            if let Err(errs) = validate_params(&schema, params) {
+                return Err(ApiError::BadRequest(errs.join("; ")));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build the YAML mapping for a device block from the provided fields.
+fn device_block(w: &DeviceWrite, screen: &str) -> serde_yaml::Mapping {
+    let mut m = serde_yaml::Mapping::new();
+    m.insert("screen".into(), screen.into());
+    if let Some(p) = &w.panel { m.insert("panel".into(), p.as_str().into()); }
+    if let Some(d) = &w.dither { m.insert("dither".into(), d.as_str().into()); }
+    if let Some(c) = &w.colors { m.insert("colors".into(), c.as_str().into()); }
+    if let Some(params) = &w.params {
+        let mut pm = serde_yaml::Mapping::new();
+        for (k, v) in params {
+            pm.insert(k.as_str().into(), v.clone());
+        }
+        m.insert("params".into(), serde_yaml::Value::Mapping(pm));
+    }
+    m
+}
+
+fn persist(state: &AppState, path: &std::path::Path, new_yaml: String) -> Result<(), ApiError> {
+    // Snapshot current contents so we can roll back if the new text fails to reparse.
+    let previous = std::fs::read_to_string(path).ok();
+
+    // Atomic write: temp file in same dir, then rename.
+    let tmp = path.with_extension("yaml.tmp");
+    std::fs::write(&tmp, &new_yaml)
+        .map_err(|e| ApiError::Internal(format!("write temp: {e}")))?;
+    std::fs::rename(&tmp, path)
+        .map_err(|e| ApiError::Internal(format!("rename: {e}")))?;
+
+    // Reload into the live config; on failure, roll the file back.
+    if let Err(e) = reload_config(state) {
+        if let Some(prev) = previous {
+            let _ = std::fs::write(path, prev);
+        }
+        return Err(ApiError::Internal(format!("reload failed, rolled back: {e}")));
+    }
+    Ok(())
+}
+```
+
+> **Write serialization:** each mutating handler below acquires the write lock for the whole
+> read-modify-write-reload cycle. Add this line as the first statement after
+> `require_file_config(&state)?` in `add_device`, `patch_device`, `delete_device`, and
+> (Task 11) `patch_settings`:
+>
+> ```rust
+>     let _guard = state.write_lock.lock().await;
+> ```
+
+pub async fn add_device(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<DeviceWrite>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+    let key = body
+        .key
+        .clone()
+        .ok_or_else(|| ApiError::BadRequest("`key` is required".into()))?;
+    let screen = body
+        .screen
+        .clone()
+        .ok_or_else(|| ApiError::BadRequest("`screen` is required".into()))?;
+
+    // Reject duplicate.
+    if state.config.load().devices.contains_key(&key) {
+        return Err(ApiError::Conflict(format!("device `{key}` already exists")));
+    }
+
+    let empty = HashMap::new();
+    validate_screen_and_params(&state, &screen, body.params.as_ref().unwrap_or(&empty))?;
+
+    let block = device_block(&body, &screen);
+    let yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let new_yaml = config_writer::upsert_device(&yaml, &key, &block)
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    persist(&state, &path, new_yaml)?;
+
+    Ok(Json(serde_json::json!({ "key": key, "screen": screen })))
+}
+
+pub async fn patch_device(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<DeviceWrite>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+
+    // Must already exist.
+    let existing = {
+        let config = state.config.load();
+        config
+            .devices
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| ApiError::NotFound)?
+    };
+
+    // Merge: start from existing, override provided fields.
+    let screen = body.screen.clone().unwrap_or(existing.screen.clone());
+    let merged = DeviceWrite {
+        key: Some(key.clone()),
+        screen: Some(screen.clone()),
+        panel: body.panel.clone().or(existing.panel.clone()),
+        dither: body.dither.clone().or(existing.dither.clone()),
+        colors: body.colors.clone().or(existing.colors.clone()),
+        params: Some(body.params.clone().unwrap_or(existing.params.clone())),
+    };
+
+    let empty = HashMap::new();
+    validate_screen_and_params(&state, &screen, merged.params.as_ref().unwrap_or(&empty))?;
+
+    let block = device_block(&merged, &screen);
+    let yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let new_yaml = config_writer::upsert_device(&yaml, &key, &block)
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    persist(&state, &path, new_yaml)?;
+
+    Ok(Json(serde_json::json!({ "key": key, "screen": screen })))
+}
+
+pub async fn delete_device(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+
+    let yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let new_yaml = match config_writer::remove_device(&yaml, &key) {
+        Ok(y) => y,
+        Err(config_writer::ConfigWriteError::NotFound(_)) => return Err(ApiError::NotFound),
+        Err(e) => return Err(ApiError::Internal(e.to_string())),
+    };
+    persist(&state, &path, new_yaml)?;
+
+    Ok(Json(serde_json::json!({ "deleted": key })))
+}
+```
+
+- [ ] **Step 4: Wire routes**
+
+In `src/api/admin/mod.rs`: add `pub mod write;`, import `post`, `patch`, `delete` from
+`axum::routing`, and extend `admin_router`:
+
+```rust
+        .route("/devices", post(write::add_device))
+        .route("/devices/:key", patch(write::patch_device).delete(write::delete_device))
+```
+
+(Combine with the existing `.route("/devices", get(read::list_devices))` using
+`get(read::list_devices).post(write::add_device)` on the same path.)
+
+- [ ] **Step 5: Run tests + full suite**
+
+Run: `cargo test --test admin_write_test && make check`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/admin/ tests/admin_write_test.rs Cargo.toml Cargo.lock
+git commit -m "feat(admin): device write endpoints with validation + hot-reload
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Global settings — `PATCH /api/admin/settings`
+
+**Files:**
+- Modify: `src/api/admin/write.rs`, `src/api/admin/mod.rs`
+- Test: add to `tests/admin_write_test.rs`
+
+**Interfaces:**
+- Consumes: `config_writer::set_scalar`, `reload_config`.
+- Produces: handler `patch_settings`; route `PATCH /settings`. Body:
+  `{ "registration_enabled"?: bool, "auth_mode"?: String, "default_screen"?: String }`.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/admin_write_test.rs`:
+
+```rust
+#[tokio::test]
+async fn test_patch_settings_toggles_registration() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, path) = TestApp::new_admin_with_file("secret", dir.path());
+
+    let resp = app
+        .patch_json("/api/admin/settings", &[AUTH], r#"{"registration_enabled":false}"#)
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(on_disk.contains("enabled: false"));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --test admin_write_test test_patch_settings`
+Expected: FAIL — route not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `src/api/admin/write.rs`:
+
+```rust
+#[derive(Deserialize)]
+pub struct SettingsWrite {
+    pub registration_enabled: Option<bool>,
+    pub auth_mode: Option<String>,
+    pub default_screen: Option<String>,
+}
+
+pub async fn patch_settings(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<SettingsWrite>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+
+    let mut yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    if let Some(enabled) = body.registration_enabled {
+        yaml = config_writer::set_scalar(&yaml, &["registration", "enabled"], enabled.into())
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+    }
+    if let Some(mode) = &body.auth_mode {
+        if mode != "api_key" && mode != "ed25519" {
+            return Err(ApiError::BadRequest("auth_mode must be api_key or ed25519".into()));
+        }
+        yaml = config_writer::set_scalar(&yaml, &["auth_mode"], mode.as_str().into())
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+    }
+    if let Some(screen) = &body.default_screen {
+        if !state.config.load().screens.contains_key(screen) {
+            return Err(ApiError::BadRequest(format!("unknown screen `{screen}`")));
+        }
+        yaml = config_writer::set_scalar(&yaml, &["default_screen"], screen.as_str().into())
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+    }
+
+    persist(&state, &path, yaml)?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+```
+
+> `registration.enabled` is the documented path. If the seeded config omits the
+> `registration:` block, `set_scalar` will return a patch error — the default config in this
+> repo DOES include `registration:\n  enabled: true`, so this is fine. If a future config
+> lacks it, the handler returns 500; acceptable for Phase 1 (documented limitation).
+
+- [ ] **Step 4: Add route**
+
+In `admin_router`: `.route("/settings", patch(write::patch_settings))`.
+
+- [ ] **Step 5: Run tests + full suite**
+
+Run: `cargo test --test admin_write_test && make check`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/admin/ tests/admin_write_test.rs
+git commit -m "feat(admin): PATCH /api/admin/settings for global settings
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Add `@params` headers to all repo screens
+
+**Files:**
+- Modify: `screens/transit.lua`, `screens/gphoto.lua`, `screens/floerli.lua`,
+  `screens/fontdemo-bitmap.lua` (add `@params`); leave `default`, `graytest`, `hello`,
+  `hintdemo`, `calibrator`, `mandelbrot`, `fontdemo-terminus` without a block (no params).
+- Test: create `tests/screen_schemas_test.rs`
+
+**Interfaces:**
+- Consumes: `byonk::models::param_schema::schema_for_script`, `byonk::assets::AssetLoader`.
+
+- [ ] **Step 1: Write a failing test that all bundled screens parse cleanly**
+
+Create `tests/screen_schemas_test.rs`:
+
+```rust
+//! Every bundled screen's @params block must parse without error, and known
+//! screens expose their documented params.
+
+use byonk::assets::AssetLoader;
+use byonk::models::param_schema::schema_for_script;
+use std::path::Path;
+
+fn schema(script: &str) -> Option<Vec<String>> {
+    let loader = AssetLoader::new(None, None, None);
+    let src = loader.read_screen_string(Path::new(script)).unwrap();
+    schema_for_script(&src)
+        .expect("schema must parse")
+        .map(|s| s.fields.iter().map(|f| f.name.clone()).collect())
+}
+
+#[test]
+fn test_transit_params() {
+    let names = schema("transit.lua").unwrap();
+    assert!(names.contains(&"station".to_string()));
+    assert!(names.contains(&"limit".to_string()));
+}
+
+#[test]
+fn test_gphoto_params() {
+    let names = schema("gphoto.lua").unwrap();
+    assert!(names.contains(&"album_url".to_string()));
+}
+
+#[test]
+fn test_fontdemo_bitmap_is_enum() {
+    let loader = AssetLoader::new(None, None, None);
+    let src = loader.read_screen_string(Path::new("fontdemo-bitmap.lua")).unwrap();
+    let schema = schema_for_script(&src).unwrap().unwrap();
+    let f = schema.fields.iter().find(|f| f.name == "font_prefix").unwrap();
+    assert!(!f.options.is_empty());
+}
+
+#[test]
+fn test_no_param_screens_have_no_schema_or_empty() {
+    for s in ["default.lua", "graytest.lua", "hello.lua", "mandelbrot.lua"] {
+        let loader = AssetLoader::new(None, None, None);
+        let src = loader.read_screen_string(Path::new(s)).unwrap();
+        // Either no block, or a block that parses to zero fields.
+        let parsed = schema_for_script(&src).expect("must parse");
+        if let Some(p) = parsed {
+            assert!(p.fields.is_empty());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --test screen_schemas_test`
+Expected: FAIL — params not declared yet.
+
+- [ ] **Step 3: Add the `@params` header to `screens/transit.lua`**
+
+Insert at the very top of the file (before existing code):
+
+```lua
+--[[ @params
+station:
+  type: string
+  label: "Stop name"
+  default: "Olten, Südwest"
+  description: "Stop name as used by the transport API"
+limit:
+  type: int
+  label: "Departures"
+  default: 8
+  min: 1
+  max: 30
+  mode: box
+  description: "Number of departures to show"
+]]
+```
+
+- [ ] **Step 4: Add `@params` to `screens/gphoto.lua`**
+
+```lua
+--[[ @params
+album_url:
+  type: url
+  label: "Album URL"
+  required: true
+  description: "Shared Google Photos album link"
+show_status:
+  type: bool
+  label: "Show status overlay"
+  default: false
+refresh_rate:
+  type: int
+  label: "Refresh rate"
+  default: 3600
+  min: 60
+  unit: "s"
+  mode: box
+]]
+```
+
+- [ ] **Step 5: Add `@params` to `screens/floerli.lua`**
+
+```lua
+--[[ @params
+room:
+  type: string
+  label: "Room name"
+  default: "Rosa"
+test_timestamp:
+  type: int
+  label: "Test timestamp"
+  hidden: true
+  description: "Debug: override current time (unix seconds)"
+]]
+```
+
+- [ ] **Step 6: Add `@params` to `screens/fontdemo-bitmap.lua`**
+
+```lua
+--[[ @params
+font_prefix:
+  type: enum
+  label: "Font family"
+  default: "X11Helv"
+  options:
+    - {value: X11Helv, label: "X11 Helvetica"}
+    - {value: X11LuSans, label: "X11 Lucida Sans"}
+    - {value: X11LuType, label: "X11 Lucida Typewriter"}
+    - {value: X11Term, label: "X11 Terminal"}
+    - {value: X11Misc, label: "X11 Misc"}
+]]
+```
+
+- [ ] **Step 7: If Task 8's second test was `#[ignore]`d, remove the attribute now**
+
+Edit `tests/admin_screens_test.rs` to un-ignore `test_transit_has_station_param_after_headers_added`.
+
+- [ ] **Step 8: Run tests + full suite**
+
+Run: `cargo test --test screen_schemas_test --test admin_screens_test && make check`
+Expected: PASS, clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add screens/transit.lua screens/gphoto.lua screens/floerli.lua screens/fontdemo-bitmap.lua tests/screen_schemas_test.rs tests/admin_screens_test.rs
+git commit -m "feat(admin): declare @params schemas for bundled screens
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Documentation + changelog
+
+**Files:**
+- Create: `docs/src/api/admin-api.md`
+- Modify: `docs/src/SUMMARY.md`
+- Modify: `CHANGES.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Write the admin API doc page**
+
+Create `docs/src/api/admin-api.md` documenting: enabling the API (`BYONK_ADMIN_TOKEN` or
+`admin.token`), the 404-when-disabled behavior, `Authorization: Bearer` usage, every
+endpoint from Tasks 6–11 with a request/response example, the `@params` schema format
+(all fields from Task 3, with the `transit` example), and that writes preserve comments and
+hot-reload. Keep examples consistent with the handlers' actual JSON shapes.
+
+- [ ] **Step 2: Link it into the book**
+
+Add to `docs/src/SUMMARY.md` under the appropriate API section:
+
+```markdown
+  - [Admin API](api/admin-api.md)
+```
+
+- [ ] **Step 3: Build the docs**
+
+Run: `make docs`
+Expected: builds without warnings about the new page.
+
+- [ ] **Step 4: Update CHANGES.md**
+
+Under the `## [Unreleased]` section in `CHANGES.md`, add:
+
+```markdown
+### Added
+- Admin/management API (`/api/admin/*`), gated by a bearer token
+  (`BYONK_ADMIN_TOKEN` env or `admin.token` in config; disabled = returns 404):
+  read device telemetry, pending/unregistered devices, effective config, and
+  screen param schemas; create/update/delete device mappings and update global
+  settings.
+- Per-screen parameter schemas via a parsed (not executed) `@params` header in
+  each screen's `.lua`, with UI hints (label, min/max/step/unit/mode, enum
+  options, sensitive/multiline/hidden/advanced). Bundled screens now declare
+  their params.
+- Config hot-reload: admin writes update `config.yaml` in place (preserving
+  comments via yamlpath/yamlpatch) and take effect without a restart.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/api/admin-api.md docs/src/SUMMARY.md CHANGES.md
+git commit -m "docs(admin): document the admin API, @params schema, and changelog
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `make check` — fmt, clippy, and the entire test suite pass.
+- [ ] Run `make docs` — documentation builds.
+- [ ] Manually confirm acceptance criteria from the spec (§12):
+  1. No token ⇒ `/api/admin/*` returns 404 (covered by `test_admin_disabled_returns_404`).
+  2. Token set ⇒ endpoints work with Bearer; bad/missing token rejected (covered).
+  3. Device screen change served on next `/api/display` without restart — verify by hand:
+     start the server with a file config + token, `PATCH` a device's screen, then request
+     `/api/display` for that device and confirm the new screen renders.
+  4. Comments preserved after writes (covered by `config_writer` + write tests).
+  5. `/api/admin/screens` returns param schemas; validation enforced on writes (covered).
+  6. `make check` passes; `CHANGES.md` + docs updated (this task).

--- a/docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase1-admin-api-design.md
+++ b/docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase1-admin-api-design.md
@@ -97,7 +97,7 @@ All endpoints are JSON, under `/api/admin/`, token-gated as above. Errors use th
 | `GET /api/admin/devices` | All known devices: union of configured devices and live-seen devices. Each entry merges configured mapping (screen, dither, panel, colors, params) with live telemetry (model, firmware, `last_seen`, `battery_voltage`, `rssi`) and the **resolved active** screen/dither/panel actually being served. |
 | `GET /api/admin/pending` | Devices that have connected but are **not registered** — includes the registration code shown on-device, model/firmware, `last_seen`. Empty when registration is disabled. |
 | `GET /api/admin/config` | The full effective configuration as JSON (devices, screens, panels, global settings). Secrets such as `admin.token` are omitted. |
-| `GET /api/admin/screens` | Enumerations the integration needs to build native forms: list of screens each with its **param schema**; list of available panel profiles; list of available dither algorithms. |
+| `GET /api/admin/screens` | Enumerations the integration needs to build native forms: list of screens each with its **param schema** (and any schema-parse error for that screen); list of available panel profiles; list of available dither algorithms. |
 
 ### Write
 
@@ -125,57 +125,103 @@ All endpoints are JSON, under `/api/admin/`, token-gated as above. Errors use th
 
 ## 5. Per-screen parameter schema
 
-### Where it lives
+The schema is **part of the screen definition** — it lives in the screen's own `.lua`
+file, so it travels with the screen (portable/shareable) and sits right next to the code
+that reads `params.*`, minimizing drift.
 
-An **optional `params_schema:` block** under each screen in `config.yaml`, beside the
-existing `script` / `template` / `default_refresh` fields. Declarative, readable without
-executing Lua, and co-located with the screen definition.
+### Where it lives: a `@params` header in the `.lua` file
 
-*(Alternative considered and rejected for Phase 1: embedding the schema inside the Lua
-script. Rejected to avoid having to execute Lua merely to read metadata, and to keep the
-schema serializable straight from config.)*
+A YAML block inside a Lua block-comment at the top of the script, **parsed textually —
+never executed**. byonk extracts the text between the `@params` marker and the closing
+`]]`, then parses it as YAML.
 
-### Shape
+```lua
+--[[ @params
+station:
+  type: string
+  label: "Stop name"
+  required: true
+  description: "Stop name as used by the transport API"
+limit:
+  type: int
+  label: "Departures"
+  default: 8
+  min: 1
+  max: 30
+  unit: ""
+  mode: box
+]]
 
-Each schema entry is a list of field descriptors:
-
-```yaml
-screens:
-  transit:
-    script: transit.lua
-    template: transit.svg
-    default_refresh: 60
-    params_schema:
-      - name: station
-        type: string
-        required: true
-        description: "Stop name as used by the transport API"
-      - name: limit
-        type: int
-        required: false
-        default: 8
-        description: "Number of departures to show"
+local station = params.station or "Olten, Südwest"
+local limit   = params.limit or 8
 ```
 
-Field descriptor fields:
+*(Alternatives considered and rejected: `params_schema:` in `config.yaml` — far from the
+code, drifts, and not portable with the screen; a sidecar file — proliferates files. A
+Lua-executed metadata table was rejected to avoid running scripts merely to read
+metadata.)*
 
-- `name` (string, required)
-- `type` (enum, required): one of `string | int | float | bool | enum | color | url`
+### Schema shape
+
+The block is a mapping of **param key → field descriptor**.
+
+**Core fields (always supported):**
+
+- `type` (required): one of `string | int | float | bool | enum | color | url`
 - `required` (bool, default `false`)
 - `default` (any, optional)
-- `description` (string, optional)
-- `options` (list, required **iff** `type == enum`): allowed values
+- `description` (string, optional) — helper text
+- `label` (string, optional) — display name; falls back to a prettified key
 
-### Behavior
+**UI-helper fields (all included in v1):**
 
-- Exposed via `GET /api/admin/screens`.
-- Used to **validate** `params` on `POST`/`PATCH` device writes. Screens with no
-  `params_schema` accept arbitrary params (back-compat; no validation).
+- Numbers (`int`/`float`): `min`, `max`, `step`, `unit` (e.g. `"s"`, `"dBm"`),
+  `mode` (`box | slider`)
+- `enum`: `options` as a list of `{ value, label }` pairs (a bare list of values is also
+  accepted and labels default to the values)
+- `sensitive` (bool) — mask the field (rendered as a password input)
+- `multiline` (bool) — long-text input
+- `hidden` (bool) — debug-only params (e.g. `test_timestamp`); known to byonk/docs but
+  omitted from HA forms by default
+- `advanced` (bool) — shown under an "advanced" expander in the form
+
+**Deferred to a later phase:** `pattern` (regex), `group`/`section` (form grouping),
+`show_if` (conditional visibility).
+
+### Validation at ingestion (warn, non-fatal)
+
+When a screen is loaded (startup and on reload), byonk parses and validates its `@params`
+block:
+
+- A **well-formed** block is stored and exposed via `GET /api/admin/screens`.
+- A **malformed** block (bad YAML, unknown `type`, `enum` without `options`, etc.) is
+  **logged as a clear error and surfaced in `GET /api/admin/screens`** for that screen,
+  but **byonk keeps serving the screen** with its params treated as unvalidated. One
+  screen's typo never takes the server down.
+- A screen with **no `@params` block** is valid and accepts arbitrary params
+  (back-compat).
+
+### Use
+
+- Exposed via `GET /api/admin/screens` (with per-screen parse errors, if any).
+- Used to **validate** `params` on `POST`/`PATCH` device writes, per field `type`,
+  `required`, and numeric/enum constraints. Screens without a valid schema skip param
+  validation.
 - Keeping the schema in sync with the Lua implementation is the screen author's
-  responsibility (same as any schema/impl split). Existing screens in this repo gain
-  `params_schema` blocks as part of this phase where their params are known
-  (`transit`, `gphoto`, `mandelbrot`, `fontdemo-bitmap`, …); screens without one keep
-  working.
+  responsibility (advisory, same as any schema/impl split).
+
+### Scope of work: schema **all** screens in this repo
+
+Every screen in `screens/` gets a `@params` header as part of Phase 1, derived by reading
+each script's `params.*` usage:
+
+| Screen | Params |
+|---|---|
+| `transit` | `station` str (def "Olten, Südwest"); `limit` int (def 8, min 1, max 30) |
+| `gphoto` | `album_url` url **(required)**; `show_status` bool (def false); `refresh_rate` int (def 3600, unit "s") |
+| `floerli` | `room` str (def "Rosa"); `test_timestamp` int (**hidden**, debug) |
+| `fontdemo-bitmap` | `font_prefix` **enum** [X11Helv, X11LuSans, X11LuType, X11Term, X11Misc] (def X11Helv) |
+| `default`, `graytest`, `hello`, `hintdemo`, `calibrator`, `mandelbrot`, `fontdemo-terminus` | no params (no `@params` block, or an empty one) |
 
 ---
 
@@ -240,13 +286,19 @@ afterward.
 - `src/server.rs` — add `/api/admin/*` routes; `AppState.config` → arc-swap; admin auth
   middleware.
 - `src/api/` — new admin handlers module.
-- `src/models/config.rs` — `params_schema` on screen config; optional `admin.token`; JSON
-  (de)serialization for API responses; helpers to add/edit/remove device blocks and patch
-  globals.
+- `src/models/config.rs` — optional `admin.token`; JSON (de)serialization for API
+  responses; helpers to add/edit/remove device blocks and patch globals.
+- New module for the **`@params` schema**: types for the field descriptors, a textual
+  extractor that pulls the `@params` block out of a `.lua` file, a parser/validator
+  (warn-non-fatal), and param-value validation against a schema.
+- Screen loading (`AssetLoader` / `ContentPipeline` / `RenderService` where `.lua` files
+  are read) — extract + validate each screen's `@params` at load/reload; cache the parsed
+  schema and any parse error per screen.
 - `src/services/device_registry.rs` — a method to list all devices (registry is currently
   find-by-id only); compute pending/unregistered set.
 - `src/services/content_pipeline.rs` — read config via the swappable handle.
 - New module for comment-preserving YAML patching (wrapping `yamlpath`/`yamlpatch`).
+- `screens/*.lua` — add `@params` headers to all screens (per §5 table).
 - `Cargo.toml` — add `yamlpath`, `yamlpatch`, `arc-swap`.
 
 ---
@@ -257,9 +309,12 @@ Follow the project's TDD discipline; write tests first.
 
 - **YAML patch unit tests:** add/edit/remove device + global scalar edits each preserve
   surrounding comments; malformed inputs rejected.
-- **Param-schema tests:** schema parses from config; serializes correctly via
-  `GET /api/admin/screens`; param validation accepts/rejects correctly per type and
-  `required`.
+- **Param-schema tests:** `@params` extraction from a `.lua` file (incl. no-block and
+  empty-block cases); well-formed schema parses and serializes correctly via
+  `GET /api/admin/screens`; a malformed block is reported as an error there **without**
+  failing the server and the screen still renders; param validation accepts/rejects per
+  `type`, `required`, and numeric/enum constraints; all repo screens' `@params` headers
+  parse cleanly.
 - **API integration tests** (axum harness, mirroring existing `tests/`): each endpoint's
   happy path + error paths — `401` (wrong token), `404` (admin disabled, unknown device),
   `409` (duplicate key, embedded-only config), `400` (validation failures).
@@ -273,8 +328,8 @@ Follow the project's TDD discipline; write tests first.
 
 - `CHANGES.md` — add entries under **Unreleased** for the admin API, param schemas, and
   hot-reload.
-- `docs/src/` — new page documenting the admin API (endpoints, auth, `params_schema`
-  format), wired into `SUMMARY.md`.
+- `docs/src/` — new page documenting the admin API (endpoints, auth) and the `@params`
+  screen-schema format, wired into `SUMMARY.md`.
 
 ---
 
@@ -284,8 +339,11 @@ Follow the project's TDD discipline; write tests first.
   device-block strategy and scalar-only global Replaces (§6). Covered by round-trip tests.
 - **Hot-reload touching many config readers** → contained by the arc-swap accessor; the
   pipeline is the one non-trivial consumer and is explicitly addressed (§7).
-- **Schema drift** between `params_schema` and Lua → author responsibility; validation is
-  advisory and screens without a schema stay permissive (back-compat).
+- **Schema drift** between the `@params` header and the Lua code → minimized by
+  co-location in the same file; validation is advisory and screens without a schema stay
+  permissive (back-compat).
+- **`@params` extractor edge cases** (nested `]]`, CRLF, BOM, indentation) → covered by
+  extractor unit tests; malformed blocks degrade gracefully (warn, serve unvalidated).
 - **Empty/flow constructs in existing config** (e.g. `params: {}`) → exercised by tests
   against the repo's real `config.yaml` to catch patcher edge cases early.
 

--- a/docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase1-admin-api-design.md
+++ b/docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase1-admin-api-design.md
@@ -1,0 +1,303 @@
+# Byonk ↔ Home Assistant — Phase 1: Admin/Management API
+
+**Date:** 2026-06-28
+**Status:** Approved (design)
+**Scope of this spec:** Phase 1 only — the byonk-side "friendliness" layer. Phases 2–4 are summarized for context but specced separately.
+
+---
+
+## 1. Background & overall vision
+
+Byonk is a self-hosted content server for TRMNL e-ink devices: a single static Rust
+binary shipped as a multi-arch Docker image (`ghcr.io/oetiker/byonk`, amd64 + arm64).
+It is configured via env vars (`BIND_ADDR`, `CONFIG_FILE`, `SCREENS_DIR`, `FONTS_DIR`)
+and a YAML config file (`config.yaml`) that maps devices → screens and defines screen,
+panel, and dither settings. Device telemetry (MAC, model, firmware, `last_seen`,
+`battery_voltage`, `rssi`) is tracked in an **in-memory** registry and is currently
+**not exposed over HTTP**.
+
+The user wants byonk usable from **Home Assistant** with two deliverables:
+
+- An **Add-on** that runs byonk as a Supervisor-managed container (reusing the
+  prebuilt image, with persistent config).
+- An **Integration** (`custom_components/byonk/`) that surfaces and **fully manages**
+  byonk via **HA-idiomatic UI elements** (select / switch / number / text entities and
+  native config/options forms) — not merely an embedded web panel. Full read-write of
+  the byonk configuration and operating mode from HA.
+
+Both live as folders inside the existing byonk repo. The integration talks to a new
+**admin/management API** added to byonk. Byonk remains the source of truth and persists
+all changes to `config.yaml`.
+
+### Phased plan (each phase = its own spec → plan → build)
+
+1. **Phase 1 (this spec)** — Byonk admin API + per-screen param schemas + config
+   hot-reload + comment-preserving config writes. Pure Rust; independently testable.
+2. **Phase 2** — HA Add-on packaging (`homeassistant/` add-on repository structure,
+   prebuilt image, persistent `addon_config`, options, optional Ingress for `/dev`).
+3. **Phase 3** — HA Integration (`custom_components/byonk/`): config flow, HA Device
+   per TRMNL, sensors, diagnostic entities, select/number/switch/text controls,
+   subentry-based device add/edit, registration onboarding flow.
+4. **Phase 4** — Release & docs (multi-arch publishing aligned to add-on versions,
+   mdBook docs, HACS metadata).
+
+Everything in phases 2–4 depends on the Phase 1 API contract, which is why Phase 1 is
+built first.
+
+---
+
+## 2. Phase 1 goals & non-goals
+
+### Goals
+
+- Expose live device telemetry and the effective configuration over HTTP (read).
+- Allow full read-write management of device→screen mappings and global settings (write).
+- Make per-screen parameters self-describing (param schemas) so HA can render native forms.
+- Apply config writes **without losing user comments/formatting** in `config.yaml`.
+- Apply config writes **without a restart** (hot-reload of in-memory config).
+- Secure the whole admin surface behind a bearer token; disabled by default.
+
+### Non-goals (Phase 1)
+
+- Any Home Assistant code (add-on or integration) — later phases.
+- Runtime log-level changes (deferred; log level stays an env/add-on setting).
+- Editing screen definitions / Lua / SVG or panel profiles via the API (screen
+  *authoring* stays file-based; only device mappings + global settings are writable).
+- Switching the container run mode (serve vs dev) — that is an add-on/Supervisor
+  concern handled in Phase 2/3.
+- Persisting the device registry across restarts (it remains in-memory; devices
+  repopulate as they poll).
+
+---
+
+## 3. Authentication
+
+- Admin token sourced from env var **`BYONK_ADMIN_TOKEN`**, falling back to an optional
+  `admin.token` field in `config.yaml`.
+- **If no token is configured, every `/api/admin/*` route returns `404 Not Found`** — the
+  admin surface is invisible and secure by default. The add-on (Phase 2) injects the token
+  via env, and the integration (Phase 3) reuses it.
+- When enabled, each admin request must carry `Authorization: Bearer <token>`. Missing or
+  wrong token → `401 Unauthorized`. Constant-time comparison for the token check.
+- Token is never returned by any endpoint (e.g. `GET /api/admin/config` omits `admin.token`).
+- The existing TRMNL-facing endpoints (`/api/setup`, `/api/display`, …) are unchanged and
+  keep their own auth.
+
+---
+
+## 4. API surface
+
+All endpoints are JSON, under `/api/admin/`, token-gated as above. Errors use the existing
+`ApiError` JSON shape with appropriate status codes.
+
+### Read
+
+| Method + path | Purpose |
+|---|---|
+| `GET /api/admin/devices` | All known devices: union of configured devices and live-seen devices. Each entry merges configured mapping (screen, dither, panel, colors, params) with live telemetry (model, firmware, `last_seen`, `battery_voltage`, `rssi`) and the **resolved active** screen/dither/panel actually being served. |
+| `GET /api/admin/pending` | Devices that have connected but are **not registered** — includes the registration code shown on-device, model/firmware, `last_seen`. Empty when registration is disabled. |
+| `GET /api/admin/config` | The full effective configuration as JSON (devices, screens, panels, global settings). Secrets such as `admin.token` are omitted. |
+| `GET /api/admin/screens` | Enumerations the integration needs to build native forms: list of screens each with its **param schema**; list of available panel profiles; list of available dither algorithms. |
+
+### Write
+
+| Method + path | Purpose |
+|---|---|
+| `POST /api/admin/devices` | Add a device mapping. Body: `{ key, screen, panel?, dither?, colors?, params? }` where `key` is a MAC (`AA:BB:…`) or a registration code (`ABCDE-FGHJK`). Used both for fresh additions and to register a pending device. `409` if the key already exists. |
+| `PATCH /api/admin/devices/{key}` | Update any subset of `screen`, `panel`, `dither`, `colors`, `refresh`, `params` for an existing mapping. `404` if the key is not in config. |
+| `DELETE /api/admin/devices/{key}` | Remove a device mapping. `404` if not present. |
+| `PATCH /api/admin/settings` | Update global settings: `registration.enabled`, `auth_mode`, `default_screen`. Partial updates allowed. |
+
+### Cross-cutting write behavior
+
+- All writes are validated **before** mutating the file (e.g. unknown screen name,
+  unknown panel, malformed colors, params failing the screen's schema → `400` with a
+  descriptive message; nothing is written).
+- Writes require a **file-backed config** (`CONFIG_FILE` set / a real `config.yaml` on
+  disk). If byonk is running purely from the embedded default with no writable file,
+  write endpoints return `409 Conflict` with an explanatory message.
+- A successful write returns the updated resource (the same shape the corresponding GET
+  would return for that device / settings block).
+- Writes are serialized with a mutex so concurrent admin requests cannot interleave
+  file patches.
+
+---
+
+## 5. Per-screen parameter schema
+
+### Where it lives
+
+An **optional `params_schema:` block** under each screen in `config.yaml`, beside the
+existing `script` / `template` / `default_refresh` fields. Declarative, readable without
+executing Lua, and co-located with the screen definition.
+
+*(Alternative considered and rejected for Phase 1: embedding the schema inside the Lua
+script. Rejected to avoid having to execute Lua merely to read metadata, and to keep the
+schema serializable straight from config.)*
+
+### Shape
+
+Each schema entry is a list of field descriptors:
+
+```yaml
+screens:
+  transit:
+    script: transit.lua
+    template: transit.svg
+    default_refresh: 60
+    params_schema:
+      - name: station
+        type: string
+        required: true
+        description: "Stop name as used by the transport API"
+      - name: limit
+        type: int
+        required: false
+        default: 8
+        description: "Number of departures to show"
+```
+
+Field descriptor fields:
+
+- `name` (string, required)
+- `type` (enum, required): one of `string | int | float | bool | enum | color | url`
+- `required` (bool, default `false`)
+- `default` (any, optional)
+- `description` (string, optional)
+- `options` (list, required **iff** `type == enum`): allowed values
+
+### Behavior
+
+- Exposed via `GET /api/admin/screens`.
+- Used to **validate** `params` on `POST`/`PATCH` device writes. Screens with no
+  `params_schema` accept arbitrary params (back-compat; no validation).
+- Keeping the schema in sync with the Lua implementation is the screen author's
+  responsibility (same as any schema/impl split). Existing screens in this repo gain
+  `params_schema` blocks as part of this phase where their params are known
+  (`transit`, `gphoto`, `mandelbrot`, `fontdemo-bitmap`, …); screens without one keep
+  working.
+
+---
+
+## 6. Comment-preserving config writes
+
+### Libraries
+
+Add `yamlpath` and `yamlpatch` (from the zizmor project; actively maintained,
+comment/format-preserving surgical patching). `serde_yaml` remains for parsing the file
+into `AppConfig`.
+
+### Write strategy (avoids yamlpatch's weak spots)
+
+`yamlpatch`'s `Replace` is unreliable on sequences/flow lists. The strategy below routes
+around that:
+
+- **Device add / edit / remove** → **remove the device's subtree, then append a freshly
+  block-serialized subtree**. Device blocks are machine-managed, so they carry no user
+  comments to lose; every comment *outside* the device block is preserved.
+  - *Add*: append a new block under `devices:`.
+  - *Edit*: remove the existing `devices.<key>` subtree + append the updated block.
+  - *Remove*: remove the `devices.<key>` subtree.
+- **Global scalar settings** (`registration.enabled`, `auth_mode`, `default_screen`) →
+  in-place scalar **`Replace`** (supported and safe).
+
+### Pipeline for a write
+
+1. Read `config.yaml` text from disk.
+2. Validate the requested change against the in-memory parsed config (and param schema).
+3. Build the `yamlpatch` operation(s) per the strategy above.
+4. Apply to the text; write the result back atomically (write to temp file in the same
+   dir, then rename).
+5. Reparse the new text into `AppConfig`; if parse fails, **roll back** to the previous
+   file contents and return `500` (should not happen if validation is correct, but guards
+   against corruption).
+6. Hot-swap the in-memory config (§7).
+
+### Comment-preservation guarantee (test target)
+
+A round-trip test takes a `config.yaml` rich with comments, performs each write type, and
+asserts that all comments not inside the touched device block are byte-identical
+afterward.
+
+---
+
+## 7. Config hot-reload
+
+- `AppState.config` becomes an **`arc-swap`** handle (`Arc<ArcSwap<AppConfig>>`) instead of
+  a plain `Arc<AppConfig>`. All readers use a `.load()` accessor.
+- `ContentPipeline` currently holds its own `Arc<AppConfig>`. It must read through the same
+  swappable handle (preferred) **or** be rebuilt on each config change. Decision deferred to
+  planning; the simplest correct approach (likely: pipeline reads the handle) wins. The
+  acceptance criterion is that `/api/display` reflects config changes with no restart.
+- After a successful write (§6), reparse and atomically `store` the new `AppConfig`.
+- **Bonus (include if cheap):** reuse the existing dev-mode file-watcher so *external* edits
+  to `config.yaml` also trigger a reload. Not required for Phase 1 acceptance.
+
+---
+
+## 8. Affected byonk code (orientation, not prescription)
+
+- `src/server.rs` — add `/api/admin/*` routes; `AppState.config` → arc-swap; admin auth
+  middleware.
+- `src/api/` — new admin handlers module.
+- `src/models/config.rs` — `params_schema` on screen config; optional `admin.token`; JSON
+  (de)serialization for API responses; helpers to add/edit/remove device blocks and patch
+  globals.
+- `src/services/device_registry.rs` — a method to list all devices (registry is currently
+  find-by-id only); compute pending/unregistered set.
+- `src/services/content_pipeline.rs` — read config via the swappable handle.
+- New module for comment-preserving YAML patching (wrapping `yamlpath`/`yamlpatch`).
+- `Cargo.toml` — add `yamlpath`, `yamlpatch`, `arc-swap`.
+
+---
+
+## 9. Testing (TDD)
+
+Follow the project's TDD discipline; write tests first.
+
+- **YAML patch unit tests:** add/edit/remove device + global scalar edits each preserve
+  surrounding comments; malformed inputs rejected.
+- **Param-schema tests:** schema parses from config; serializes correctly via
+  `GET /api/admin/screens`; param validation accepts/rejects correctly per type and
+  `required`.
+- **API integration tests** (axum harness, mirroring existing `tests/`): each endpoint's
+  happy path + error paths — `401` (wrong token), `404` (admin disabled, unknown device),
+  `409` (duplicate key, embedded-only config), `400` (validation failures).
+- **Hot-reload test:** `PATCH` a device's screen → `GET /api/admin/devices` reflects it →
+  `GET /api/display` for that device serves the new screen, all without a restart.
+- `make check` (fmt + clippy + tests) clean.
+
+---
+
+## 10. Documentation & changelog
+
+- `CHANGES.md` — add entries under **Unreleased** for the admin API, param schemas, and
+  hot-reload.
+- `docs/src/` — new page documenting the admin API (endpoints, auth, `params_schema`
+  format), wired into `SUMMARY.md`.
+
+---
+
+## 11. Risks & mitigations
+
+- **`yamlpatch` limitations on sequences/flow lists** → mitigated by the remove+append
+  device-block strategy and scalar-only global Replaces (§6). Covered by round-trip tests.
+- **Hot-reload touching many config readers** → contained by the arc-swap accessor; the
+  pipeline is the one non-trivial consumer and is explicitly addressed (§7).
+- **Schema drift** between `params_schema` and Lua → author responsibility; validation is
+  advisory and screens without a schema stay permissive (back-compat).
+- **Empty/flow constructs in existing config** (e.g. `params: {}`) → exercised by tests
+  against the repo's real `config.yaml` to catch patcher edge cases early.
+
+---
+
+## 12. Acceptance criteria (Phase 1 done when…)
+
+1. With `BYONK_ADMIN_TOKEN` unset, all `/api/admin/*` return `404`.
+2. With a token set, all endpoints in §4 work with `Bearer` auth and reject bad/missing tokens.
+3. A device's screen/params can be changed via the API and is served on the next
+   `/api/display` **without restarting** byonk.
+4. After any write, comments elsewhere in `config.yaml` are preserved.
+5. `GET /api/admin/screens` returns param schemas usable to build forms; param validation
+   enforces them on writes.
+6. `make check` passes; `CHANGES.md` and admin-API docs updated.

--- a/screens/floerli.lua
+++ b/screens/floerli.lua
@@ -1,3 +1,14 @@
+--[[ @params
+room:
+  type: string
+  label: "Room name"
+  default: "Rosa"
+test_timestamp:
+  type: int
+  label: "Test timestamp"
+  hidden: true
+  description: "Debug: override current time (unix seconds)"
+]]
 -- Floerli room booking display
 -- Fetches schedule from floerli-olten.ch and shows current/upcoming bookings
 

--- a/screens/fontdemo-bitmap.lua
+++ b/screens/fontdemo-bitmap.lua
@@ -1,3 +1,15 @@
+--[[ @params
+font_prefix:
+  type: enum
+  label: "Font family"
+  default: "X11Helv"
+  options:
+    - {value: X11Helv, label: "X11 Helvetica"}
+    - {value: X11LuSans, label: "X11 Lucida Sans"}
+    - {value: X11LuType, label: "X11 Lucida Typewriter"}
+    - {value: X11Term, label: "X11 Terminal"}
+    - {value: X11Misc, label: "X11 Misc"}
+]]
 -- Bitmap font showcase
 -- Each line shows a font rendered at its native size with CSS shorthand as label
 -- Params:

--- a/screens/gphoto.lua
+++ b/screens/gphoto.lua
@@ -1,3 +1,21 @@
+--[[ @params
+album_url:
+  type: url
+  label: "Album URL"
+  required: true
+  description: "Shared Google Photos album link"
+show_status:
+  type: bool
+  label: "Show status overlay"
+  default: false
+refresh_rate:
+  type: int
+  label: "Refresh rate"
+  default: 3600
+  min: 60
+  unit: "s"
+  mode: box
+]]
 -- Google Photos shared album display
 -- Fetches random photos from a shared Google Photos album
 -- Uses HTML scraping of the shared album page (no OAuth required)

--- a/screens/transit.lua
+++ b/screens/transit.lua
@@ -1,3 +1,18 @@
+--[[ @params
+station:
+  type: string
+  label: "Stop name"
+  default: "Olten, Südwest"
+  description: "Stop name as used by the transport API"
+limit:
+  type: int
+  label: "Departures"
+  default: 8
+  min: 1
+  max: 30
+  mode: box
+  description: "Number of departures to show"
+]]
 -- Public transport departure display
 -- Fetches real-time departures from Swiss OpenData Transport API
 

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -37,6 +37,8 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 
 /// All admin routes, to be nested under `/api/admin`.
 pub fn admin_router() -> Router<AppState> {
-    Router::new().route("/devices", get(read::list_devices))
-    // read.rs/write.rs add more routes in later tasks
+    Router::new()
+        .route("/devices", get(read::list_devices))
+        .route("/pending", get(read::pending))
+        .route("/config", get(read::get_config))
 }

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -51,4 +51,5 @@ pub fn admin_router() -> Router<AppState> {
         .route("/pending", get(read::pending))
         .route("/config", get(read::get_config))
         .route("/screens", get(read::screens))
+        .route("/settings", patch(write::patch_settings))
 }

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -1,0 +1,42 @@
+//! Admin/management API (`/api/admin/*`), gated by a bearer token.
+
+pub mod read;
+
+use axum::{http::HeaderMap, routing::get, Router};
+
+use crate::error::ApiError;
+use crate::server::AppState;
+
+/// Enforce admin auth. Returns 404 when admin is disabled (no token configured),
+/// 401 when the token is missing or wrong.
+pub fn require_admin(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError> {
+    let Some(expected) = state.admin_token.as_deref() else {
+        return Err(ApiError::NotFound); // admin disabled ⇒ invisible
+    };
+    let provided = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    match provided {
+        Some(tok) if constant_time_eq(tok.as_bytes(), expected.as_bytes()) => Ok(()),
+        _ => Err(ApiError::Unauthorized),
+    }
+}
+
+/// Constant-time byte comparison (avoids token-length/timing leaks).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// All admin routes, to be nested under `/api/admin`.
+pub fn admin_router() -> Router<AppState> {
+    Router::new().route("/devices", get(read::list_devices))
+    // read.rs/write.rs add more routes in later tasks
+}

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -1,8 +1,13 @@
 //! Admin/management API (`/api/admin/*`), gated by a bearer token.
 
 pub mod read;
+pub mod write;
 
-use axum::{http::HeaderMap, routing::get, Router};
+use axum::{
+    http::HeaderMap,
+    routing::{get, patch},
+    Router,
+};
 
 use crate::error::ApiError;
 use crate::server::AppState;
@@ -38,7 +43,11 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 /// All admin routes, to be nested under `/api/admin`.
 pub fn admin_router() -> Router<AppState> {
     Router::new()
-        .route("/devices", get(read::list_devices))
+        .route("/devices", get(read::list_devices).post(write::add_device))
+        .route(
+            "/devices/:key",
+            patch(write::patch_device).delete(write::delete_device),
+        )
         .route("/pending", get(read::pending))
         .route("/config", get(read::get_config))
         .route("/screens", get(read::screens))

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -41,4 +41,5 @@ pub fn admin_router() -> Router<AppState> {
         .route("/devices", get(read::list_devices))
         .route("/pending", get(read::pending))
         .route("/config", get(read::get_config))
+        .route("/screens", get(read::screens))
 }

--- a/src/api/admin/read.rs
+++ b/src/api/admin/read.rs
@@ -4,6 +4,7 @@ use axum::{extract::State, http::HeaderMap, Json};
 use serde::Serialize;
 
 use crate::error::ApiError;
+use crate::models::param_schema::{schema_for_script, ParamField};
 use crate::server::AppState;
 use crate::services::DeviceRegistry;
 
@@ -158,4 +159,85 @@ pub async fn list_devices(
     }
 
     Ok(Json(out))
+}
+
+#[derive(Serialize)]
+pub struct ScreenInfo {
+    pub name: String,
+    pub params: Vec<ParamField>,
+    pub schema_error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct PanelInfo {
+    pub name: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub colors: String,
+}
+
+#[derive(Serialize)]
+pub struct ScreensResponse {
+    pub screens: Vec<ScreenInfo>,
+    pub panels: Vec<PanelInfo>,
+    pub dither_algorithms: Vec<String>,
+}
+
+/// Canonical dither algorithm names byonk understands.
+const DITHER_ALGORITHMS: &[&str] = &[
+    "floyd-steinberg",
+    "atkinson",
+    "atkinson-hybrid",
+    "jarvis-judice-ninke",
+    "sierra",
+    "sierra-two-row",
+    "sierra-lite",
+    "sierra-light",
+    "stucki",
+    "burkes",
+];
+
+pub async fn screens(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<ScreensResponse>, ApiError> {
+    require_admin(&state, &headers)?;
+    let config = state.config.load();
+
+    let mut screens = Vec::new();
+    for (name, sc) in &config.screens {
+        let (params, schema_error) = match state.asset_loader.read_screen_string(&sc.script) {
+            Err(e) => (Vec::new(), Some(format!("cannot read script: {e}"))),
+            Ok(src) => match schema_for_script(&src) {
+                Ok(Some(schema)) => (schema.fields, None),
+                Ok(None) => (Vec::new(), None),
+                Err(e) => {
+                    tracing::warn!(screen = %name, error = %e, "invalid @params schema");
+                    (Vec::new(), Some(e))
+                }
+            },
+        };
+        screens.push(ScreenInfo {
+            name: name.clone(),
+            params,
+            schema_error,
+        });
+    }
+
+    let panels = config
+        .panels
+        .iter()
+        .map(|(name, p)| PanelInfo {
+            name: name.clone(),
+            width: p.width,
+            height: p.height,
+            colors: p.colors.clone(),
+        })
+        .collect();
+
+    Ok(Json(ScreensResponse {
+        screens,
+        panels,
+        dither_algorithms: DITHER_ALGORITHMS.iter().map(|s| s.to_string()).collect(),
+    }))
 }

--- a/src/api/admin/read.rs
+++ b/src/api/admin/read.rs
@@ -1,0 +1,99 @@
+//! Admin read endpoints.
+
+use axum::{extract::State, http::HeaderMap, Json};
+use serde::Serialize;
+
+use crate::error::ApiError;
+use crate::server::AppState;
+use crate::services::DeviceRegistry;
+
+use super::require_admin;
+
+#[derive(Serialize)]
+pub struct AdminDevice {
+    /// Config key (MAC or registration code) if configured, else the MAC.
+    pub key: String,
+    pub mac: String,
+    pub registration_code: String,
+    pub registered: bool,
+    // telemetry (None when never seen)
+    pub model: Option<String>,
+    pub firmware_version: Option<String>,
+    pub last_seen: Option<String>,
+    pub battery_voltage: Option<f32>,
+    pub rssi: Option<i32>,
+    // resolved active config (None when no mapping)
+    pub screen: Option<String>,
+    pub dither: Option<String>,
+    pub panel: Option<String>,
+    pub colors: Option<String>,
+    pub params: serde_json::Value,
+}
+
+pub async fn list_devices(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<AdminDevice>>, ApiError> {
+    require_admin(&state, &headers)?;
+
+    let config = state.config.load();
+    let seen = state.registry.list_all().await?;
+
+    let mut out: Vec<AdminDevice> = Vec::new();
+
+    // 1) Every device the registry has seen, merged with its config mapping.
+    for d in &seen {
+        let mac = d.device_id.to_string();
+        let code = d.api_key.registration_code();
+        let dc = config
+            .get_device_config(&mac)
+            .or_else(|| config.get_device_config_for_code(&code));
+        let registered = config.is_device_registered(&mac, Some(&code));
+        out.push(AdminDevice {
+            key: mac.clone(),
+            mac,
+            registration_code: code,
+            registered,
+            model: Some(d.model.to_string()),
+            firmware_version: Some(d.firmware_version.clone()),
+            last_seen: Some(d.last_seen.to_rfc3339()),
+            battery_voltage: d.battery_voltage,
+            rssi: d.rssi,
+            screen: dc.map(|c| c.screen.clone()),
+            dither: dc.and_then(|c| c.dither.clone()),
+            panel: dc.and_then(|c| c.panel.clone()),
+            colors: dc.and_then(|c| c.colors.clone()),
+            params: dc
+                .map(|c| serde_json::to_value(&c.params).unwrap_or(serde_json::Value::Null))
+                .unwrap_or(serde_json::Value::Null),
+        });
+    }
+
+    // 2) Configured devices that have NOT been seen yet (telemetry = None).
+    let seen_macs: std::collections::HashSet<String> =
+        seen.iter().map(|d| d.device_id.to_string()).collect();
+    for (key, dc) in &config.devices {
+        // Skip if this config entry corresponds to a seen device (by MAC key).
+        if seen_macs.contains(key) {
+            continue;
+        }
+        out.push(AdminDevice {
+            key: key.clone(),
+            mac: key.clone(),
+            registration_code: String::new(),
+            registered: true,
+            model: None,
+            firmware_version: None,
+            last_seen: None,
+            battery_voltage: None,
+            rssi: None,
+            screen: Some(dc.screen.clone()),
+            dither: dc.dither.clone(),
+            panel: dc.panel.clone(),
+            colors: dc.colors.clone(),
+            params: serde_json::to_value(&dc.params).unwrap_or(serde_json::Value::Null),
+        });
+    }
+
+    Ok(Json(out))
+}

--- a/src/api/admin/read.rs
+++ b/src/api/admin/read.rs
@@ -10,6 +10,68 @@ use crate::services::DeviceRegistry;
 use super::require_admin;
 
 #[derive(Serialize)]
+pub struct PendingDevice {
+    pub mac: String,
+    pub registration_code: String,
+    pub model: String,
+    pub firmware_version: String,
+    pub last_seen: String,
+}
+
+pub async fn pending(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<PendingDevice>>, ApiError> {
+    require_admin(&state, &headers)?;
+
+    let config = state.config.load();
+    let mut out = Vec::new();
+    for d in state.registry.list_all().await? {
+        let mac = d.device_id.to_string();
+        let code = d.api_key.registration_code();
+        if config.is_device_registered(&mac, Some(&code)) {
+            continue;
+        }
+        out.push(PendingDevice {
+            mac,
+            registration_code: code,
+            model: d.model.to_string(),
+            firmware_version: d.firmware_version.clone(),
+            last_seen: d.last_seen.to_rfc3339(),
+        });
+    }
+    Ok(Json(out))
+}
+
+pub async fn get_config(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+
+    let text = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(format!("read config: {e}")))?;
+    let mut value: serde_yaml::Value = serde_yaml::from_str(&text)
+        .map_err(|e| ApiError::Internal(format!("parse config: {e}")))?;
+
+    // Strip admin.token from the response.
+    if let Some(map) = value.as_mapping_mut() {
+        if let Some(admin) = map
+            .get_mut(serde_yaml::Value::from("admin"))
+            .and_then(|a| a.as_mapping_mut())
+        {
+            admin.remove(serde_yaml::Value::from("token"));
+        }
+    }
+
+    let json =
+        serde_json::to_value(&value).map_err(|e| ApiError::Internal(format!("to json: {e}")))?;
+    Ok(Json(json))
+}
+
+#[derive(Serialize)]
 pub struct AdminDevice {
     /// Config key (MAC or registration code) if configured, else the MAC.
     pub key: String,

--- a/src/api/admin/write.rs
+++ b/src/api/admin/write.rs
@@ -1,0 +1,209 @@
+//! Admin write endpoints: device mappings + global settings.
+
+use axum::{
+    extract::{Path, State},
+    http::HeaderMap,
+    Json,
+};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::error::ApiError;
+use crate::models::param_schema::{schema_for_script, validate_params};
+use crate::server::{reload_config, AppState};
+use crate::services::config_writer;
+
+use super::require_admin;
+
+#[derive(Deserialize)]
+pub struct DeviceWrite {
+    pub key: Option<String>, // required for POST, ignored for PATCH (taken from URL)
+    pub screen: Option<String>,
+    pub panel: Option<String>,
+    pub dither: Option<String>,
+    pub colors: Option<String>,
+    pub params: Option<HashMap<String, serde_yaml::Value>>,
+}
+
+/// Guard: writes require a file-backed config.
+fn require_file_config(state: &AppState) -> Result<std::path::PathBuf, ApiError> {
+    state
+        .asset_loader
+        .config_path()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| ApiError::Conflict("config is embedded/read-only; set CONFIG_FILE".into()))
+}
+
+/// Validate the screen exists and (if it has a schema) the params pass it.
+fn validate_screen_and_params(
+    state: &AppState,
+    screen: &str,
+    params: &HashMap<String, serde_yaml::Value>,
+) -> Result<(), ApiError> {
+    let config = state.config.load();
+    let sc = config
+        .screens
+        .get(screen)
+        .ok_or_else(|| ApiError::BadRequest(format!("unknown screen `{screen}`")))?;
+    if let Ok(src) = state
+        .asset_loader
+        .read_screen_string(std::path::Path::new(&sc.script))
+    {
+        if let Ok(Some(schema)) = schema_for_script(&src) {
+            if let Err(errs) = validate_params(&schema, params) {
+                return Err(ApiError::BadRequest(errs.join("; ")));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build the YAML mapping for a device block from the provided fields.
+fn device_block(w: &DeviceWrite, screen: &str) -> serde_yaml::Mapping {
+    let mut m = serde_yaml::Mapping::new();
+    m.insert("screen".into(), screen.into());
+    if let Some(p) = &w.panel {
+        m.insert("panel".into(), p.as_str().into());
+    }
+    if let Some(d) = &w.dither {
+        m.insert("dither".into(), d.as_str().into());
+    }
+    if let Some(c) = &w.colors {
+        m.insert("colors".into(), c.as_str().into());
+    }
+    if let Some(params) = &w.params {
+        let mut pm = serde_yaml::Mapping::new();
+        for (k, v) in params {
+            pm.insert(k.as_str().into(), v.clone());
+        }
+        m.insert("params".into(), serde_yaml::Value::Mapping(pm));
+    }
+    m
+}
+
+fn persist(state: &AppState, path: &std::path::Path, new_yaml: String) -> Result<(), ApiError> {
+    // Snapshot current contents so we can roll back if the new text fails to reparse.
+    let previous = std::fs::read_to_string(path).ok();
+
+    // Atomic write: temp file in same dir, then rename.
+    let tmp = path.with_extension("yaml.tmp");
+    std::fs::write(&tmp, &new_yaml).map_err(|e| ApiError::Internal(format!("write temp: {e}")))?;
+    std::fs::rename(&tmp, path).map_err(|e| ApiError::Internal(format!("rename: {e}")))?;
+
+    // Reload into the live config; on failure, roll the file back.
+    if let Err(e) = reload_config(state) {
+        if let Some(prev) = previous {
+            let _ = std::fs::write(path, prev);
+        }
+        return Err(ApiError::Internal(format!(
+            "reload failed, rolled back: {e}"
+        )));
+    }
+    Ok(())
+}
+
+pub async fn add_device(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<DeviceWrite>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+    let key = body
+        .key
+        .clone()
+        .ok_or_else(|| ApiError::BadRequest("`key` is required".into()))?;
+    let screen = body
+        .screen
+        .clone()
+        .ok_or_else(|| ApiError::BadRequest("`screen` is required".into()))?;
+
+    // Reject duplicate.
+    if state.config.load().devices.contains_key(&key) {
+        return Err(ApiError::Conflict(format!("device `{key}` already exists")));
+    }
+
+    let empty = HashMap::new();
+    validate_screen_and_params(&state, &screen, body.params.as_ref().unwrap_or(&empty))?;
+
+    let block = device_block(&body, &screen);
+    let yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let new_yaml = config_writer::upsert_device(&yaml, &key, &block)
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    persist(&state, &path, new_yaml)?;
+
+    Ok(Json(serde_json::json!({ "key": key, "screen": screen })))
+}
+
+pub async fn patch_device(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<DeviceWrite>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+
+    // Must already exist.
+    let existing = {
+        let config = state.config.load();
+        config
+            .devices
+            .get(&key)
+            .cloned()
+            .ok_or(ApiError::NotFound)?
+    };
+
+    // Merge: start from existing, override provided fields.
+    let screen = body.screen.clone().unwrap_or(existing.screen.clone());
+    let merged = DeviceWrite {
+        key: Some(key.clone()),
+        screen: Some(screen.clone()),
+        panel: body.panel.clone().or(existing.panel.clone()),
+        dither: body.dither.clone().or(existing.dither.clone()),
+        colors: body.colors.clone().or(existing.colors.clone()),
+        params: Some(body.params.clone().unwrap_or(existing.params.clone())),
+    };
+
+    let empty = HashMap::new();
+    validate_screen_and_params(&state, &screen, merged.params.as_ref().unwrap_or(&empty))?;
+
+    let block = device_block(&merged, &screen);
+    let yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let new_yaml = config_writer::upsert_device(&yaml, &key, &block)
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    persist(&state, &path, new_yaml)?;
+
+    Ok(Json(serde_json::json!({ "key": key, "screen": screen })))
+}
+
+pub async fn delete_device(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+
+    let yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let new_yaml = match config_writer::remove_device(&yaml, &key) {
+        Ok(y) => y,
+        Err(config_writer::ConfigWriteError::NotFound(_)) => return Err(ApiError::NotFound),
+        Err(e) => return Err(ApiError::Internal(e.to_string())),
+    };
+    persist(&state, &path, new_yaml)?;
+
+    Ok(Json(serde_json::json!({ "deleted": key })))
+}

--- a/src/api/admin/write.rs
+++ b/src/api/admin/write.rs
@@ -207,3 +207,49 @@ pub async fn delete_device(
 
     Ok(Json(serde_json::json!({ "deleted": key })))
 }
+
+#[derive(Deserialize)]
+pub struct SettingsWrite {
+    pub registration_enabled: Option<bool>,
+    pub auth_mode: Option<String>,
+    pub default_screen: Option<String>,
+}
+
+pub async fn patch_settings(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<SettingsWrite>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    require_admin(&state, &headers)?;
+    let path = require_file_config(&state)?;
+    let _guard = state.write_lock.lock().await;
+
+    let mut yaml = state
+        .asset_loader
+        .read_config_string()
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    if let Some(enabled) = body.registration_enabled {
+        yaml = config_writer::set_scalar(&yaml, &["registration", "enabled"], enabled.into())
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+    }
+    if let Some(mode) = &body.auth_mode {
+        if mode != "api_key" && mode != "ed25519" {
+            return Err(ApiError::BadRequest(
+                "auth_mode must be api_key or ed25519".into(),
+            ));
+        }
+        yaml = config_writer::set_scalar(&yaml, &["auth_mode"], mode.as_str().into())
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+    }
+    if let Some(screen) = &body.default_screen {
+        if !state.config.load().screens.contains_key(screen) {
+            return Err(ApiError::BadRequest(format!("unknown screen `{screen}`")));
+        }
+        yaml = config_writer::set_scalar(&yaml, &["default_screen"], screen.as_str().into())
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+    }
+
+    persist(&state, &path, yaml)?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}

--- a/src/api/admin/write.rs
+++ b/src/api/admin/write.rs
@@ -210,9 +210,9 @@ pub async fn delete_device(
 
 #[derive(Deserialize)]
 pub struct SettingsWrite {
-    pub registration_enabled: Option<bool>,
-    pub auth_mode: Option<String>,
-    pub default_screen: Option<String>,
+    pub(crate) registration_enabled: Option<bool>,
+    pub(crate) auth_mode: Option<String>,
+    pub(crate) default_screen: Option<String>,
 }
 
 pub async fn patch_settings(
@@ -224,6 +224,21 @@ pub async fn patch_settings(
     let path = require_file_config(&state)?;
     let _guard = state.write_lock.lock().await;
 
+    // 1. Validate all provided fields before touching yaml.
+    if let Some(mode) = &body.auth_mode {
+        if mode != "api_key" && mode != "ed25519" {
+            return Err(ApiError::BadRequest(
+                "auth_mode must be api_key or ed25519".into(),
+            ));
+        }
+    }
+    if let Some(screen) = &body.default_screen {
+        if !state.config.load().screens.contains_key(screen) {
+            return Err(ApiError::BadRequest(format!("unknown screen `{screen}`")));
+        }
+    }
+
+    // 2. Apply all mutations.
     let mut yaml = state
         .asset_loader
         .read_config_string()
@@ -234,22 +249,15 @@ pub async fn patch_settings(
             .map_err(|e| ApiError::Internal(e.to_string()))?;
     }
     if let Some(mode) = &body.auth_mode {
-        if mode != "api_key" && mode != "ed25519" {
-            return Err(ApiError::BadRequest(
-                "auth_mode must be api_key or ed25519".into(),
-            ));
-        }
         yaml = config_writer::set_scalar(&yaml, &["auth_mode"], mode.as_str().into())
             .map_err(|e| ApiError::Internal(e.to_string()))?;
     }
     if let Some(screen) = &body.default_screen {
-        if !state.config.load().screens.contains_key(screen) {
-            return Err(ApiError::BadRequest(format!("unknown screen `{screen}`")));
-        }
         yaml = config_writer::set_scalar(&yaml, &["default_screen"], screen.as_str().into())
             .map_err(|e| ApiError::Internal(e.to_string()))?;
     }
 
+    // 3. Persist.
     persist(&state, &path, yaml)?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod dev;
 pub mod display;
 mod headers;

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -219,6 +219,11 @@ impl AssetLoader {
         fonts
     }
 
+    /// Path to the external config file, if one is configured.
+    pub fn config_path(&self) -> Option<&std::path::Path> {
+        self.config_file.as_deref()
+    }
+
     /// Read the config file
     ///
     /// If an external path is configured and exists, uses that.
@@ -439,6 +444,17 @@ mod tests {
         assert!(loader.screens_dir.is_some());
         assert!(loader.fonts_dir.is_some());
         assert!(loader.config_file.is_some());
+    }
+
+    #[test]
+    fn test_config_path_getter() {
+        let loader = AssetLoader::new(None, None, Some(PathBuf::from("/tmp/x.yaml")));
+        assert_eq!(
+            loader.config_path(),
+            Some(std::path::Path::new("/tmp/x.yaml"))
+        );
+        let embedded = AssetLoader::new(None, None, None);
+        assert_eq!(embedded.config_path(), None);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,15 @@ pub enum ApiError {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
+    #[error("Conflict: {0}")]
+    Conflict(String),
 }
 
 impl From<crate::services::content_pipeline::ContentError> for ApiError {
@@ -66,6 +75,9 @@ impl IntoResponse for ApiError {
             ApiError::Render(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
             ApiError::Content(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
             ApiError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
+            ApiError::BadRequest(m) => (StatusCode::BAD_REQUEST, m.clone()),
+            ApiError::Conflict(m) => (StatusCode::CONFLICT, m.clone()),
         };
 
         let body = Json(json!({
@@ -80,6 +92,24 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_api_error_unauthorized_status() {
+        let resp = ApiError::Unauthorized.into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn test_api_error_bad_request_status() {
+        let resp = ApiError::BadRequest("nope".into()).into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_api_error_conflict_status() {
+        let resp = ApiError::Conflict("dup".into()).into_response();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
 
     #[test]
     fn test_api_error_missing_header() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,8 +197,10 @@ fn run_render_command(
     // Load config and initialize services
     let config = Arc::new(AppConfig::load_from_assets(&asset_loader)?);
     let renderer = Arc::new(RenderService::new(&asset_loader)?);
+    let shared: byonk::server::SharedConfig =
+        std::sync::Arc::new(arc_swap::ArcSwap::from(config.clone()));
     let content_pipeline = Arc::new(
-        ContentPipeline::new(config.clone(), asset_loader, renderer.clone())
+        ContentPipeline::new(shared, asset_loader, renderer.clone())
             .expect("Failed to initialize content pipeline"),
     );
 

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -175,6 +175,10 @@ pub struct AppConfig {
     /// Note: /api/display always accepts both methods regardless of this setting
     #[serde(default = "default_auth_mode")]
     pub auth_mode: String,
+
+    /// Admin/management API settings
+    #[serde(default)]
+    pub admin: AdminConfig,
 }
 
 /// Panel profile with official and measured display colors
@@ -249,6 +253,15 @@ pub struct DeviceConfig {
 
     /// Optional dither strength override (0.0 = no diffusion, 1.0 = standard)
     pub strength: Option<f32>,
+}
+
+/// Admin/management API settings.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct AdminConfig {
+    /// Bearer token gating `/api/admin/*`. If unset (and `BYONK_ADMIN_TOKEN` is
+    /// unset), the admin API is disabled (returns 404).
+    #[serde(default)]
+    pub token: Option<String>,
 }
 
 /// Device registration settings
@@ -455,6 +468,7 @@ impl Default for AppConfig {
             default_screen: Some("default".to_string()),
             registration: RegistrationConfig::default(),
             auth_mode: default_auth_mode(),
+            admin: AdminConfig::default(),
         }
     }
 }
@@ -462,6 +476,16 @@ impl Default for AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_admin_token_parses_and_defaults() {
+        let yaml = "admin:\n  token: secret123\nscreens: {}\n";
+        let cfg: AppConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.admin.token.as_deref(), Some("secret123"));
+
+        let cfg2: AppConfig = serde_yaml::from_str("screens: {}\n").unwrap();
+        assert_eq!(cfg2.admin.token, None);
+    }
 
     #[test]
     fn test_default_config() {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -10,6 +10,6 @@ pub use config::{
 pub use device::{verify_ed25519_signature, ApiKey, Device, DeviceId, DeviceModel, Ed25519Error};
 pub use display_spec::DisplaySpec;
 pub use param_schema::{
-    extract_params_block, parse_schema, schema_for_script, EnumOption, ParamField, ParamSchema,
-    ParamType,
+    extract_params_block, parse_schema, schema_for_script, validate_params, EnumOption, ParamField,
+    ParamSchema, ParamType,
 };

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod device;
 pub mod display_spec;
+pub mod param_schema;
 
 pub use config::{
     normalize_algorithm_name, AdminConfig, AppConfig, DeviceConfig, DitherTuningValues,
@@ -8,3 +9,7 @@ pub use config::{
 };
 pub use device::{verify_ed25519_signature, ApiKey, Device, DeviceId, DeviceModel, Ed25519Error};
 pub use display_spec::DisplaySpec;
+pub use param_schema::{
+    extract_params_block, parse_schema, schema_for_script, EnumOption, ParamField, ParamSchema,
+    ParamType,
+};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,8 +3,8 @@ pub mod device;
 pub mod display_spec;
 
 pub use config::{
-    normalize_algorithm_name, AppConfig, DeviceConfig, DitherTuningValues, PanelDitherConfig,
-    RegistrationConfig, ScreenConfig,
+    normalize_algorithm_name, AdminConfig, AppConfig, DeviceConfig, DitherTuningValues,
+    PanelDitherConfig, RegistrationConfig, ScreenConfig,
 };
 pub use device::{verify_ed25519_signature, ApiKey, Device, DeviceId, DeviceModel, Ed25519Error};
 pub use display_spec::DisplaySpec;

--- a/src/models/param_schema.rs
+++ b/src/models/param_schema.rs
@@ -127,7 +127,10 @@ fn parse_options(raw: serde_yaml::Value) -> Result<Vec<EnumOption>, String> {
     let mut out = Vec::new();
     for item in seq {
         if let Some(s) = item.as_str() {
-            out.push(EnumOption { value: s.to_string(), label: s.to_string() });
+            out.push(EnumOption {
+                value: s.to_string(),
+                label: s.to_string(),
+            });
         } else if let Some(map) = item.as_mapping() {
             let value = map
                 .get(serde_yaml::Value::from("value"))
@@ -162,8 +165,8 @@ pub fn parse_schema(yaml: &str) -> Result<ParamSchema, String> {
             .as_str()
             .ok_or_else(|| "param keys must be strings".to_string())?
             .to_string();
-        let raw: RawField = serde_yaml::from_value(v)
-            .map_err(|e| format!("param `{name}`: {e}"))?;
+        let raw: RawField =
+            serde_yaml::from_value(v).map_err(|e| format!("param `{name}`: {e}"))?;
 
         let options = match raw.options {
             Some(o) => parse_options(o)?,
@@ -227,7 +230,11 @@ pub fn validate_params(
         }
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors) }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
 }
 
 fn check_value(field: &ParamField, value: &serde_yaml::Value) -> Result<(), String> {
@@ -260,7 +267,9 @@ fn check_value(field: &ParamField, value: &serde_yaml::Value) -> Result<(), Stri
                 .as_str()
                 .ok_or_else(|| format!("param `{name}` must be one of the enum values"))?;
             if !field.options.iter().any(|o| o.value == s) {
-                return Err(format!("param `{name}` value `{s}` is not an allowed option"));
+                return Err(format!(
+                    "param `{name}` value `{s}` is not an allowed option"
+                ));
             }
         }
     }
@@ -354,7 +363,10 @@ mod tests {
     use std::collections::HashMap;
 
     fn params(pairs: &[(&str, serde_yaml::Value)]) -> HashMap<String, serde_yaml::Value> {
-        pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
     }
 
     #[test]

--- a/src/models/param_schema.rs
+++ b/src/models/param_schema.rs
@@ -1,0 +1,274 @@
+//! Per-screen `@params` schema: types, textual extraction from `.lua`, and parsing.
+//!
+//! The schema is declared inside a Lua block comment at the top of a screen script:
+//! ```lua
+//! --[[ @params
+//! station:
+//!   type: string
+//!   required: true
+//! ]]
+//! ```
+//! It is parsed as YAML — never executed.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ParamType {
+    #[default]
+    String,
+    Int,
+    Float,
+    Bool,
+    Enum,
+    Color,
+    Url,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnumOption {
+    pub value: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ParamField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub param_type: ParamType,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<EnumOption>,
+    #[serde(default)]
+    pub sensitive: bool,
+    #[serde(default)]
+    pub multiline: bool,
+    #[serde(default)]
+    pub hidden: bool,
+    #[serde(default)]
+    pub advanced: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+pub struct ParamSchema {
+    pub fields: Vec<ParamField>,
+}
+
+/// Extract the YAML text inside a `--[[ @params ... ]]` block. Returns `None`
+/// if no `@params` marker is present.
+pub fn extract_params_block(lua_source: &str) -> Option<String> {
+    let marker = lua_source.find("@params")?;
+    // Start after the rest of the marker line.
+    let after_marker = &lua_source[marker + "@params".len()..];
+    let body_start = after_marker.find('\n').map(|i| i + 1).unwrap_or(0);
+    let body = &after_marker[body_start..];
+    let end = body.find("]]")?;
+    Some(body[..end].to_string())
+}
+
+/// Raw descriptor as written in YAML (without the `name`, which is the map key).
+#[derive(Deserialize)]
+struct RawField {
+    #[serde(rename = "type")]
+    param_type: ParamType,
+    #[serde(default)]
+    required: bool,
+    #[serde(default)]
+    default: Option<serde_json::Value>,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    min: Option<f64>,
+    #[serde(default)]
+    max: Option<f64>,
+    #[serde(default)]
+    step: Option<f64>,
+    #[serde(default)]
+    unit: Option<String>,
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    options: Option<serde_yaml::Value>,
+    #[serde(default)]
+    sensitive: bool,
+    #[serde(default)]
+    multiline: bool,
+    #[serde(default)]
+    hidden: bool,
+    #[serde(default)]
+    advanced: bool,
+}
+
+fn parse_options(raw: serde_yaml::Value) -> Result<Vec<EnumOption>, String> {
+    let seq = raw
+        .as_sequence()
+        .ok_or_else(|| "enum `options` must be a list".to_string())?;
+    let mut out = Vec::new();
+    for item in seq {
+        if let Some(s) = item.as_str() {
+            out.push(EnumOption { value: s.to_string(), label: s.to_string() });
+        } else if let Some(map) = item.as_mapping() {
+            let value = map
+                .get(serde_yaml::Value::from("value"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "enum option object needs a string `value`".to_string())?
+                .to_string();
+            let label = map
+                .get(serde_yaml::Value::from("label"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| value.clone());
+            out.push(EnumOption { value, label });
+        } else {
+            return Err("enum option must be a scalar or {value,label} map".to_string());
+        }
+    }
+    Ok(out)
+}
+
+/// Parse a `@params` YAML body into a schema. Preserves field order.
+pub fn parse_schema(yaml: &str) -> Result<ParamSchema, String> {
+    // Empty body ⇒ empty schema (screen takes no params).
+    if yaml.trim().is_empty() {
+        return Ok(ParamSchema::default());
+    }
+    let mapping: serde_yaml::Mapping =
+        serde_yaml::from_str(yaml).map_err(|e| format!("invalid @params YAML: {e}"))?;
+
+    let mut fields = Vec::new();
+    for (k, v) in mapping {
+        let name = k
+            .as_str()
+            .ok_or_else(|| "param keys must be strings".to_string())?
+            .to_string();
+        let raw: RawField = serde_yaml::from_value(v)
+            .map_err(|e| format!("param `{name}`: {e}"))?;
+
+        let options = match raw.options {
+            Some(o) => parse_options(o)?,
+            None => Vec::new(),
+        };
+        if raw.param_type == ParamType::Enum && options.is_empty() {
+            return Err(format!("param `{name}`: enum requires non-empty `options`"));
+        }
+
+        fields.push(ParamField {
+            name,
+            param_type: raw.param_type,
+            required: raw.required,
+            default: raw.default,
+            label: raw.label,
+            description: raw.description,
+            min: raw.min,
+            max: raw.max,
+            step: raw.step,
+            unit: raw.unit,
+            mode: raw.mode,
+            options,
+            sensitive: raw.sensitive,
+            multiline: raw.multiline,
+            hidden: raw.hidden,
+            advanced: raw.advanced,
+        });
+    }
+    Ok(ParamSchema { fields })
+}
+
+/// Extract + parse a screen's schema. `Ok(None)` when there is no `@params`
+/// block; `Err` when a block is present but malformed.
+pub fn schema_for_script(lua_source: &str) -> Result<Option<ParamSchema>, String> {
+    match extract_params_block(lua_source) {
+        None => Ok(None),
+        Some(body) => parse_schema(&body).map(Some),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_block_present() {
+        let lua = "--[[ @params\nstation:\n  type: string\n]]\nlocal x = 1\n";
+        let block = extract_params_block(lua).unwrap();
+        assert!(block.contains("station:"));
+        assert!(block.contains("type: string"));
+        assert!(!block.contains("local x"));
+    }
+
+    #[test]
+    fn test_extract_block_absent() {
+        assert!(extract_params_block("local x = 1\n").is_none());
+    }
+
+    #[test]
+    fn test_parse_minimal_field() {
+        let schema = parse_schema("station:\n  type: string\n  required: true\n").unwrap();
+        assert_eq!(schema.fields.len(), 1);
+        let f = &schema.fields[0];
+        assert_eq!(f.name, "station");
+        assert_eq!(f.param_type, ParamType::String);
+        assert!(f.required);
+    }
+
+    #[test]
+    fn test_parse_preserves_order() {
+        let schema = parse_schema("b:\n  type: int\na:\n  type: string\n").unwrap();
+        assert_eq!(schema.fields[0].name, "b");
+        assert_eq!(schema.fields[1].name, "a");
+    }
+
+    #[test]
+    fn test_parse_enum_options_objects_and_bare() {
+        let obj = parse_schema(
+            "k:\n  type: enum\n  options:\n    - {value: a, label: Apple}\n    - {value: b, label: Banana}\n",
+        )
+        .unwrap();
+        assert_eq!(obj.fields[0].options.len(), 2);
+        assert_eq!(obj.fields[0].options[0].label, "Apple");
+
+        let bare = parse_schema("k:\n  type: enum\n  options: [a, b]\n").unwrap();
+        assert_eq!(bare.fields[0].options[0].value, "a");
+        assert_eq!(bare.fields[0].options[0].label, "a"); // label defaults to value
+    }
+
+    #[test]
+    fn test_parse_enum_without_options_is_error() {
+        assert!(parse_schema("k:\n  type: enum\n").is_err());
+    }
+
+    #[test]
+    fn test_parse_unknown_type_is_error() {
+        assert!(parse_schema("k:\n  type: banana\n").is_err());
+    }
+
+    #[test]
+    fn test_schema_for_script_none_when_no_block() {
+        assert!(schema_for_script("local x = 1\n").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_schema_for_script_err_when_malformed() {
+        let lua = "--[[ @params\nk:\n  type: banana\n]]\n";
+        assert!(schema_for_script(lua).is_err());
+    }
+}

--- a/src/models/param_schema.rs
+++ b/src/models/param_schema.rs
@@ -10,6 +10,8 @@
 //! ```
 //! It is parsed as YAML — never executed.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -202,6 +204,83 @@ pub fn schema_for_script(lua_source: &str) -> Result<Option<ParamSchema>, String
     }
 }
 
+/// Validate a params map against a schema. Returns all problems found (not just
+/// the first). Params not described by the schema are allowed (ignored).
+pub fn validate_params(
+    schema: &ParamSchema,
+    params: &HashMap<String, serde_yaml::Value>,
+) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+
+    for field in &schema.fields {
+        match params.get(&field.name) {
+            None => {
+                if field.required {
+                    errors.push(format!("missing required param `{}`", field.name));
+                }
+            }
+            Some(value) => {
+                if let Err(e) = check_value(field, value) {
+                    errors.push(e);
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
+}
+
+fn check_value(field: &ParamField, value: &serde_yaml::Value) -> Result<(), String> {
+    let name = &field.name;
+    match field.param_type {
+        ParamType::String | ParamType::Color | ParamType::Url => {
+            if !value.is_string() {
+                return Err(format!("param `{name}` must be a string"));
+            }
+        }
+        ParamType::Bool => {
+            if !value.is_bool() {
+                return Err(format!("param `{name}` must be a boolean"));
+            }
+        }
+        ParamType::Int => {
+            let n = value
+                .as_i64()
+                .ok_or_else(|| format!("param `{name}` must be an integer"))?;
+            check_range(field, n as f64)?;
+        }
+        ParamType::Float => {
+            let n = value
+                .as_f64()
+                .ok_or_else(|| format!("param `{name}` must be a number"))?;
+            check_range(field, n)?;
+        }
+        ParamType::Enum => {
+            let s = value
+                .as_str()
+                .ok_or_else(|| format!("param `{name}` must be one of the enum values"))?;
+            if !field.options.iter().any(|o| o.value == s) {
+                return Err(format!("param `{name}` value `{s}` is not an allowed option"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_range(field: &ParamField, n: f64) -> Result<(), String> {
+    if let Some(min) = field.min {
+        if n < min {
+            return Err(format!("param `{}` must be >= {min}", field.name));
+        }
+    }
+    if let Some(max) = field.max {
+        if n > max {
+            return Err(format!("param `{}` must be <= {max}", field.name));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,5 +349,45 @@ mod tests {
     fn test_schema_for_script_err_when_malformed() {
         let lua = "--[[ @params\nk:\n  type: banana\n]]\n";
         assert!(schema_for_script(lua).is_err());
+    }
+
+    use std::collections::HashMap;
+
+    fn params(pairs: &[(&str, serde_yaml::Value)]) -> HashMap<String, serde_yaml::Value> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.clone())).collect()
+    }
+
+    #[test]
+    fn test_validate_missing_required() {
+        let schema = parse_schema("station:\n  type: string\n  required: true\n").unwrap();
+        let errs = validate_params(&schema, &params(&[])).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("station")));
+    }
+
+    #[test]
+    fn test_validate_type_mismatch() {
+        let schema = parse_schema("limit:\n  type: int\n").unwrap();
+        let errs = validate_params(&schema, &params(&[("limit", "abc".into())])).unwrap_err();
+        assert!(errs.iter().any(|e| e.contains("limit")));
+    }
+
+    #[test]
+    fn test_validate_min_max() {
+        let schema = parse_schema("limit:\n  type: int\n  min: 1\n  max: 30\n").unwrap();
+        assert!(validate_params(&schema, &params(&[("limit", 50i64.into())])).is_err());
+        assert!(validate_params(&schema, &params(&[("limit", 8i64.into())])).is_ok());
+    }
+
+    #[test]
+    fn test_validate_enum_membership() {
+        let schema = parse_schema("k:\n  type: enum\n  options: [a, b]\n").unwrap();
+        assert!(validate_params(&schema, &params(&[("k", "c".into())])).is_err());
+        assert!(validate_params(&schema, &params(&[("k", "a".into())])).is_ok());
+    }
+
+    #[test]
+    fn test_validate_ok_when_optional_absent() {
+        let schema = parse_schema("station:\n  type: string\n").unwrap();
+        assert!(validate_params(&schema, &params(&[])).is_ok());
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -155,6 +155,8 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/time/", get(api::handle_time))
         // Health check
         .route("/health", get(|| async { "OK" }))
+        // Admin API
+        .nest("/api/admin", crate::api::admin::admin_router())
         // Add state and tracing with request IDs
         .with_state(state)
         .layer(TraceLayer::new_for_http().make_span_with(RequestIdSpan))

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,6 +3,7 @@
 //! This module provides the router and application state used by both
 //! the production server and integration tests.
 
+use arc_swap::ArcSwap;
 use axum::{
     http::{header::CONNECTION, Request},
     routing::{get, post},
@@ -57,10 +58,17 @@ impl<B> MakeSpan<B> for RequestIdSpan {
     }
 }
 
+/// Hot-swappable application config shared by the server and the content pipeline.
+pub type SharedConfig = std::sync::Arc<ArcSwap<AppConfig>>;
+
 /// Application state shared across all handlers.
 #[derive(Clone)]
 pub struct AppState {
-    pub config: Arc<AppConfig>,
+    pub config: SharedConfig,
+    pub asset_loader: Arc<AssetLoader>,
+    pub admin_token: Option<String>,
+    /// Serializes admin config writes so concurrent requests can't interleave file patches.
+    pub write_lock: Arc<tokio::sync::Mutex<()>>,
     pub registry: Arc<InMemoryRegistry>,
     pub renderer: Arc<RenderService>,
     pub content_pipeline: Arc<ContentPipeline>,
@@ -70,8 +78,8 @@ pub struct AppState {
 
 /// Create application state from an asset loader.
 pub fn create_app_state(asset_loader: Arc<AssetLoader>) -> anyhow::Result<AppState> {
-    let config = Arc::new(AppConfig::load_from_assets(&asset_loader)?);
-    create_app_state_with_config(asset_loader, config)
+    let config = AppConfig::load_from_assets(&asset_loader)?;
+    create_app_state_with_config(asset_loader, Arc::new(config))
 }
 
 /// Create application state with a custom config.
@@ -88,22 +96,43 @@ pub fn create_app_state_with_overrides(
     config: Arc<AppConfig>,
     dev_overrides: DevOverrides,
 ) -> anyhow::Result<AppState> {
+    let admin_token = std::env::var("BYONK_ADMIN_TOKEN")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| config.admin.token.clone());
+
+    let shared_config: SharedConfig = Arc::new(ArcSwap::from(config));
+
     let registry = Arc::new(InMemoryRegistry::new());
     let renderer = Arc::new(RenderService::new(&asset_loader)?);
     let content_pipeline = Arc::new(
-        ContentPipeline::new(config.clone(), asset_loader, renderer.clone())
-            .map_err(|e| anyhow::anyhow!("Failed to create content pipeline: {e}"))?,
+        ContentPipeline::new(
+            shared_config.clone(),
+            asset_loader.clone(),
+            renderer.clone(),
+        )
+        .map_err(|e| anyhow::anyhow!("Failed to create content pipeline: {e}"))?,
     );
     let content_cache = Arc::new(ContentCache::new());
 
     Ok(AppState {
-        config,
+        config: shared_config,
+        asset_loader,
+        admin_token,
+        write_lock: Arc::new(tokio::sync::Mutex::new(())),
         registry,
         renderer,
         content_pipeline,
         content_cache,
         dev_overrides,
     })
+}
+
+/// Reparse the config file via the asset loader and atomically swap it in.
+pub fn reload_config(state: &AppState) -> anyhow::Result<()> {
+    let fresh = AppConfig::load_from_assets(&state.asset_loader)?;
+    state.config.store(Arc::new(fresh));
+    Ok(())
 }
 
 /// Build the API router with all endpoints and middleware.
@@ -145,7 +174,7 @@ async fn handle_setup(
     headers: axum::http::HeaderMap,
 ) -> Result<impl axum::response::IntoResponse, ApiError> {
     api::handle_setup(
-        axum::extract::State(state.config),
+        axum::extract::State(state.config.load_full()),
         axum::extract::State(state.registry),
         headers,
     )
@@ -157,7 +186,7 @@ async fn handle_display(
     headers: axum::http::HeaderMap,
 ) -> Result<axum::response::Response, ApiError> {
     api::handle_display(
-        axum::extract::State(state.config),
+        axum::extract::State(state.config.load_full()),
         axum::extract::State(state.registry),
         axum::extract::State(state.content_pipeline),
         axum::extract::State(state.content_cache),
@@ -179,4 +208,25 @@ async fn handle_image(
         path,
     )
     .await
+}
+
+#[cfg(test)]
+mod reload_tests {
+    use super::*;
+
+    #[test]
+    fn test_config_swap_is_visible() {
+        let loader = Arc::new(AssetLoader::new(None, None, None));
+        let state = create_app_state(loader).unwrap();
+        assert!(state.config.load().screens.contains_key("default"));
+
+        // Swap in a config with a sentinel screen and confirm the snapshot updates.
+        let mut cfg = (**state.config.load()).clone();
+        cfg.default_screen = Some("sentinel".to_string());
+        state.config.store(Arc::new(cfg));
+        assert_eq!(
+            state.config.load().default_screen.as_deref(),
+            Some("sentinel")
+        );
+    }
 }

--- a/src/services/config_writer.rs
+++ b/src/services/config_writer.rs
@@ -270,6 +270,13 @@ devices:
             serde_yaml::Value::from("hello")
         );
         assert!(out.contains("# top comment"));
+        // Trailing top-level comment must survive AND stay after the device
+        // content (not relocated into the middle of the devices map).
+        assert!(out.contains("# trailing comment"));
+        assert!(
+            out.find("# trailing comment").unwrap() > out.rfind("screen:").unwrap(),
+            "trailing comment was relocated above device content:\n{out}"
+        );
     }
 
     #[test]
@@ -283,6 +290,13 @@ devices:
             serde_yaml::Value::from("graytest")
         );
         assert!(out.contains("# top comment"));
+        // Trailing top-level comment must survive AND stay after the device
+        // content (not relocated into the middle of the devices map).
+        assert!(out.contains("# trailing comment"));
+        assert!(
+            out.find("# trailing comment").unwrap() > out.rfind("screen:").unwrap(),
+            "trailing comment was relocated above device content:\n{out}"
+        );
     }
 
     #[test]

--- a/src/services/config_writer.rs
+++ b/src/services/config_writer.rs
@@ -1,0 +1,322 @@
+//! Comment-preserving edits to `config.yaml`, built on `yamlpath`/`yamlpatch`.
+//!
+//! Strategy (avoids yamlpatch's weak spots on sequences/flow lists):
+//! - global scalar settings → in-place scalar replace
+//! - device add/edit/remove → remove the device subtree + append a freshly
+//!   block-serialized subtree (device blocks are machine-managed, so no user
+//!   comments live inside them).
+
+use yamlpatch::{apply_yaml_patches, Op, Patch};
+use yamlpath::Document;
+
+/// Errors produced when rewriting `config.yaml`.
+#[derive(Debug)]
+pub enum ConfigWriteError {
+    /// The requested device/key was not present in the document.
+    NotFound(String),
+    /// The underlying patch / parse operation failed.
+    Patch(String),
+}
+
+impl std::fmt::Display for ConfigWriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigWriteError::NotFound(s) => write!(f, "not found: {s}"),
+            ConfigWriteError::Patch(s) => write!(f, "patch failed: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigWriteError {}
+
+/// Build a `yaml_serde::Value` (the value type `yamlpatch` operates on) from a
+/// `serde_yaml::Value` by round-tripping through a YAML string. This keeps us
+/// decoupled from the exact in-memory representation of either crate.
+fn to_patch_value(value: &serde_yaml::Value) -> Result<yaml_serde::Value, ConfigWriteError> {
+    let s = serde_yaml::to_string(value).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    yaml_serde::from_str(&s).map_err(|e| ConfigWriteError::Patch(e.to_string()))
+}
+
+fn document(yaml: &str) -> Result<Document, ConfigWriteError> {
+    Document::new(yaml).map_err(|e| ConfigWriteError::Patch(e.to_string()))
+}
+
+fn render(doc: Document) -> String {
+    doc.source().to_string()
+}
+
+/// Replace a scalar value at `path` (e.g. `["registration","enabled"]`),
+/// preserving all surrounding comments and formatting.
+pub fn set_scalar(
+    yaml: &str,
+    path: &[&str],
+    value: serde_yaml::Value,
+) -> Result<String, ConfigWriteError> {
+    let doc = document(yaml)?;
+
+    let mut route = yamlpath::Route::default();
+    for key in path {
+        route = route.with_key(*key);
+    }
+
+    let patch = Patch {
+        route,
+        operation: Op::Replace(to_patch_value(&value)?),
+    };
+
+    let new_doc =
+        apply_yaml_patches(&doc, &[patch]).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    Ok(render(new_doc))
+}
+
+/// Byte offset just past the next `\n` at or after `from` (or end of string).
+fn next_line_start(s: &str, from: usize) -> usize {
+    match s[from..].find('\n') {
+        Some(i) => from + i + 1,
+        None => s.len(),
+    }
+}
+
+/// Count of leading space characters in `line` (its indentation depth).
+fn indent_of(line: &str) -> usize {
+    line.bytes().take_while(|b| *b == b' ').count()
+}
+
+/// Compute the byte range covering `devices.<key>` *and only* its own block,
+/// starting at the device key line and extending over the deeper-indented body
+/// lines that belong to it.
+///
+/// This is done manually instead of via `yamlpatch::Op::Remove` because
+/// tree-sitter attaches any following less-indented comment (e.g. a trailing
+/// top-level `# comment`) to the last block node, which would make `Op::Remove`
+/// delete that comment too. Scanning by indentation keeps such comments intact.
+fn device_block_range(yaml: &str, key: &str) -> Result<(usize, usize), ConfigWriteError> {
+    let doc = document(yaml)?;
+    let route = yamlpath::Route::default().with_key("devices").with_key(key);
+    let feature = doc
+        .query_pretty(&route)
+        .map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let key_byte = feature.location.byte_span.0;
+
+    // Start of the device key line.
+    let line_start = yaml[..key_byte].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let key_indent = indent_of(&yaml[line_start..]);
+
+    // Walk forward, consuming lines that are more deeply indented than the key.
+    let mut end = next_line_start(yaml, line_start);
+    while end < yaml.len() {
+        let line_end = next_line_start(yaml, end);
+        let line = &yaml[end..line_end];
+        if line.trim().is_empty() || indent_of(line) <= key_indent {
+            break;
+        }
+        end = line_end;
+    }
+
+    Ok((line_start, end))
+}
+
+/// Remove `devices.<key>` entirely. Returns [`ConfigWriteError::NotFound`] if
+/// the device does not exist.
+pub fn remove_device(yaml: &str, key: &str) -> Result<String, ConfigWriteError> {
+    // Confirm presence first for a clean NotFound error.
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(yaml).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let exists = parsed.get("devices").and_then(|d| d.get(key)).is_some();
+    if !exists {
+        return Err(ConfigWriteError::NotFound(format!("device {key}")));
+    }
+
+    let (start, end) = device_block_range(yaml, key)?;
+    let mut out = yaml.to_string();
+    out.replace_range(start..end, "");
+    Ok(out)
+}
+
+/// Add a new device or replace an existing one with `block`.
+///
+/// Editing is implemented as remove-then-add so it is robust against odd
+/// existing layouts (flow lists / sequence params) inside the old block.
+pub fn upsert_device(
+    yaml: &str,
+    key: &str,
+    block: &serde_yaml::Mapping,
+) -> Result<String, ConfigWriteError> {
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(yaml).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let exists = parsed.get("devices").and_then(|d| d.get(key)).is_some();
+
+    // Edit = remove then add (robust against sequence/flow-list params).
+    let base = if exists {
+        remove_device(yaml, key)?
+    } else {
+        yaml.to_string()
+    };
+
+    // If `devices` already holds at least one entry, `yamlpatch`'s block-mapping
+    // addition handles indentation and trailing-comment placement correctly.
+    let base_parsed: serde_yaml::Value =
+        serde_yaml::from_str(&base).map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let devices_nonempty = base_parsed
+        .get("devices")
+        .and_then(|d| d.as_mapping())
+        .map(|m| !m.is_empty())
+        .unwrap_or(false);
+
+    if devices_nonempty {
+        let doc = document(&base)?;
+        let route = yamlpath::Route::default().with_key("devices");
+        let value = to_patch_value(&serde_yaml::Value::Mapping(block.clone()))?;
+        let patch = Patch {
+            route,
+            operation: Op::Add {
+                key: key.to_string(),
+                value,
+            },
+        };
+        let new_doc = apply_yaml_patches(&doc, &[patch])
+            .map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+        Ok(render(new_doc))
+    } else {
+        // `devices:` is empty/null (e.g. after editing the only device).
+        // `yamlpatch` can't add into an empty mapping, so insert the block
+        // manually right after the `devices:` header line, indented two spaces.
+        insert_into_empty_devices(&base, key, block)
+    }
+}
+
+/// Insert a freshly block-serialized device under an empty `devices:` header,
+/// preserving everything else (including trailing comments).
+fn insert_into_empty_devices(
+    base: &str,
+    key: &str,
+    block: &serde_yaml::Mapping,
+) -> Result<String, ConfigWriteError> {
+    let doc = document(base)?;
+    let route = yamlpath::Route::default().with_key("devices");
+    let feature = doc
+        .query_pretty(&route)
+        .map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let header_byte = feature.location.byte_span.0;
+    let header_line_end = next_line_start(base, header_byte);
+
+    // Serialize `{ key: block }` then indent every line by two spaces so the
+    // device key sits one level under `devices:`.
+    let mut outer = serde_yaml::Mapping::new();
+    outer.insert(
+        serde_yaml::Value::from(key),
+        serde_yaml::Value::Mapping(block.clone()),
+    );
+    let serialized = serde_yaml::to_string(&serde_yaml::Value::Mapping(outer))
+        .map_err(|e| ConfigWriteError::Patch(e.to_string()))?;
+    let mut indented = String::new();
+    for line in serialized.lines() {
+        if line.is_empty() {
+            indented.push('\n');
+        } else {
+            indented.push_str("  ");
+            indented.push_str(line);
+            indented.push('\n');
+        }
+    }
+
+    let mut out = base.to_string();
+    out.insert_str(header_line_end, &indented);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+# top comment
+registration:
+  enabled: true   # inline comment
+auth_mode: api_key
+devices:
+  \"AA:BB\":
+    screen: transit
+    params:
+      station: Olten
+# trailing comment
+";
+
+    #[test]
+    fn test_set_scalar_preserves_comments() {
+        let out = set_scalar(SAMPLE, &["registration", "enabled"], false.into()).unwrap();
+        assert!(out.contains("# top comment"));
+        assert!(out.contains("# trailing comment"));
+        assert!(out.contains("enabled: false"));
+    }
+
+    #[test]
+    fn test_remove_device_keeps_other_comments() {
+        let out = remove_device(SAMPLE, "AA:BB").unwrap();
+        assert!(!out.contains("station: Olten"));
+        assert!(out.contains("# top comment"));
+        assert!(out.contains("# trailing comment"));
+    }
+
+    #[test]
+    fn test_upsert_adds_new_device() {
+        let mut block = serde_yaml::Mapping::new();
+        block.insert("screen".into(), "hello".into());
+        let out = upsert_device(SAMPLE, "CC:DD", &block).unwrap();
+        // Re-parse and confirm the new device exists with the right screen.
+        let v: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(
+            v["devices"]["CC:DD"]["screen"],
+            serde_yaml::Value::from("hello")
+        );
+        assert!(out.contains("# top comment"));
+    }
+
+    #[test]
+    fn test_upsert_edits_existing_device() {
+        let mut block = serde_yaml::Mapping::new();
+        block.insert("screen".into(), "graytest".into());
+        let out = upsert_device(SAMPLE, "AA:BB", &block).unwrap();
+        let v: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(
+            v["devices"]["AA:BB"]["screen"],
+            serde_yaml::Value::from("graytest")
+        );
+        assert!(out.contains("# top comment"));
+    }
+
+    #[test]
+    fn test_remove_one_of_several_devices_keeps_siblings_and_comments() {
+        let multi = "\
+# top comment
+devices:
+  \"AA:BB\":
+    screen: transit
+  \"CC:DD\":   # keep me
+    screen: clock
+# trailing comment
+";
+        let out = remove_device(multi, "AA:BB").unwrap();
+        assert!(!out.contains("screen: transit"));
+        assert!(out.contains("\"CC:DD\""));
+        assert!(out.contains("screen: clock"));
+        assert!(out.contains("# keep me"));
+        assert!(out.contains("# top comment"));
+        assert!(out.contains("# trailing comment"));
+        // Still valid YAML with the sibling intact.
+        let v: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert!(v["devices"]["AA:BB"].is_null());
+        assert_eq!(
+            v["devices"]["CC:DD"]["screen"],
+            serde_yaml::Value::from("clock")
+        );
+    }
+
+    #[test]
+    fn test_remove_missing_device_errors() {
+        assert!(matches!(
+            remove_device(SAMPLE, "ZZ:ZZ"),
+            Err(ConfigWriteError::NotFound(_))
+        ));
+    }
+}

--- a/src/services/content_pipeline.rs
+++ b/src/services/content_pipeline.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::assets::AssetLoader;
 use crate::error::RenderError;
-use crate::models::{AppConfig, DisplaySpec, ScreenConfig};
+use crate::models::{DisplaySpec, ScreenConfig};
 use crate::services::{FontFaceInfo, LuaRuntime, RenderService, TemplateService};
 
 /// Result from running a Lua script (before rendering)
@@ -89,7 +89,7 @@ pub enum ContentError {
 
 /// Content pipeline that orchestrates script → template → render
 pub struct ContentPipeline {
-    config: Arc<AppConfig>,
+    config: crate::server::SharedConfig,
     asset_loader: Arc<AssetLoader>,
     lua_runtime: LuaRuntime,
     template_service: TemplateService,
@@ -98,7 +98,7 @@ pub struct ContentPipeline {
 
 impl ContentPipeline {
     pub fn new(
-        config: Arc<AppConfig>,
+        config: crate::server::SharedConfig,
         asset_loader: Arc<AssetLoader>,
         renderer: Arc<RenderService>,
     ) -> Result<Self, ContentError> {
@@ -135,7 +135,8 @@ impl ContentPipeline {
 
     /// Resolve a screen by name from config or filesystem auto-discovery
     fn resolve_screen(&self, screen_name: &str) -> Option<ScreenConfig> {
-        self.config.screens.get(screen_name).cloned().or_else(|| {
+        let config = self.config.load();
+        config.screens.get(screen_name).cloned().or_else(|| {
             let all_files = self.asset_loader.list_screens();
             let lua_file = format!("{}.lua", screen_name);
             let svg_file = format!("{}.svg", screen_name);
@@ -159,11 +160,12 @@ impl ContentPipeline {
         device_ctx: Option<DeviceContext>,
     ) -> Result<ScriptResult, ContentError> {
         // Look up device config - try registration code first, then MAC address
+        let config = self.config.load();
         let device_config = device_ctx
             .as_ref()
             .and_then(|ctx| ctx.registration_code.as_deref())
-            .and_then(|code| self.config.get_device_config_for_code(code))
-            .or_else(|| self.config.get_device_config(device_mac));
+            .and_then(|code| config.get_device_config_for_code(code))
+            .or_else(|| config.get_device_config(device_mac));
 
         if let Some(device_config) = device_config {
             // Found device config — resolve screen from config or filesystem
@@ -179,7 +181,7 @@ impl ContentPipeline {
 
         // Fall back to default screen with empty params
         let screen_config = self
-            .resolve_screen(self.config.default_screen.as_deref().unwrap_or("default"))
+            .resolve_screen(config.default_screen.as_deref().unwrap_or("default"))
             .ok_or_else(|| ContentError::ScreenNotFound(device_mac.to_string()))?;
 
         static EMPTY_DEVICE: std::sync::OnceLock<crate::models::DeviceConfig> =

--- a/src/services/device_registry.rs
+++ b/src/services/device_registry.rs
@@ -77,8 +77,16 @@ mod tests {
     #[tokio::test]
     async fn test_list_all_returns_all_devices() {
         let registry = InMemoryRegistry::new();
-        let d1 = Device::new(DeviceId::new("AA:AA:AA:AA:AA:AA"), DeviceModel::OG, "1".into());
-        let d2 = Device::new(DeviceId::new("BB:BB:BB:BB:BB:BB"), DeviceModel::X, "2".into());
+        let d1 = Device::new(
+            DeviceId::new("AA:AA:AA:AA:AA:AA"),
+            DeviceModel::OG,
+            "1".into(),
+        );
+        let d2 = Device::new(
+            DeviceId::new("BB:BB:BB:BB:BB:BB"),
+            DeviceModel::X,
+            "2".into(),
+        );
         registry.upsert(d1).await.unwrap();
         registry.upsert(d2).await.unwrap();
 

--- a/src/services/device_registry.rs
+++ b/src/services/device_registry.rs
@@ -13,6 +13,9 @@ pub trait DeviceRegistry: Send + Sync {
 
     /// Find device by ID (MAC address)
     async fn find_by_id(&self, device_id: &DeviceId) -> Result<Option<Device>, ApiError>;
+
+    /// List all known devices.
+    async fn list_all(&self) -> Result<Vec<Device>, ApiError>;
 }
 
 /// In-memory device metadata storage
@@ -46,6 +49,11 @@ impl DeviceRegistry for InMemoryRegistry {
         let devices = self.devices.read().await;
         Ok(devices.get(device_id).cloned())
     }
+
+    async fn list_all(&self) -> Result<Vec<Device>, ApiError> {
+        let devices = self.devices.read().await;
+        Ok(devices.values().cloned().collect())
+    }
 }
 
 #[cfg(test)]
@@ -64,6 +72,18 @@ mod tests {
 
         assert!(found.is_some());
         assert_eq!(found.unwrap().device_id, device.device_id);
+    }
+
+    #[tokio::test]
+    async fn test_list_all_returns_all_devices() {
+        let registry = InMemoryRegistry::new();
+        let d1 = Device::new(DeviceId::new("AA:AA:AA:AA:AA:AA"), DeviceModel::OG, "1".into());
+        let d2 = Device::new(DeviceId::new("BB:BB:BB:BB:BB:BB"), DeviceModel::X, "2".into());
+        registry.upsert(d1).await.unwrap();
+        registry.upsert(d2).await.unwrap();
+
+        let all = registry.list_all().await.unwrap();
+        assert_eq!(all.len(), 2);
     }
 
     #[tokio::test]

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod config_writer;
 pub mod content_cache;
 pub mod content_pipeline;
 pub mod device_registry;
@@ -7,6 +8,7 @@ pub mod lua_runtime;
 pub mod renderer;
 pub mod template_service;
 
+pub use config_writer::{remove_device, set_scalar, upsert_device, ConfigWriteError};
 pub use content_cache::{CachedContent, ContentCache};
 pub use content_pipeline::{ContentPipeline, DeviceContext};
 pub use device_registry::{DeviceRegistry, InMemoryRegistry};

--- a/tests/admin_devices_test.rs
+++ b/tests/admin_devices_test.rs
@@ -1,0 +1,48 @@
+//! Tests for GET /api/admin/devices and admin auth.
+
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+#[tokio::test]
+async fn test_admin_disabled_returns_404() {
+    // Default TestApp has no admin token configured.
+    let app = TestApp::new();
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer x")])
+        .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_admin_wrong_token_returns_401() {
+    let app = TestApp::new_admin("secret");
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer nope")])
+        .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_admin_missing_token_returns_401() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get("/api/admin/devices").await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_admin_devices_lists_seen_device() {
+    let app = TestApp::new_admin("secret");
+    // Make a device appear in the registry via the normal setup flow.
+    app.register_device("AA:BB:CC:DD:EE:FF").await;
+
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer secret")])
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let json: serde_json::Value = resp.json();
+    let arr = json.as_array().expect("array");
+    assert!(arr.iter().any(|d| d["mac"] == "AA:BB:CC:DD:EE:FF"));
+}

--- a/tests/admin_read_test.rs
+++ b/tests/admin_read_test.rs
@@ -1,0 +1,38 @@
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
+
+#[tokio::test]
+async fn test_pending_lists_unregistered_seen_device() {
+    let app = TestApp::new_admin("secret");
+    // A freshly-set-up device with no config mapping is "pending".
+    app.register_device("11:22:33:44:55:66").await;
+
+    let resp = app.get_with_headers("/api/admin/pending", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let arr: serde_json::Value = resp.json();
+    let list = arr.as_array().unwrap();
+    assert!(list.iter().any(|d| d["mac"] == "11:22:33:44:55:66"));
+    assert!(list[0]["registration_code"].as_str().unwrap().len() == 10);
+}
+
+#[tokio::test]
+async fn test_config_returns_json_without_token() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get_with_headers("/api/admin/config", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let json: serde_json::Value = resp.json();
+    assert!(json["screens"].is_object());
+    // admin.token must be stripped.
+    assert!(json["admin"]["token"].is_null());
+}
+
+#[tokio::test]
+async fn test_config_requires_auth() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get("/api/admin/config").await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}

--- a/tests/admin_read_test.rs
+++ b/tests/admin_read_test.rs
@@ -20,14 +20,45 @@ async fn test_pending_lists_unregistered_seen_device() {
 }
 
 #[tokio::test]
-async fn test_config_returns_json_without_token() {
+async fn test_pending_requires_auth() {
     let app = TestApp::new_admin("secret");
+    let resp = app.get("/api/admin/pending").await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_pending_excludes_registered_device() {
+    let app = TestApp::new_admin("secret");
+    // "B4:A9:90:8C:6D:18" is present in the embedded config's devices section,
+    // so it counts as registered. Once we trigger the setup flow for that MAC,
+    // it must NOT appear in /api/admin/pending.
+    let registered_mac = "B4:A9:90:8C:6D:18";
+    app.register_device(registered_mac).await;
+
+    let resp = app.get_with_headers("/api/admin/pending", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let arr: serde_json::Value = resp.json();
+    let list = arr.as_array().unwrap();
+    assert!(
+        !list.iter().any(|d| d["mac"] == registered_mac),
+        "registered device should not appear in /api/admin/pending"
+    );
+}
+
+#[tokio::test]
+async fn test_config_returns_json_without_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, _cfg) = TestApp::new_admin_with_file("secret", dir.path());
     let resp = app.get_with_headers("/api/admin/config", &[AUTH]).await;
     assert_eq!(resp.status, StatusCode::OK);
     let json: serde_json::Value = resp.json();
     assert!(json["screens"].is_object());
-    // admin.token must be stripped.
-    assert!(json["admin"]["token"].is_null());
+    // admin section present but token stripped
+    assert!(json["admin"].is_object(), "admin section should be present");
+    assert!(
+        json["admin"]["token"].is_null(),
+        "admin.token must be stripped"
+    );
 }
 
 #[tokio::test]

--- a/tests/admin_screens_test.rs
+++ b/tests/admin_screens_test.rs
@@ -2,6 +2,7 @@ mod common;
 
 use axum::http::StatusCode;
 use common::TestApp;
+use tempfile::tempdir;
 
 const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
 
@@ -24,6 +25,35 @@ async fn test_screens_lists_screens_and_enums() {
         .unwrap()
         .iter()
         .any(|d| d == "atkinson"));
+}
+
+#[tokio::test]
+async fn test_screens_unauthorized() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get("/api/admin/screens").await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_broken_params_returns_schema_error() {
+    let dir = tempdir().expect("tempdir");
+    let app = TestApp::new_admin_with_screens("secret", dir.path());
+
+    let resp = app.get_with_headers("/api/admin/screens", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let json: serde_json::Value = resp.json();
+    let screens = json["screens"].as_array().expect("screens array");
+    let broken = screens
+        .iter()
+        .find(|s| s["name"] == "broken")
+        .expect("broken screen in response");
+
+    assert!(
+        broken["schema_error"].is_string(),
+        "expected schema_error to be a string, got: {:?}",
+        broken["schema_error"]
+    );
 }
 
 #[tokio::test]

--- a/tests/admin_screens_test.rs
+++ b/tests/admin_screens_test.rs
@@ -57,7 +57,6 @@ async fn test_broken_params_returns_schema_error() {
 }
 
 #[tokio::test]
-#[ignore] // un-ignored in Task 12 once transit.lua has @params
 async fn test_transit_has_station_param_after_headers_added() {
     // After Task 12 adds @params headers, transit exposes a `station` param.
     let app = TestApp::new_admin("secret");

--- a/tests/admin_screens_test.rs
+++ b/tests/admin_screens_test.rs
@@ -1,0 +1,44 @@
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
+
+#[tokio::test]
+async fn test_screens_lists_screens_and_enums() {
+    let app = TestApp::new_admin("secret");
+    let resp = app.get_with_headers("/api/admin/screens", &[AUTH]).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let json: serde_json::Value = resp.json();
+
+    let screens = json["screens"].as_array().unwrap();
+    assert!(screens.iter().any(|s| s["name"] == "transit"));
+    assert!(json["panels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|p| p["name"] == "trmnl_og"));
+    assert!(json["dither_algorithms"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|d| d == "atkinson"));
+}
+
+#[tokio::test]
+#[ignore] // un-ignored in Task 12 once transit.lua has @params
+async fn test_transit_has_station_param_after_headers_added() {
+    // After Task 12 adds @params headers, transit exposes a `station` param.
+    let app = TestApp::new_admin("secret");
+    let resp = app.get_with_headers("/api/admin/screens", &[AUTH]).await;
+    let json: serde_json::Value = resp.json();
+    let transit = json["screens"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["name"] == "transit")
+        .unwrap();
+    let params = transit["params"].as_array().unwrap();
+    assert!(params.iter().any(|p| p["name"] == "station"));
+}

--- a/tests/admin_write_test.rs
+++ b/tests/admin_write_test.rs
@@ -64,6 +64,30 @@ async fn test_patch_settings_toggles_registration() {
 }
 
 #[tokio::test]
+async fn test_patch_settings_bogus_auth_mode_returns_400() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, _) = TestApp::new_admin_with_file("secret", dir.path());
+    let resp = app
+        .patch_json("/api/admin/settings", &[AUTH], r#"{"auth_mode":"bogus"}"#)
+        .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_patch_settings_unknown_default_screen_returns_400() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, _) = TestApp::new_admin_with_file("secret", dir.path());
+    let resp = app
+        .patch_json(
+            "/api/admin/settings",
+            &[AUTH],
+            r#"{"default_screen":"does-not-exist"}"#,
+        )
+        .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn test_patch_then_delete_device() {
     let dir = tempfile::tempdir().unwrap();
     let (app, _) = TestApp::new_admin_with_file("secret", dir.path());

--- a/tests/admin_write_test.rs
+++ b/tests/admin_write_test.rs
@@ -1,0 +1,72 @@
+mod common;
+
+use axum::http::StatusCode;
+use common::TestApp;
+
+const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
+
+#[tokio::test]
+async fn test_write_on_embedded_config_returns_409() {
+    let app = TestApp::new_admin("secret"); // embedded-only
+    let body = r#"{"key":"CC:DD:EE:FF:00:11","screen":"hello"}"#;
+    let resp = app.post_json("/api/admin/devices", &[AUTH], body).await;
+    assert_eq!(resp.status, StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_add_device_persists_and_hot_reloads() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, path) = TestApp::new_admin_with_file("secret", dir.path());
+
+    let body = r#"{"key":"CC:DD:EE:FF:00:11","screen":"hello"}"#;
+    let resp = app.post_json("/api/admin/devices", &[AUTH], body).await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    // File updated + comment preserved.
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(on_disk.contains("CC:DD:EE:FF:00:11"));
+
+    // Hot-reload: GET /devices shows it without restart.
+    let listed = app.get_with_headers("/api/admin/devices", &[AUTH]).await;
+    let json: serde_json::Value = listed.json();
+    assert!(json
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|d| d["mac"] == "CC:DD:EE:FF:00:11"));
+}
+
+#[tokio::test]
+async fn test_add_unknown_screen_returns_400() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, _) = TestApp::new_admin_with_file("secret", dir.path());
+    let body = r#"{"key":"CC:DD:EE:FF:00:11","screen":"does-not-exist"}"#;
+    let resp = app.post_json("/api/admin/devices", &[AUTH], body).await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_patch_then_delete_device() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, _) = TestApp::new_admin_with_file("secret", dir.path());
+    app.post_json(
+        "/api/admin/devices",
+        &[AUTH],
+        r#"{"key":"CC:DD","screen":"hello"}"#,
+    )
+    .await;
+
+    let patch = app
+        .patch_json(
+            "/api/admin/devices/CC:DD",
+            &[AUTH],
+            r#"{"screen":"graytest"}"#,
+        )
+        .await;
+    assert_eq!(patch.status, StatusCode::OK);
+
+    let del = app.delete("/api/admin/devices/CC:DD", &[AUTH]).await;
+    assert_eq!(del.status, StatusCode::OK);
+    let del_again = app.delete("/api/admin/devices/CC:DD", &[AUTH]).await;
+    assert_eq!(del_again.status, StatusCode::NOT_FOUND);
+}

--- a/tests/admin_write_test.rs
+++ b/tests/admin_write_test.rs
@@ -46,6 +46,24 @@ async fn test_add_unknown_screen_returns_400() {
 }
 
 #[tokio::test]
+async fn test_patch_settings_toggles_registration() {
+    let dir = tempfile::tempdir().unwrap();
+    let (app, path) = TestApp::new_admin_with_file("secret", dir.path());
+
+    let resp = app
+        .patch_json(
+            "/api/admin/settings",
+            &[AUTH],
+            r#"{"registration_enabled":false}"#,
+        )
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(on_disk.contains("enabled: false"));
+}
+
+#[tokio::test]
 async fn test_patch_then_delete_device() {
     let dir = tempfile::tempdir().unwrap();
     let (app, _) = TestApp::new_admin_with_file("secret", dir.path());

--- a/tests/common/app.rs
+++ b/tests/common/app.rs
@@ -127,6 +127,72 @@ impl TestApp {
         }
     }
 
+    /// Admin app whose config is EMBEDDED only (writes will return 409),
+    /// with the given admin token enabled.
+    pub fn new_admin(token: &str) -> Self {
+        let asset_loader = Arc::new(AssetLoader::new(None, None, None));
+        let mut config = AppConfig::load_from_assets(&asset_loader).expect("load config");
+        config.admin.token = Some(token.to_string());
+        let state =
+            create_app_state_with_config(asset_loader, Arc::new(config)).expect("create state");
+        let registry = state.registry.clone();
+        let content_cache = state.content_cache.clone();
+        let router = build_router(state);
+        Self {
+            router,
+            registry,
+            content_cache,
+        }
+    }
+
+    /// Admin app backed by a real config FILE seeded from the embedded default
+    /// (writes succeed). Returns (app, config_path). `dir` must outlive the app.
+    pub fn new_admin_with_file(token: &str, dir: &std::path::Path) -> (Self, std::path::PathBuf) {
+        let config_path = dir.join("config.yaml");
+        let embedded = AssetLoader::new(None, None, None);
+        let yaml = embedded.read_config_string().expect("read embedded config");
+        std::fs::write(&config_path, format!("admin:\n  token: {token}\n{yaml}"))
+            .expect("write config file");
+
+        let asset_loader = Arc::new(AssetLoader::new(None, None, Some(config_path.clone())));
+        let config = AppConfig::load_from_assets(&asset_loader).expect("load config");
+        let state =
+            create_app_state_with_config(asset_loader, Arc::new(config)).expect("create state");
+        let registry = state.registry.clone();
+        let content_cache = state.content_cache.clone();
+        let router = build_router(state);
+        (
+            Self {
+                router,
+                registry,
+                content_cache,
+            },
+            config_path,
+        )
+    }
+
+    pub async fn patch_json(
+        &self,
+        path: &str,
+        headers: &[(&str, &str)],
+        body: &str,
+    ) -> TestResponse {
+        let mut builder = Request::patch(path).header("Content-Type", "application/json");
+        for (n, v) in headers {
+            builder = builder.header(*n, *v);
+        }
+        self.request(builder.body(Body::from(body.to_string())).unwrap())
+            .await
+    }
+
+    pub async fn delete(&self, path: &str, headers: &[(&str, &str)]) -> TestResponse {
+        let mut builder = Request::delete(path);
+        for (n, v) in headers {
+            builder = builder.header(*n, *v);
+        }
+        self.request(builder.body(Body::empty()).unwrap()).await
+    }
+
     /// Register a device and return the api_key
     pub async fn register_device(&self, mac: &str) -> String {
         let headers = [("ID", mac), ("FW-Version", "1.0.0"), ("Model", "og")];

--- a/tests/common/app.rs
+++ b/tests/common/app.rs
@@ -171,6 +171,48 @@ impl TestApp {
         )
     }
 
+    /// Admin app with a custom screens directory containing a `broken.lua` with an
+    /// invalid `@params` block, wired up via a fresh `config.yaml` on disk.
+    /// Use this to exercise the warn-not-fatal `schema_error` path.
+    /// `dir` must outlive the app.
+    pub fn new_admin_with_screens(token: &str, dir: &std::path::Path) -> Self {
+        // Create screens/ subdirectory with broken.lua and broken.svg
+        let screens_dir = dir.join("screens");
+        std::fs::create_dir_all(&screens_dir).expect("create screens dir");
+
+        std::fs::write(
+            screens_dir.join("broken.lua"),
+            "--[[ @params\nk:\n  type: banana\n]]\n",
+        )
+        .expect("write broken.lua");
+
+        std::fs::write(
+            screens_dir.join("broken.svg"),
+            r#"<svg xmlns="http://www.w3.org/2000/svg"></svg>"#,
+        )
+        .expect("write broken.svg");
+
+        // Write a minimal config.yaml pointing at the broken screen
+        let config_path = dir.join("config.yaml");
+        let yaml = format!(
+            "admin:\n  token: {token}\ndefault_screen: broken\nscreens:\n  broken:\n    script: broken.lua\n    template: broken.svg\n"
+        );
+        std::fs::write(&config_path, yaml).expect("write config.yaml");
+
+        let asset_loader = Arc::new(AssetLoader::new(Some(screens_dir), None, Some(config_path)));
+        let config = AppConfig::load_from_assets(&asset_loader).expect("load config");
+        let state =
+            create_app_state_with_config(asset_loader, Arc::new(config)).expect("create state");
+        let registry = state.registry.clone();
+        let content_cache = state.content_cache.clone();
+        let router = build_router(state);
+        Self {
+            router,
+            registry,
+            content_cache,
+        }
+    }
+
     pub async fn patch_json(
         &self,
         path: &str,

--- a/tests/screen_schemas_test.rs
+++ b/tests/screen_schemas_test.rs
@@ -1,0 +1,55 @@
+//! Every bundled screen's @params block must parse without error, and known
+//! screens expose their documented params.
+
+use byonk::assets::AssetLoader;
+use byonk::models::param_schema::schema_for_script;
+use std::path::Path;
+
+fn schema(script: &str) -> Option<Vec<String>> {
+    let loader = AssetLoader::new(None, None, None);
+    let src = loader.read_screen_string(Path::new(script)).unwrap();
+    schema_for_script(&src)
+        .expect("schema must parse")
+        .map(|s| s.fields.iter().map(|f| f.name.clone()).collect())
+}
+
+#[test]
+fn test_transit_params() {
+    let names = schema("transit.lua").unwrap();
+    assert!(names.contains(&"station".to_string()));
+    assert!(names.contains(&"limit".to_string()));
+}
+
+#[test]
+fn test_gphoto_params() {
+    let names = schema("gphoto.lua").unwrap();
+    assert!(names.contains(&"album_url".to_string()));
+}
+
+#[test]
+fn test_fontdemo_bitmap_is_enum() {
+    let loader = AssetLoader::new(None, None, None);
+    let src = loader
+        .read_screen_string(Path::new("fontdemo-bitmap.lua"))
+        .unwrap();
+    let schema = schema_for_script(&src).unwrap().unwrap();
+    let f = schema
+        .fields
+        .iter()
+        .find(|f| f.name == "font_prefix")
+        .unwrap();
+    assert!(!f.options.is_empty());
+}
+
+#[test]
+fn test_no_param_screens_have_no_schema_or_empty() {
+    for s in ["default.lua", "graytest.lua", "hello.lua", "mandelbrot.lua"] {
+        let loader = AssetLoader::new(None, None, None);
+        let src = loader.read_screen_string(Path::new(s)).unwrap();
+        // Either no block, or a block that parses to zero fields.
+        let parsed = schema_for_script(&src).expect("must parse");
+        if let Some(p) = parsed {
+            assert!(p.fields.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Phase 1 — Byonk admin/management API (foundation for Home Assistant)

First of several phases toward running and managing byonk from Home Assistant. This phase is **byonk-only**: it adds the token-gated admin API the future HA add-on and integration will build on. No HA code yet.

Design & plan:
- Spec: `docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase1-admin-api-design.md`
- Plan: `docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase1-admin-api.md`

### What this adds
- **Token-gated `/api/admin/*` API** (bearer token via `BYONK_ADMIN_TOKEN` env or `admin.token` in config). Invisible (404) when no token is configured; 401 on wrong/missing token.
  - `GET /api/admin/devices` — configured + live-seen devices with telemetry (battery, RSSI, last-seen, model, fw) and resolved active screen.
  - `GET /api/admin/pending` — connected-but-unregistered devices (with registration codes).
  - `GET /api/admin/config` — effective config as JSON (admin token stripped).
  - `GET /api/admin/screens` — screens + per-screen param schemas + panels + dither algorithms.
  - `POST` / `PATCH` / `DELETE /api/admin/devices[/:key]` — create/update/remove device→screen mappings.
  - `PATCH /api/admin/settings` — registration on/off, auth_mode, default_screen.
- **Per-screen `@params` schemas** — declared as a parsed-not-executed `@params` YAML header in each screen's `.lua`; surfaced via `/api/admin/screens` and used to validate writes. Bundled screens (transit, gphoto, floerli, fontdemo-bitmap) now declare theirs.
- **Comment-preserving config writes** — admin writes patch `config.yaml` surgically via `yamlpath`/`yamlpatch`, preserving user comments/formatting.
- **Config hot-reload** — `AppState.config` moved behind `arc-swap`; admin writes take effect with no restart (atomic write + reparse + rollback on failure; writes serialized by a mutex).

### Notes
- Built task-by-task with TDD; each task individually reviewed plus a final whole-branch review (verdict: ready to merge, no Critical/Important findings). Full test suite green; docs build clean.
- This branch was cut from `chore/update-dependencies`, so it also carries that dependency-update commit.
- Non-blocking fast-follows noted in review: convert per-handler `require_admin` into a router middleware layer; reconcile write-path screen validation with filesystem screen auto-discovery; minor `@params` extractor hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
