### PR TITLE
Phase 2: Home Assistant add-on

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New
 
+- **Home Assistant add-on**: run Byonk as a Supervisor add-on (references the
+  prebuilt `ghcr.io/oetiker/byonk` image) with persistent, editable
+  config/screens/fonts and a host port for TRMNL devices. Byonk reads
+  `admin_token` and `log_level` from the add-on options (`/data/options.json`);
+  the admin token stays the single source of truth, dormant until provisioned by
+  the forthcoming Byonk integration. See *Getting Started → Home Assistant Add-on*.
 - **Mandelbrot screen** (`mandelbrot`): Renders a random, aesthetically-pleasing region of the Mandelbrot set on each refresh. Picks from a curated list of well-known locations (Seahorse Valley, Elephant Valley, Mini Mandelbrot, Feigenbaum Point, ...), jitters the centre and zoom, computes escape-time in Lua with smooth iteration count, run-length encodes horizontal pixel runs for compact SVG output, and labels the view with location name, zoom factor, and complex centre coordinates. Builds the escape-time gradient from the panel's own `layout.colors` (sorted by Rec. 709 luminance), so greyscale panels get a black→white ramp and colour panels get a natural through-the-palette ramp (e.g. black→red→yellow→white on a 4-colour TRMNL OG).
 - **reTerminal E1004 panel profile** (`reterminal_e1004`): 1200×1600, 6-color Spectra 6 palette. Added to the bundled `config.yaml`.
 - **Admin/management API** (`/api/admin/*`), gated by a bearer token

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,6 +1,6 @@
 # Handover — Byonk ↔ Home Assistant
 
-_Last updated: 2026-06-28_
+_Last updated: 2026-06-28 (Phase 2 complete, PR #20)_
 
 ## Goal (the whole effort)
 
@@ -62,6 +62,8 @@ Key source: `src/api/admin/{mod,read,write}.rs`, `src/models/param_schema.rs`, `
 
 ## Deferred / fast-follow items (non-blocking, from the final review)
 
+### Phase 1 deferred
+
 1. Convert the per-handler `require_admin` call into a nested-router **middleware layer** so a future admin endpoint can't silently skip auth.
 2. Reconcile write-path screen validation (config-only) with `ContentPipeline::resolve_screen`'s filesystem auto-discovery — or document that admin writes require a configured `screens:` entry.
 3. Minor hardening: `extract_params_block` should require the `@params` marker inside a `--[[ ]]` comment; surface `persist` rollback-write failures; `config_writer` insert assumes 2-space indent and a non-flow `devices:` map.
@@ -75,6 +77,6 @@ Key source: `src/api/admin/{mod,read,write}.rs`, `src/models/param_schema.rs`, `
 
 ## Build / verify
 
-- `make check` — fmt + clippy + tests (all green as of Phase 1).
+- `make check` — fmt + clippy + tests (all green as of Phase 2).
 - `make docs` — mdBook build (clean).
 - `make build` / `make release`.

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -12,16 +12,18 @@ Both live as folders in this repo and talk to a byonk **admin API**. Byonk stays
 
 ### Phase plan (each phase = its own spec → plan → implementation)
 1. **Phase 1 — Byonk admin/management API. ✅ DONE** (see below).
-2. **Phase 2 — HA Add-on** packaging (`homeassistant/` add-on repo structure, prebuilt image, persistent `addon_config`, options, optional Ingress for the `/dev` preview). NEXT.
+2. **Phase 2 — HA Add-on** packaging. ✅ DONE (PR **#20**). Direct prebuilt-image add-on (`repository.yaml` at repo root + `homeassistant/byonk/`), static `environment:` for paths/bind, editable persistent `/config` via `map: addon_config:rw`, host port 3000 for LAN devices. byonk reads `admin_token`+`log_level` from `/data/options.json` (read-only; no token gen/persist/log). No Ingress (out of scope).
 3. **Phase 3 — HA Integration** (`custom_components/byonk/`): config flow, HA Device per TRMNL, sensors, diagnostic entities, select/number/switch/text controls, subentry-based device add/edit, registration onboarding. Consumes the Phase 1 API.
 4. **Phase 4 — Release & docs** (multi-arch publishing aligned to add-on versions, mdBook docs, HACS metadata).
 
 ## Current status
 
-- **Phase 1 is complete and in review:** PR **#19** → https://github.com/oetiker/byonk/pull/19
-  - Branch: `feat/homeassistant-admin-api` (cut from `chore/update-dependencies`, so it also carries that dep-update commit; base of the PR is `main`).
-  - Built task-by-task with TDD; every task individually reviewed + a final whole-branch review (verdict: ready to merge, no Critical/Important). Full suite green; `make docs` clean.
-- Nothing else started yet. Phases 2–4 are not begun.
+- **Phase 1 is merged** into `main` (PR #19, commit `33ed51f`).
+- **Phase 2 is complete and in review:** PR **#20** → https://github.com/oetiker/byonk/pull/20
+  - Branch: `feat/homeassistant-addon` (cut from `main`; base of the PR is `main`).
+  - Built task-by-task with TDD (4 tasks); every task individually reviewed + a final whole-branch review (verdict: ready to merge, no Critical/Important). Full suite green; `make docs` clean.
+  - SDD ledger: `.superpowers/sdd/progress.md` (git-ignored) has per-task commits + deferred Minors.
+- **Phase 3 (HA Integration) is NEXT.** Phase 4 not begun.
 
 ## What Phase 1 delivered (the API Phase 3 will consume)
 
@@ -44,16 +46,18 @@ Key source: `src/api/admin/{mod,read,write}.rs`, `src/models/param_schema.rs`, `
 
 ## Where to pick up next
 
-**Start Phase 2 (HA Add-on).** Run the `brainstorming` skill to produce a Phase 2 spec, then `writing-plans`, then execute (subagent-driven-development). Likely contents:
-- `homeassistant/` add-on repository structure (repository.yaml + one add-on folder with `config.yaml`/`Dockerfile` or `image:` referencing `ghcr.io/oetiker/byonk`).
-- Map a persistent config dir (`addon_config`); set env `CONFIG_FILE`/`SCREENS_DIR`/`FONTS_DIR`/`BIND_ADDR` and `BYONK_ADMIN_TOKEN`.
-- Add-on options: token (auto-generate?), port, log level, run mode (serve vs dev), optional Ingress for `/dev`.
-- TRMNL devices reach byonk directly on the LAN (host port), not via Ingress.
+**Start Phase 3 (HA Integration, `custom_components/byonk/`).** Run `brainstorming` → `writing-plans` → execute (subagent-driven-development). Key contract already established by Phase 2 and **must stay zero-touch / no-redundancy**:
+- **Trust is automatic** — the integration generates the admin token, writes it into the byonk add-on's options via the Supervisor API (`AddonManager.async_set_addon_options` + `async_restart_addon`, the `zwave_js` pattern; needs `after_dependencies: ["hassio"]`, guard with `is_hassio`), then reads it back. The **user never sets or copies a token.** The add-on option is the token's single source of truth; the integration must not cache its own copy.
+- byonk reads `admin_token`/`log_level` from `/data/options.json` (Phase 2); a blank token leaves the admin API dormant (404) until the integration provisions it.
+- The integration manages device→screen mappings and global settings **only** via the Phase 1 admin API — never duplicate settings the add-on/`config.yaml` already own.
+- Likely contents: config flow + Supervisor add-on discovery, HA Device per TRMNL, sensors/diagnostics, select/number/switch/text controls, subentry-based device add/edit, registration onboarding.
 
 ## Reference docs (read these before continuing)
 
 - Phase 1 spec: `docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase1-admin-api-design.md` (also contains the umbrella vision + phase summaries)
 - Phase 1 plan: `docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase1-admin-api.md`
+- **Phase 2 spec:** `docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase2-addon-design.md` (§5 zero-touch trust model — the Phase 3 contract)
+- **Phase 2 plan:** `docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase2-addon.md`
 - SDD progress ledger (git-ignored): `.superpowers/sdd/progress.md` — per-task commit ranges + deferred findings.
 
 ## Deferred / fast-follow items (non-blocking, from the final review)
@@ -62,6 +66,12 @@ Key source: `src/api/admin/{mod,read,write}.rs`, `src/models/param_schema.rs`, `
 2. Reconcile write-path screen validation (config-only) with `ContentPipeline::resolve_screen`'s filesystem auto-discovery — or document that admin writes require a configured `screens:` entry.
 3. Minor hardening: `extract_params_block` should require the `@params` marker inside a `--[[ ]]` comment; surface `persist` rollback-write failures; `config_writer` insert assumes 2-space indent and a non-flow `devices:` map.
 4. Test coverage gaps (all behavior is integration-tested, but some unit gaps): per-screen `@params` parse tests (floerli), more no-param screens, more device-write branch unit tests.
+
+### Phase 2 deferred (non-blocking, from the final review)
+
+1. `AddonOptions` derives `Debug` (plan-mandated) → the token *could* leak via `{:?}` if future code debug-prints it (no current path does). Consider a redacting `Debug` impl.
+2. Integration test `addon_options_test` assumes `BYONK_ADMIN_TOKEN` is unset (same harness-wide assumption as all `new_admin` tests) — could false-fail in a CI env that sets it.
+3. Minor test gaps: no `Malformed`/`Missing`-path integration test (both verified no-op via unit tests); manifest test doesn't assert `init: true`.
 
 ## Build / verify
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 # Getting Started
 
 - [Installation](guide/installation.md)
+- [Home Assistant Add-on](guide/ha-addon.md)
 - [Configuration](guide/configuration.md)
 - [Dev Mode](guide/dev-mode.md)
 

--- a/docs/src/guide/ha-addon.md
+++ b/docs/src/guide/ha-addon.md
@@ -1,0 +1,41 @@
+# Home Assistant Add-on
+
+Byonk can run as a Home Assistant Supervisor add-on. The add-on runs the same
+prebuilt `ghcr.io/oetiker/byonk` image, stores its configuration in a persistent,
+editable folder, and exposes Byonk on a host port so your TRMNL devices can reach
+it directly on your LAN.
+
+> Requires a Supervisor-managed install (Home Assistant OS or Supervised).
+
+## Install
+
+1. **Settings → Add-ons → Add-on Store**.
+2. **⋮ → Repositories**, add `https://github.com/oetiker/byonk`, then close.
+3. Open **Byonk** in the store, **Install**, then **Start**.
+
+## Point your TRMNL device at Byonk
+
+The add-on publishes Byonk on host port **3000**. Set your TRMNL device's server
+to `http://<your-home-assistant-host>:3000`.
+
+## Options
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `admin_token` | *(blank)* | **Leave blank.** Managed automatically by the Byonk integration (a later release). While blank, the management API is disabled — serving screens is unaffected. |
+| `log_level` | `info` | Server log verbosity (`trace`/`debug`/`info`/`warn`/`error`). |
+
+## Configuration, screens, and fonts
+
+The add-on maps an editable, persistent folder to `/config` inside the container,
+holding `config.yaml`, `screens/`, and `fonts/`. Edit these with the **File
+editor** or **Studio Code Server** add-on. Empty folders are seeded with the
+embedded defaults on first start. Edits to `config.yaml` are applied without a
+restart.
+
+## How it relates to the Byonk integration
+
+A companion Home Assistant **integration** (shipping in a later release) manages
+device→screen mappings and global settings from the Home Assistant UI and
+establishes trust with Byonk automatically — you will not need to copy or set any
+token by hand.

--- a/docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase2-addon.md
+++ b/docs/superpowers/plans/2026-06-28-byonk-homeassistant-phase2-addon.md
@@ -1,0 +1,793 @@
+# Byonk HA Add-on (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Package byonk as a Home Assistant Supervisor add-on that runs the prebuilt `ghcr.io/oetiker/byonk` image directly, plus the minimal byonk change to read add-on options from `/data/options.json`.
+
+**Architecture:** A declarative add-on package (`repository.yaml` at repo root + `homeassistant/byonk/`) references the prebuilt multi-arch image, wires byonk's paths/bind via static `environment:`, mounts an editable persistent `/config`, and publishes host port 3000 for LAN TRMNL devices. byonk gains one small read-only module that, at `serve` startup, reads `admin_token` + `log_level` from `/data/options.json` and feeds them into its existing in-memory `AppConfig.admin.token` and tracing filter. byonk never generates or persists a token; a blank token leaves the admin API dormant (404). The Phase 3 integration will provision the token automatically (out of scope here).
+
+**Tech Stack:** Rust (axum, serde, serde_json, serde_yaml, tracing), Home Assistant Supervisor add-on YAML, mdBook docs.
+
+## Global Constraints
+
+- **Single source of truth for the admin token = the add-on option** (`/data/options.json`). byonk only *reads* it; it MUST NOT generate, persist, or log a token. Blank/absent → admin API stays dormant (Phase 1 returns 404).
+- **byonk stays usable outside HA:** if the options file is absent, the reader is a complete no-op; existing Phase 1 behavior (`BYONK_ADMIN_TOKEN` env, then `config.admin.token`) is unchanged. Explicit `BYONK_ADMIN_TOKEN` env always wins over the option (preserved automatically because `server.rs` resolves env before `config.admin.token`).
+- **The options reader is wired into `run_server()` ONLY** — not `dev`, `render`, or `status`.
+- **No global `set_var`:** the reader injects the token into the in-memory `AppConfig.admin.token` (the same mechanism `TestApp::new_admin` uses), not into a process env var.
+- **Image reference, not a wrapper:** `image: ghcr.io/oetiker/byonk` (multi-arch manifest, no `{arch}`). The add-on `version:` MUST equal a published image tag; initial value `0.15.0` (current release). Release automation of the bump is Phase 4.
+- **Add-on options surface is exactly two keys:** `admin_token` (documented "managed by the integration — leave blank") and `log_level`. Do NOT add `registration`/`default_screen` (the Phase 3 integration owns those via the admin API).
+- **No Ingress, no `/dev` exposure, no host_network.** LAN access is via `ports: {3000/tcp: 3000}`.
+- TDD throughout: failing test → run-fail → implement → run-pass → commit. Run `make check` (fmt + clippy + tests) before finishing each code task.
+- Spec: `docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase2-addon-design.md`.
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/addon_options.rs` (create) | Read/parse `/data/options.json`; map `log_level`→tracing filter; apply `admin_token`→`AppConfig.admin.token`. Pure + unit-tested. | 1 |
+| `src/lib.rs` (modify) | Export `pub mod addon_options;` | 1 |
+| `src/main.rs` (modify, `run_server`) | Wire the reader into startup: filter for tracing init, warn on malformed, inject token into config. | 2 |
+| `tests/common/app.rs` (modify) | Add `TestApp::from_config(config)` helper. | 2 |
+| `tests/addon_options_test.rs` (create) | Integration: options token activates admin API; blank keeps it dormant. | 2 |
+| `repository.yaml` (create, repo root) | Add-on repository descriptor. | 3 |
+| `homeassistant/byonk/config.yaml` (create) | Add-on manifest (image, arch, env, ports, map, options, schema). | 3 |
+| `homeassistant/byonk/DOCS.md` (create) | HA "Documentation" tab content. | 3 |
+| `homeassistant/byonk/CHANGELOG.md` (create) | HA "Changelog" tab content. | 3 |
+| `homeassistant/byonk/translations/en.yaml` (create) | Option labels/help text. | 3 |
+| `tests/addon_manifest_test.rs` (create) | Assert the manifest invariants stay consistent with the design. | 3 |
+| `docs/src/guide/ha-addon.md` (create) | User-facing add-on guide. | 4 |
+| `docs/src/SUMMARY.md` (modify) | Wire the new page into the book. | 4 |
+| `CHANGES.md` (modify) | Unreleased changelog entry. | 4 |
+
+---
+
+### Task 1: byonk add-on-options reader module (pure, unit-tested)
+
+**Files:**
+- Create: `src/addon_options.rs`
+- Modify: `src/lib.rs` (add `pub mod addon_options;`)
+- Test: inline `#[cfg(test)]` in `src/addon_options.rs`
+
+**Interfaces:**
+- Consumes: `crate::models::AppConfig` (has `pub admin: AdminConfig` with `pub token: Option<String>`); `crate::assets::AssetLoader` (for the apply test's config fixture).
+- Produces (used by Task 2):
+  - `pub enum ReadResult { Missing, Parsed(AddonOptions), Malformed(String) }`
+  - `pub struct AddonOptions { pub admin_token: Option<String>, pub log_level: Option<String> }`
+  - `pub fn options_path() -> std::path::PathBuf`
+  - `pub fn read_options(path: &std::path::Path) -> ReadResult`
+  - `pub fn log_filter(result: &ReadResult) -> Option<String>`
+  - `pub fn apply_to_config(result: &ReadResult, config: &mut AppConfig)`
+
+- [ ] **Step 1: Add the module export**
+
+In `src/lib.rs`, add the line alphabetically near the other `pub mod` lines (after `pub mod assets;`):
+
+```rust
+pub mod addon_options;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/addon_options.rs` with ONLY the test module first (the impl comes in Step 4). This makes the file compile-fail on missing items, which is the expected failure.
+
+```rust
+//! Reads Home Assistant add-on options from `/data/options.json`.
+//!
+//! When byonk runs as an HA Supervisor add-on, Supervisor writes the Configuration
+//! tab values to `/data/options.json`. This module reads two of them — `admin_token`
+//! and `log_level` — and feeds them into byonk's existing mechanisms (the in-memory
+//! `AppConfig.admin.token` and the tracing filter). It never writes the file, never
+//! generates a token, and never logs one. Outside HA (file absent) it is a no-op.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assets::AssetLoader;
+    use crate::models::AppConfig;
+
+    fn embedded_config() -> AppConfig {
+        let loader = AssetLoader::new(None, None, None);
+        AppConfig::load_from_assets(&loader).expect("load embedded config")
+    }
+
+    #[test]
+    fn missing_file_is_missing() {
+        let result = read_options(std::path::Path::new("/no/such/options.json"));
+        assert!(matches!(result, ReadResult::Missing));
+    }
+
+    #[test]
+    fn valid_json_parses_both_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("options.json");
+        std::fs::write(&path, r#"{"admin_token":"secret","log_level":"info"}"#).unwrap();
+        match read_options(&path) {
+            ReadResult::Parsed(opts) => {
+                assert_eq!(opts.admin_token.as_deref(), Some("secret"));
+                assert_eq!(opts.log_level.as_deref(), Some("info"));
+            }
+            other => panic!("expected Parsed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_keys_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("options.json");
+        std::fs::write(&path, r#"{"port":3000,"log_level":"warn"}"#).unwrap();
+        match read_options(&path) {
+            ReadResult::Parsed(opts) => {
+                assert_eq!(opts.admin_token, None);
+                assert_eq!(opts.log_level.as_deref(), Some("warn"));
+            }
+            other => panic!("expected Parsed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_json_is_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("options.json");
+        std::fs::write(&path, "{ not json").unwrap();
+        assert!(matches!(read_options(&path), ReadResult::Malformed(_)));
+    }
+
+    #[test]
+    fn log_filter_maps_known_level() {
+        let r = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("info".to_string()),
+        });
+        assert_eq!(log_filter(&r).as_deref(), Some("byonk=info,tower_http=info"));
+    }
+
+    #[test]
+    fn log_filter_none_for_unknown_level_or_missing() {
+        let unknown = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("verbose".to_string()),
+        });
+        assert_eq!(log_filter(&unknown), None);
+        assert_eq!(log_filter(&ReadResult::Missing), None);
+    }
+
+    #[test]
+    fn apply_sets_token_when_present() {
+        let r = ReadResult::Parsed(AddonOptions {
+            admin_token: Some("secret".to_string()),
+            log_level: None,
+        });
+        let mut config = embedded_config();
+        config.admin.token = None;
+        apply_to_config(&r, &mut config);
+        assert_eq!(config.admin.token.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn apply_ignores_blank_token_and_missing() {
+        let mut config = embedded_config();
+        config.admin.token = Some("keep".to_string());
+
+        // Blank/whitespace token must not clobber an existing value.
+        let blank = ReadResult::Parsed(AddonOptions {
+            admin_token: Some("   ".to_string()),
+            log_level: None,
+        });
+        apply_to_config(&blank, &mut config);
+        assert_eq!(config.admin.token.as_deref(), Some("keep"));
+
+        // Missing options file leaves config untouched.
+        apply_to_config(&ReadResult::Missing, &mut config);
+        assert_eq!(config.admin.token.as_deref(), Some("keep"));
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test --lib addon_options`
+Expected: FAIL to compile — `cannot find type/function ReadResult / AddonOptions / read_options / log_filter / apply_to_config in this scope`.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+Prepend the implementation above the `#[cfg(test)]` module in `src/addon_options.rs` (keep the module doc-comment at the very top):
+
+```rust
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::models::AppConfig;
+
+/// Subset of the add-on options byonk consumes. Unknown keys are ignored.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AddonOptions {
+    #[serde(default)]
+    pub admin_token: Option<String>,
+    #[serde(default)]
+    pub log_level: Option<String>,
+}
+
+/// Outcome of attempting to read the options file.
+#[derive(Debug)]
+pub enum ReadResult {
+    /// No options file present (normal for non-add-on runs).
+    Missing,
+    /// File present and parsed successfully.
+    Parsed(AddonOptions),
+    /// File present but unreadable or not valid JSON. Carries a human message.
+    Malformed(String),
+}
+
+/// Default in-container path Supervisor writes options to.
+const DEFAULT_OPTIONS_PATH: &str = "/data/options.json";
+
+/// Resolve the options file path. `BYONK_OPTIONS_FILE` overrides the default
+/// (used by tests and as an escape hatch).
+pub fn options_path() -> PathBuf {
+    std::env::var("BYONK_OPTIONS_FILE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_OPTIONS_PATH))
+}
+
+/// Read and parse the options file at `path`. Never panics.
+pub fn read_options(path: &Path) -> ReadResult {
+    match std::fs::read_to_string(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReadResult::Missing,
+        Err(e) => ReadResult::Malformed(format!("cannot read {}: {e}", path.display())),
+        Ok(text) => match serde_json::from_str::<AddonOptions>(&text) {
+            Ok(opts) => ReadResult::Parsed(opts),
+            Err(e) => ReadResult::Malformed(format!("invalid JSON in {}: {e}", path.display())),
+        },
+    }
+}
+
+/// Map a log-level word to byonk's tracing filter string, or `None` if unknown.
+fn level_to_filter(level: &str) -> Option<String> {
+    let l = level.trim().to_ascii_lowercase();
+    match l.as_str() {
+        "trace" | "debug" | "info" | "warn" | "error" => {
+            Some(format!("byonk={l},tower_http={l}"))
+        }
+        _ => None,
+    }
+}
+
+/// Tracing filter implied by the options, if a valid `log_level` is present.
+/// `None` when there is no options file, no `log_level`, or an unknown level.
+pub fn log_filter(result: &ReadResult) -> Option<String> {
+    match result {
+        ReadResult::Parsed(opts) => opts.log_level.as_deref().and_then(level_to_filter),
+        _ => None,
+    }
+}
+
+/// Apply add-on options to the in-memory config. Only a non-empty `admin_token`
+/// has an effect — it sets `config.admin.token`. byonk never persists this.
+pub fn apply_to_config(result: &ReadResult, config: &mut AppConfig) {
+    if let ReadResult::Parsed(opts) = result {
+        if let Some(token) = opts.admin_token.as_deref() {
+            let token = token.trim();
+            if !token.is_empty() {
+                config.admin.token = Some(token.to_string());
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --lib addon_options`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 6: Lint + format**
+
+Run: `make check`
+Expected: fmt clean, clippy clean, full test suite passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/addon_options.rs src/lib.rs
+git commit -m "feat: add HA add-on options reader (parse /data/options.json)"
+```
+
+---
+
+### Task 2: Wire the reader into `run_server` + integration test
+
+**Files:**
+- Modify: `src/main.rs` (the `run_server()` function — the tracing init block and the `create_app_state` call)
+- Modify: `tests/common/app.rs` (add `TestApp::from_config`)
+- Create: `tests/addon_options_test.rs`
+
+**Interfaces:**
+- Consumes: `byonk::addon_options::{options_path, read_options, log_filter, apply_to_config, ReadResult}` (Task 1); `byonk::models::AppConfig`; `byonk::server::{create_app_state_with_config, build_router}`.
+- Produces: `TestApp::from_config(config: AppConfig) -> TestApp` (an admin-capable test app built from an arbitrary config).
+
+- [ ] **Step 1: Add the `TestApp::from_config` helper**
+
+In `tests/common/app.rs`, add this method to the `impl TestApp` block (right after `new_admin`, mirroring its structure). It builds a test app from a caller-supplied config:
+
+```rust
+    /// Build a test app from an arbitrary config (embedded assets, in-memory).
+    pub fn from_config(config: AppConfig) -> Self {
+        let asset_loader = Arc::new(AssetLoader::new(None, None, None));
+        let state = create_app_state_with_config(asset_loader, Arc::new(config))
+            .expect("create state");
+        let registry = state.registry.clone();
+        let content_cache = state.content_cache.clone();
+        let router = build_router(state);
+        Self {
+            router,
+            registry,
+            content_cache,
+        }
+    }
+```
+
+(`AppConfig`, `AssetLoader`, `Arc`, `create_app_state_with_config`, `build_router` are already imported at the top of `app.rs`.)
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `tests/addon_options_test.rs`:
+
+```rust
+//! Integration: HA add-on options.json feeds the admin token into the running server.
+
+mod common;
+
+use axum::http::StatusCode;
+use byonk::addon_options::{apply_to_config, read_options};
+use byonk::assets::AssetLoader;
+use byonk::models::AppConfig;
+use common::TestApp;
+use std::sync::Arc;
+
+/// Build a TestApp as `run_server` would: read an options.json, apply it to the
+/// freshly loaded config, then build the app.
+fn app_with_options(json: &str) -> TestApp {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("options.json");
+    std::fs::write(&path, json).expect("write options");
+    let result = read_options(&path);
+
+    let loader = Arc::new(AssetLoader::new(None, None, None));
+    let mut config = AppConfig::load_from_assets(&loader).expect("load config");
+    apply_to_config(&result, &mut config);
+    TestApp::from_config(config)
+}
+
+#[tokio::test]
+async fn options_token_activates_admin_api() {
+    let app = app_with_options(r#"{"admin_token":"secret","log_level":"info"}"#);
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer secret")])
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn options_token_rejects_wrong_bearer() {
+    let app = app_with_options(r#"{"admin_token":"secret"}"#);
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer nope")])
+        .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn blank_options_token_keeps_admin_dormant() {
+    let app = app_with_options(r#"{"admin_token":"","log_level":"info"}"#);
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer secret")])
+        .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cargo test --test addon_options_test`
+Expected: FAIL to compile — `no function or associated item named from_config` until Step 1 is saved; if Step 1 is already saved, the tests compile and PASS at the library level (they exercise Task 1 + the new helper, not `main.rs`). That is fine — they lock the behavior. Proceed to wire `run_server` so production matches.
+
+- [ ] **Step 4: Wire the reader into `run_server()`**
+
+In `src/main.rs`, inside `run_server()`, replace the tracing-init block:
+
+```rust
+    // Initialize tracing
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "byonk=debug,tower_http=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+```
+
+with:
+
+```rust
+    // Read HA add-on options (no-op outside the add-on). Read before tracing init
+    // so `log_level` can shape the default filter; defer the warning until logging is up.
+    let addon = byonk::addon_options::read_options(&byonk::addon_options::options_path());
+    let default_filter = byonk::addon_options::log_filter(&addon)
+        .unwrap_or_else(|| "byonk=debug,tower_http=debug".to_string());
+
+    // Initialize tracing (RUST_LOG env wins; else add-on log_level; else default)
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| default_filter.into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    if let byonk::addon_options::ReadResult::Malformed(msg) = &addon {
+        tracing::warn!("Ignoring add-on options: {msg}");
+    }
+```
+
+Then, further down in the same function, replace:
+
+```rust
+    // Create application state using shared server module
+    let state = server::create_app_state(asset_loader)?;
+```
+
+with:
+
+```rust
+    // Create application state, injecting the add-on admin token (if any) into config.
+    // Explicit BYONK_ADMIN_TOKEN env still wins (server resolves env before config.admin.token).
+    let mut config = byonk::models::AppConfig::load_from_assets(&asset_loader)?;
+    byonk::addon_options::apply_to_config(&addon, &mut config);
+    let state = server::create_app_state_with_config(asset_loader, std::sync::Arc::new(config))?;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --test addon_options_test`
+Expected: PASS — all three tests green.
+
+- [ ] **Step 6: Lint + format + full suite**
+
+Run: `make check`
+Expected: fmt clean, clippy clean, all tests pass (the existing `tests/admin_*` suites still green — `run_server` is unchanged in behavior when no options file exists).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main.rs tests/common/app.rs tests/addon_options_test.rs
+git commit -m "feat: apply HA add-on options at serve startup"
+```
+
+---
+
+### Task 3: Add-on package + manifest validation test
+
+**Files:**
+- Create: `repository.yaml` (repo root)
+- Create: `homeassistant/byonk/config.yaml`
+- Create: `homeassistant/byonk/DOCS.md`
+- Create: `homeassistant/byonk/CHANGELOG.md`
+- Create: `homeassistant/byonk/translations/en.yaml`
+- Create: `tests/addon_manifest_test.rs`
+
+**Interfaces:**
+- Consumes: nothing from byonk runtime. The manifest test uses `serde_yaml` (already a dependency) and `CARGO_MANIFEST_DIR` to locate files.
+- Produces: the installable add-on package; a test guarding its invariants.
+
+**Note on branding assets:** `icon.png`/`logo.png` are optional for a working add-on (the store shows a default). They are out of scope for this task; the add-on installs and runs without them. Mention them as a follow-up in DOCS if desired.
+
+- [ ] **Step 1: Create `repository.yaml` at the repo root**
+
+```yaml
+name: Byonk Add-ons
+url: https://github.com/oetiker/byonk
+maintainer: Tobias Oetiker <tobi@oetiker.ch>
+```
+
+- [ ] **Step 2: Create `homeassistant/byonk/config.yaml`**
+
+```yaml
+name: Byonk
+version: "0.15.0"
+slug: byonk
+description: Self-hosted content server for TRMNL e-ink devices
+url: https://github.com/oetiker/byonk/tree/main/homeassistant/byonk
+image: ghcr.io/oetiker/byonk
+arch:
+  - amd64
+  - aarch64
+init: true
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: TRMNL device + admin API access (point your device here)
+map:
+  - addon_config:rw
+environment:
+  CONFIG_FILE: /config/config.yaml
+  SCREENS_DIR: /config/screens
+  FONTS_DIR: /config/fonts
+  BIND_ADDR: 0.0.0.0:3000
+options:
+  admin_token: ""
+  log_level: info
+schema:
+  admin_token: "password?"
+  log_level: "list(trace|debug|info|warn|error)"
+```
+
+- [ ] **Step 3: Create `homeassistant/byonk/translations/en.yaml`**
+
+```yaml
+configuration:
+  admin_token:
+    name: Admin token
+    description: >-
+      Managed automatically by the Byonk Home Assistant integration. Leave this
+      blank — you do not need to set it by hand. While empty, the management API
+      stays disabled.
+  log_level:
+    name: Log level
+    description: Verbosity of the Byonk server log.
+```
+
+- [ ] **Step 4: Create `homeassistant/byonk/DOCS.md`**
+
+```markdown
+# Byonk
+
+Self-hosted content server for TRMNL e-ink devices. This add-on runs the prebuilt
+`ghcr.io/oetiker/byonk` image under Home Assistant Supervisor.
+
+## Installation
+
+1. In Home Assistant, go to **Settings → Add-ons → Add-on Store**.
+2. Open the **⋮** menu (top right) → **Repositories**, add
+   `https://github.com/oetiker/byonk`, and close.
+3. Find **Byonk** in the store and click **Install**, then **Start**.
+
+## Pointing your TRMNL device at Byonk
+
+The add-on publishes Byonk on host port **3000**. Configure your TRMNL device to
+use `http://<your-home-assistant-host>:3000` as its server.
+
+## Configuration
+
+- **Admin token** — leave blank. It is managed automatically by the Byonk Home
+  Assistant integration (a later release). While blank, the management API is
+  disabled (this does not affect serving screens to devices).
+- **Log level** — server log verbosity (default `info`).
+
+## Editing screens and config
+
+Your configuration, screens, and fonts live in the add-on's config folder
+(mapped to `/config` inside the add-on). Edit them with the **File editor** or
+**Studio Code Server** add-on. Empty folders are seeded with sensible defaults on
+first start.
+
+Changes to device→screen mappings are best made through the Byonk integration
+once it is available; manual edits to `config.yaml` are also picked up without a
+restart.
+```
+
+- [ ] **Step 5: Create `homeassistant/byonk/CHANGELOG.md`**
+
+```markdown
+# Changelog
+
+## 0.15.0
+
+- Initial Home Assistant add-on for Byonk.
+- Runs the prebuilt `ghcr.io/oetiker/byonk` image.
+- Persistent, editable config/screens/fonts under the add-on config folder.
+- Publishes host port 3000 for TRMNL devices.
+- Reads `admin_token` and `log_level` from the add-on options.
+```
+
+- [ ] **Step 6: Write the failing manifest test**
+
+Create `tests/addon_manifest_test.rs`:
+
+```rust
+//! Validates the HA add-on package manifest stays consistent with the design.
+
+use serde_yaml::Value;
+use std::path::Path;
+
+fn load_yaml(rel: &str) -> Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+#[test]
+fn repository_yaml_has_required_keys() {
+    let repo = load_yaml("repository.yaml");
+    assert!(repo.get("name").and_then(Value::as_str).is_some(), "name");
+    assert!(repo.get("url").and_then(Value::as_str).is_some(), "url");
+}
+
+#[test]
+fn addon_config_matches_design() {
+    let cfg = load_yaml("homeassistant/byonk/config.yaml");
+
+    assert_eq!(cfg["slug"].as_str(), Some("byonk"));
+    assert_eq!(cfg["image"].as_str(), Some("ghcr.io/oetiker/byonk"));
+
+    // version must be a concrete, non-empty image tag
+    assert!(
+        cfg["version"].as_str().map(|v| !v.is_empty()).unwrap_or(false),
+        "version must be a non-empty string"
+    );
+
+    // arch includes amd64 + aarch64
+    let arch: Vec<&str> = cfg["arch"]
+        .as_sequence()
+        .expect("arch seq")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        arch.contains(&"amd64") && arch.contains(&"aarch64"),
+        "arch={arch:?}"
+    );
+
+    // ports maps 3000/tcp -> 3000
+    assert_eq!(cfg["ports"]["3000/tcp"].as_u64(), Some(3000));
+
+    // editable persistent config
+    let map: Vec<&str> = cfg["map"]
+        .as_sequence()
+        .expect("map seq")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(map.contains(&"addon_config:rw"), "map={map:?}");
+
+    // environment wires byonk's paths + bind
+    assert_eq!(cfg["environment"]["CONFIG_FILE"].as_str(), Some("/config/config.yaml"));
+    assert_eq!(cfg["environment"]["SCREENS_DIR"].as_str(), Some("/config/screens"));
+    assert_eq!(cfg["environment"]["FONTS_DIR"].as_str(), Some("/config/fonts"));
+    assert_eq!(cfg["environment"]["BIND_ADDR"].as_str(), Some("0.0.0.0:3000"));
+
+    // exactly the two intended options exist in the schema
+    assert!(cfg["schema"].get("admin_token").is_some(), "schema.admin_token");
+    assert!(cfg["schema"].get("log_level").is_some(), "schema.log_level");
+    assert!(
+        cfg["schema"].get("registration").is_none()
+            && cfg["schema"].get("default_screen").is_none(),
+        "schema must not duplicate integration-owned settings"
+    );
+}
+```
+
+- [ ] **Step 7: Run the test to verify it fails, then passes**
+
+Run: `cargo test --test addon_manifest_test`
+Expected (before Steps 1–2 files exist): FAIL with a `read ...` panic. After Steps 1–5 are saved: PASS.
+
+If you are doing Steps 1–5 before Step 6 (files already exist), run the test and confirm it PASSES; to see the red state, temporarily rename `homeassistant/byonk/config.yaml` and re-run (it should panic on read), then restore it.
+
+- [ ] **Step 8: Lint + format + full suite**
+
+Run: `make check`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add repository.yaml homeassistant/ tests/addon_manifest_test.rs
+git commit -m "feat: add Home Assistant add-on package"
+```
+
+---
+
+### Task 4: User documentation + changelog
+
+**Files:**
+- Create: `docs/src/guide/ha-addon.md`
+- Modify: `docs/src/SUMMARY.md`
+- Modify: `CHANGES.md`
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Create the mdBook page `docs/src/guide/ha-addon.md`**
+
+```markdown
+# Home Assistant Add-on
+
+Byonk can run as a Home Assistant Supervisor add-on. The add-on runs the same
+prebuilt `ghcr.io/oetiker/byonk` image, stores its configuration in a persistent,
+editable folder, and exposes Byonk on a host port so your TRMNL devices can reach
+it directly on your LAN.
+
+> Requires a Supervisor-managed install (Home Assistant OS or Supervised).
+
+## Install
+
+1. **Settings → Add-ons → Add-on Store**.
+2. **⋮ → Repositories**, add `https://github.com/oetiker/byonk`, then close.
+3. Open **Byonk** in the store, **Install**, then **Start**.
+
+## Point your TRMNL device at Byonk
+
+The add-on publishes Byonk on host port **3000**. Set your TRMNL device's server
+to `http://<your-home-assistant-host>:3000`.
+
+## Options
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `admin_token` | *(blank)* | **Leave blank.** Managed automatically by the Byonk integration (a later release). While blank, the management API is disabled — serving screens is unaffected. |
+| `log_level` | `info` | Server log verbosity (`trace`/`debug`/`info`/`warn`/`error`). |
+
+## Configuration, screens, and fonts
+
+The add-on maps an editable, persistent folder to `/config` inside the container,
+holding `config.yaml`, `screens/`, and `fonts/`. Edit these with the **File
+editor** or **Studio Code Server** add-on. Empty folders are seeded with the
+embedded defaults on first start. Edits to `config.yaml` are applied without a
+restart.
+
+## How it relates to the Byonk integration
+
+A companion Home Assistant **integration** (shipping in a later release) manages
+device→screen mappings and global settings from the Home Assistant UI and
+establishes trust with Byonk automatically — you will not need to copy or set any
+token by hand.
+```
+
+- [ ] **Step 2: Wire the page into `docs/src/SUMMARY.md`**
+
+Change the Getting Started list so the new page follows Installation:
+
+```markdown
+# Getting Started
+
+- [Installation](guide/installation.md)
+- [Home Assistant Add-on](guide/ha-addon.md)
+- [Configuration](guide/configuration.md)
+- [Dev Mode](guide/dev-mode.md)
+```
+
+- [ ] **Step 3: Add the changelog entry**
+
+In `CHANGES.md`, under `## Unreleased` → `### New`, add this bullet immediately after the `### New` line:
+
+```markdown
+- **Home Assistant add-on**: run Byonk as a Supervisor add-on (references the
+  prebuilt `ghcr.io/oetiker/byonk` image) with persistent, editable
+  config/screens/fonts and a host port for TRMNL devices. Byonk reads
+  `admin_token` and `log_level` from the add-on options (`/data/options.json`);
+  the admin token stays the single source of truth, dormant until provisioned by
+  the forthcoming Byonk integration. See *Getting Started → Home Assistant Add-on*.
+```
+
+- [ ] **Step 4: Build the docs**
+
+Run: `make docs`
+Expected: mdBook build succeeds with no broken-link or missing-file errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/guide/ha-addon.md docs/src/SUMMARY.md CHANGES.md
+git commit -m "docs: Home Assistant add-on guide + changelog"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `make check` — fmt, clippy, and the full test suite (including `addon_options_test` and `addon_manifest_test`) pass.
+- [ ] Run `make docs` — clean build.
+- [ ] Confirm `git status` is clean and the four task commits are present.
+- [ ] Spot-check the acceptance criteria in the spec §12 against the implementation.
+```

--- a/docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase2-addon-design.md
+++ b/docs/superpowers/specs/2026-06-28-byonk-homeassistant-phase2-addon-design.md
@@ -1,0 +1,351 @@
+# Byonk ↔ Home Assistant — Phase 2: HA Add-on
+
+**Date:** 2026-06-28
+**Status:** Approved (design)
+**Scope of this spec:** Phase 2 only — packaging byonk as a Home Assistant Supervisor
+add-on, plus the minimal byonk change that lets it read add-on options. Phases 3–4 are
+referenced for context but specced separately. Phase 1 (the admin API) is done and is the
+contract this builds on.
+
+---
+
+## 1. Background & where this fits
+
+Byonk is a self-hosted content server for TRMNL e-ink devices: a single static Rust binary
+shipped as a multi-arch Docker image (`ghcr.io/oetiker/byonk`, linux/amd64 + linux/arm64,
+built `FROM scratch`). Phase 1 added a token-gated `/api/admin/*` management API, per-screen
+`@params` schemas, comment-preserving `config.yaml` writes, and config hot-reload.
+
+The umbrella goal is to make byonk **fully manageable from Home Assistant** via two
+deliverables: an **HA Add-on** (this phase) and an **HA Integration** (Phase 3). Phase 2
+packages byonk so a Supervisor-managed HA can run it with persistent config and expose it to
+TRMNL devices on the LAN, and lays the groundwork for the Phase 3 integration to manage it
+with **zero user-entered credentials**.
+
+### Phased plan (each phase = its own spec → plan → build)
+
+1. **Phase 1 — Byonk admin API. ✅ DONE.**
+2. **Phase 2 (this spec) — HA Add-on** packaging + a minimal byonk "add-on options reader".
+3. **Phase 3 — HA Integration** (`custom_components/byonk/`): config flow, HA Device per
+   TRMNL, entities, and the **zero-touch trust provisioning** that consumes this phase.
+4. **Phase 4 — Release & docs**: automate the add-on `version:` bump against published image
+   tags, HACS metadata, docs polish.
+
+---
+
+## 2. Phase 2 goals & non-goals
+
+### Goals
+
+- Ship an installable HA add-on that runs the **prebuilt** `ghcr.io/oetiker/byonk` image
+  directly (no wrapper image to build).
+- Give byonk **persistent, user-editable** config/screens/fonts under the add-on config dir,
+  seeded from embedded defaults on first run.
+- Expose byonk on a **raw host port** so non-HA TRMNL devices reach it directly on the LAN.
+- Let the add-on carry a small set of **options** (`admin_token`, `log_level`) that byonk
+  reads from `/data/options.json`.
+- Establish the design for **zero-touch trust**: the admin token's single source of truth is
+  the add-on option; byonk only reads it; the Phase 3 integration provisions it
+  automatically. The end user never sees or sets a token.
+- Add the **minimal byonk code** to read add-on options. byonk stays fully usable outside HA.
+
+### Non-goals (Phase 2)
+
+- Any Home Assistant **integration** code (`custom_components/`) — Phase 3.
+- Building a wrapper/derived image, or using s6-overlay/bashio (the image is `FROM scratch`).
+- **Ingress** and exposing byonk's `/dev` preview UI (the image `CMD` is `serve`; `image:`
+  add-ons can't override `CMD`; dev mode is out of scope).
+- byonk **generating or persisting** an admin token (it only reads the option). Token
+  generation/provisioning is the integration's job (Phase 3).
+- Surfacing `registration` / `default_screen` as add-on options (the Phase 3 integration owns
+  those via the admin API — keeping a single source of truth).
+- Automating the add-on `version:` bump in the release pipeline — Phase 4.
+- Runtime log-level change without an add-on restart (a restart re-renders `options.json`).
+
+---
+
+## 3. Architecture
+
+```
+TRMNL device ──LAN :3000──▶ [HA host port 3000] ──▶ byonk container (scratch image, CMD serve)
+                                                       ├─ environment: CONFIG_FILE / SCREENS_DIR /
+                                                       │               FONTS_DIR / BIND_ADDR
+                                                       ├─ /config   (map addon_config:rw) =
+                                                       │   config.yaml + screens/ + fonts/  (persistent, editable)
+                                                       └─ /data/options.json (HA-managed) → admin_token, log_level
+
+Phase 3 integration ──Supervisor API──▶ set byonk add-on options(admin_token) + restart
+                     ──HTTP :3000 admin API (Bearer token)──▶ byonk /api/admin/*
+```
+
+Two moving parts:
+
+1. **The add-on package** (`repository.yaml` + `homeassistant/byonk/`) — pure declarative
+   config; references the prebuilt image; wires paths/bind via static `environment:`,
+   persistence via `map:`, LAN access via `ports:`, and the two options.
+2. **The byonk add-on-options reader** — a small module that reads `/data/options.json` at
+   `serve` startup and feeds `admin_token`/`log_level` into byonk's existing mechanisms.
+   Everything else (admin API, token gate, seeding, hot-reload) already exists from Phase 1.
+
+---
+
+## 4. Add-on repository structure
+
+Supervisor requires `repository.yaml` at the **git repo root**, but it searches recursively
+for each add-on's `config.yaml`, so the add-on itself lives under `homeassistant/byonk/`.
+A user adds the repo by URL (`https://github.com/oetiker/byonk`) in
+Settings → Add-ons → Add-on Store → ⋮ → Repositories.
+
+```
+repository.yaml                        # at repo root (Supervisor requirement)
+homeassistant/byonk/
+  config.yaml                          # add-on manifest
+  DOCS.md                              # HA "Documentation" tab
+  CHANGELOG.md                         # HA "Changelog" tab
+  icon.png                             # store icon (square)
+  logo.png                             # store logo (wide)
+  translations/en.yaml                 # option labels + help text
+```
+
+### `repository.yaml` (repo root)
+
+```yaml
+name: Byonk Add-ons
+url: https://github.com/oetiker/byonk
+maintainer: Tobias Oetiker <tobi@oetiker.ch>
+```
+
+### `homeassistant/byonk/config.yaml`
+
+```yaml
+name: Byonk
+version: "<published ghcr image tag>"   # MUST equal a published ghcr.io/oetiker/byonk tag
+slug: byonk
+description: Self-hosted content server for TRMNL e-ink devices
+url: https://github.com/oetiker/byonk/tree/main/homeassistant/byonk
+image: ghcr.io/oetiker/byonk
+arch:
+  - amd64
+  - aarch64
+init: true
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: TRMNL device + admin API access (point your device here)
+map:
+  - addon_config:rw
+environment:
+  CONFIG_FILE: /config/config.yaml
+  SCREENS_DIR: /config/screens
+  FONTS_DIR: /config/fonts
+  BIND_ADDR: 0.0.0.0:3000
+options:
+  admin_token: ""
+  log_level: info
+schema:
+  admin_token: "password?"
+  log_level: "list(trace|debug|info|warn|error)"
+```
+
+Notes:
+
+- **`image:` (no `{arch}`)** — Supervisor pulls `{image}:{version}` and Docker resolves the
+  multi-arch manifest to the host platform. Therefore **`version:` must equal a tag that is
+  already published** to `ghcr.io/oetiker/byonk` (gotcha: `image:` add-ons have no local
+  "rebuild" — publish the image tag *before* bumping `version:`). Keeping these in lockstep
+  is automated in Phase 4; for Phase 2 we set a correct initial value and document the rule.
+- **`init: true`** (default) — Docker's tiny init is PID 1 and reaps/forwards signals; byonk
+  runs as its child. Safe for a no-shell scratch binary.
+- **`environment:`** is static (author-set, not user-tunable) — exactly right for the fixed
+  paths/bind. It is *not* a channel for user options; that is `options`/`schema` →
+  `/data/options.json`.
+- **`map: [addon_config:rw]`** mounts an editable, persistent dir at **`/config`** inside the
+  container, surfaced on the host at `/addon_configs/<repo>_byonk` (reachable via the File
+  editor / Samba / VS Code add-ons). byonk's `CONFIG_FILE`/`SCREENS_DIR`/`FONTS_DIR` point
+  here, and its existing `seed_if_configured()` seeds empty dirs from embedded defaults on
+  first run.
+- **`ports: {3000/tcp: 3000}`** publishes the container port on the host so LAN TRMNL devices
+  reach `http://<ha-host>:3000`. No `host_network`, no Ingress.
+- **`admin_token` option** is declared so the Phase 3 integration can write it via the
+  Supervisor API, but is documented as **integration-managed — leave blank**. Blank →
+  admin API dormant (404), which is the correct state until the integration provisions it.
+  `password?` masks the field and makes it optional.
+
+---
+
+## 5. Zero-touch trust model (single source of truth)
+
+The end user must **never** copy, paste, or set a token to make HA trust byonk. The token has
+exactly **one home — the add-on option** — and flows like this:
+
+1. **byonk reads only.** At `serve` startup byonk reads `admin_token` from
+   `/data/options.json` and feeds it into its existing token resolution. It never generates
+   and never persists a token. With a blank/absent token, `/api/admin/*` returns 404 (Phase 1
+   behavior) — dormant until provisioned.
+2. **The Phase 3 integration provisions automatically** (specced in Phase 3; described here so
+   Phase 2's contract is clear). Running in HA Core, it shares Core's `SUPERVISOR_TOKEN`,
+   which bypasses the Supervisor add-on role gate, so it can — for the byonk add-on slug —
+   `set_addon_options(admin_token=<generated>)` and `restart_addon()` via the `hassio`
+   `AddonManager` (the same pattern the official `zwave_js` integration uses; requires
+   `after_dependencies: ["hassio"]` and a Supervisor install). After the restart byonk
+   re-reads `options.json` and the admin API comes alive.
+3. **No duplicate copies.** The integration reads the token back from the add-on option when
+   it needs to authenticate rather than caching its own; the add-on option remains the sole
+   source of truth. byonk's `config.yaml` does **not** hold an add-on-provisioned token.
+
+Outside Supervisor (bare `docker run`), nothing here applies: byonk keeps its Phase 1
+behavior (`BYONK_ADMIN_TOKEN` env or `config.admin.token`), and the admin token can also be
+set directly in the editable `config.yaml`.
+
+### Why not Ingress (considered, rejected)
+
+Reaching byonk's admin API through the Supervisor Ingress proxy would need no shared secret,
+but it forces byonk to gate admin access **by network interface** (a separate ingress
+listener / ingress path-prefix handling) so the raw LAN port can't reach `/api/admin/*`. That
+is a substantially larger byonk change and discards Phase 1's already-correct uniform token
+gate. Token-via-options reuses Phase 1 unchanged and keeps `/api/admin/*` protected on every
+interface, including the LAN port.
+
+---
+
+## 6. byonk add-on-options reader (the only code change)
+
+A small, well-bounded module — byonk's only Phase 2 change. It must not affect non-add-on
+runs (file absent → complete no-op).
+
+### Module
+
+- New `src/addon_options.rs` exposing:
+  - `struct AddonOptions { admin_token: Option<String>, log_level: Option<String> }`
+    (`serde::Deserialize`, unknown keys ignored, all fields optional).
+  - `fn load() -> Option<AddonOptions>` — reads the options file if present; returns `None`
+    if absent; on read/parse error logs a `warn!` and returns `None` (never fatal).
+  - The path is `/data/options.json`, **overridable via env `BYONK_OPTIONS_FILE`** so tests
+    can point at a temp file.
+
+### Wiring (only in `run_server()`; not `dev`, not `render`, not `status`)
+
+- **Log level** — computed *before* `tracing_subscriber` init. Precedence:
+  explicit `RUST_LOG` env → `log_level` option (rendered as
+  `byonk=<lvl>,tower_http=<lvl>`) → existing built-in default
+  (`byonk=debug,tower_http=debug`). Unknown level strings fall back to the default with a
+  `warn!`.
+- **Admin token** — *before* `create_app_state`. If `admin_token` is present and non-empty
+  **and** `BYONK_ADMIN_TOKEN` env is unset/empty, set the env var to that value so the
+  existing `server.rs` resolution (`env → config.admin.token`) picks it up. Explicit
+  `BYONK_ADMIN_TOKEN` env always wins. Blank/absent → leave admin API dormant. **No token is
+  ever logged** (the user never needs it).
+- `server.rs` and the Phase 1 token gate are **unchanged**.
+
+### Behavior summary
+
+| `options.json` state | Effect on admin API |
+|---|---|
+| absent (non-HA run) | unchanged Phase 1 behavior (env / `config.admin.token`) |
+| present, `admin_token` empty | dormant (404) until provisioned |
+| present, `admin_token` set | admin API active with that token |
+| present, malformed | `warn!`, ignored; server still starts |
+
+---
+
+## 7. Persistence, networking, seeding
+
+- **Persistent + editable config:** `/config` (from `map: addon_config:rw`) holds
+  `config.yaml`, `screens/`, `fonts/`. Survives add-on restarts/updates; editable by the user
+  via the File editor for power-user screen authoring. The admin API and Phase 3 integration
+  write `config.yaml` here (Phase 1's comment-preserving writer + hot-reload).
+- **Seeding:** byonk's existing `seed_if_configured()` populates empty `/config` subdirs from
+  embedded defaults on first start — fresh installs work with zero configuration.
+- **`/data`:** holds HA-managed `options.json` only; byonk reads it, never writes it.
+- **Networking:** raw host port `3000` for non-HA TRMNL clients; no Ingress, no host network.
+  The admin API shares the same port and stays token-gated.
+
+---
+
+## 8. Versioning & updates (Phase 2 scope vs Phase 4)
+
+- The add-on `version:` **is** the Docker tag Supervisor pulls. Bumping it (after the matching
+  image tag is published) makes the Supervisor UI offer an update, which pulls the new tag.
+- **Phase 2** sets a correct initial `version:` matching the current published image and
+  documents the lockstep rule + the "publish image before bump" gotcha.
+- **Phase 4** automates the bump (release workflow updates `homeassistant/byonk/config.yaml`
+  `version:` when a new image tag is published) and adds `breaking_versions:` handling.
+
+---
+
+## 9. Documentation & changelog
+
+- **mdBook:** new page **"Home Assistant Add-on"** under *Getting Started* (alongside
+  Installation), wired into `docs/src/SUMMARY.md`: how to add the repo URL and install; what
+  the add-on does; that **the Phase 3 integration handles trust automatically and the
+  `admin_token` option should be left blank**; pointing TRMNL devices at `http://<ha-host>:3000`;
+  where the editable config lives. A short note that the integration itself ships in Phase 3.
+- **Add-on docs:** `homeassistant/byonk/DOCS.md` (HA Documentation tab) and `CHANGELOG.md`.
+- **CHANGES.md:** Unreleased entries for the add-on package and the byonk add-on-options
+  reader.
+
+---
+
+## 10. Testing (TDD)
+
+Follow the project's TDD discipline; write tests first.
+
+- **Add-on options reader (unit):**
+  - file absent → `load()` returns `None`, no env mutation.
+  - valid file → fields parsed; unknown keys ignored.
+  - admin-token precedence: explicit `BYONK_ADMIN_TOKEN` env wins over the option; option
+    used when env unset; blank option leaves things dormant.
+  - log-level mapping: known levels render the expected filter; unknown level falls back with
+    a warning; `RUST_LOG` env overrides the option.
+  - malformed JSON → `warn!` + `None` (no panic).
+  - (tests drive the file via `BYONK_OPTIONS_FILE`.)
+- **Admin-API integration (reuse Phase 1 axum harness):** with an `options.json` (via
+  `BYONK_OPTIONS_FILE`) carrying a token, `/api/admin/*` is reachable with the matching
+  `Bearer`; with a blank/no token it returns 404.
+- **Add-on manifest (static):** a Rust test parses `repository.yaml` and
+  `homeassistant/byonk/config.yaml` as YAML and asserts the required keys and invariants —
+  `image == ghcr.io/oetiker/byonk`, `arch` ⊇ {amd64, aarch64}, `ports` maps `3000/tcp`,
+  `map` includes `addon_config:rw`, `environment` sets the four expected vars, `schema` has
+  `admin_token` + `log_level`, and `slug == byonk`.
+- **`make check`** (fmt + clippy + tests) clean; **`make docs`** clean.
+
+### Manual acceptance checklist (documented, not automated)
+
+On a real Supervisor install: add the repo URL → install byonk → it starts and serves a
+device on `:3000` over the LAN; with the `admin_token` blank, `/api/admin/*` returns 404;
+setting the option (simulating Phase 3) + restart makes the admin API respond; edits to
+`/config/config.yaml` persist across an add-on restart and an update.
+
+---
+
+## 11. Risks & mitigations
+
+- **Zero-touch depends on Supervisor.** The integration's provisioning only works on
+  HAOS/Supervised installs. *Mitigation:* a Phase-3 concern; Phase 2's add-on is independently
+  usable, and bare-docker users keep the Phase 1 token mechanisms. Documented.
+- **`version:` ↔ image-tag drift.** A bump without a published tag breaks the pull (no local
+  rebuild for `image:` add-ons). *Mitigation:* documented rule now; automated in Phase 4.
+- **Options reader leaking into non-HA runs.** *Mitigation:* absent file → strict no-op; env
+  always overridable; only wired into `serve`.
+- **`addon_config` mount path / repo-hash specifics vary by install type** (`local-` vs repo
+  hash). *Mitigation:* byonk uses the in-container `/config` path (stable); host-side path is
+  only referenced in docs as "via the File editor add-on".
+- **Add-on options API surface is not stability-guaranteed** (`aiohasupervisor` migration).
+  *Mitigation:* a Phase-3 concern (the integration pins/guards against Core versions); Phase 2
+  only reads `options.json`, whose format is stable.
+
+---
+
+## 12. Acceptance criteria (Phase 2 done when…)
+
+1. `repository.yaml` (repo root) + `homeassistant/byonk/` add-on exist and parse; the manifest
+   test passes.
+2. The add-on references `ghcr.io/oetiker/byonk` directly, sets the four `environment:` paths,
+   maps an editable persistent `/config`, publishes host port 3000, and declares the
+   `admin_token` + `log_level` options.
+3. byonk reads `admin_token` + `log_level` from `/data/options.json` at `serve` start, with
+   the precedence and graceful-degradation rules of §6; non-HA runs are unaffected.
+4. A token supplied via `options.json` activates `/api/admin/*`; a blank token leaves it
+   dormant (404) — no token is generated, persisted, or logged by byonk.
+5. `make check` and `make docs` pass; `CHANGES.md`, the mdBook add-on page, and the add-on
+   `DOCS.md`/`CHANGELOG.md` are written.

--- a/homeassistant/byonk/CHANGELOG.md
+++ b/homeassistant/byonk/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.15.0
+
+- Initial Home Assistant add-on for Byonk.
+- Runs the prebuilt `ghcr.io/oetiker/byonk` image.
+- Persistent, editable config/screens/fonts under the add-on config folder.
+- Publishes host port 3000 for TRMNL devices.
+- Reads `admin_token` and `log_level` from the add-on options.

--- a/homeassistant/byonk/DOCS.md
+++ b/homeassistant/byonk/DOCS.md
@@ -1,0 +1,34 @@
+# Byonk
+
+Self-hosted content server for TRMNL e-ink devices. This add-on runs the prebuilt
+`ghcr.io/oetiker/byonk` image under Home Assistant Supervisor.
+
+## Installation
+
+1. In Home Assistant, go to **Settings → Add-ons → Add-on Store**.
+2. Open the **⋮** menu (top right) → **Repositories**, add
+   `https://github.com/oetiker/byonk`, and close.
+3. Find **Byonk** in the store and click **Install**, then **Start**.
+
+## Pointing your TRMNL device at Byonk
+
+The add-on publishes Byonk on host port **3000**. Configure your TRMNL device to
+use `http://<your-home-assistant-host>:3000` as its server.
+
+## Configuration
+
+- **Admin token** — leave blank. It is managed automatically by the Byonk Home
+  Assistant integration (a later release). While blank, the management API is
+  disabled (this does not affect serving screens to devices).
+- **Log level** — server log verbosity (default `info`).
+
+## Editing screens and config
+
+Your configuration, screens, and fonts live in the add-on's config folder
+(mapped to `/config` inside the add-on). Edit them with the **File editor** or
+**Studio Code Server** add-on. Empty folders are seeded with sensible defaults on
+first start.
+
+Changes to device→screen mappings are best made through the Byonk integration
+once it is available; manual edits to `config.yaml` are also picked up without a
+restart.

--- a/homeassistant/byonk/config.yaml
+++ b/homeassistant/byonk/config.yaml
@@ -1,0 +1,27 @@
+name: Byonk
+version: "0.15.0"
+slug: byonk
+description: Self-hosted content server for TRMNL e-ink devices
+url: https://github.com/oetiker/byonk/tree/main/homeassistant/byonk
+image: ghcr.io/oetiker/byonk
+arch:
+  - amd64
+  - aarch64
+init: true
+ports:
+  3000/tcp: 3000
+ports_description:
+  3000/tcp: TRMNL device + admin API access (point your device here)
+map:
+  - addon_config:rw
+environment:
+  CONFIG_FILE: /config/config.yaml
+  SCREENS_DIR: /config/screens
+  FONTS_DIR: /config/fonts
+  BIND_ADDR: 0.0.0.0:3000
+options:
+  admin_token: ""
+  log_level: info
+schema:
+  admin_token: "password?"
+  log_level: "list(trace|debug|info|warn|error)"

--- a/homeassistant/byonk/translations/en.yaml
+++ b/homeassistant/byonk/translations/en.yaml
@@ -1,0 +1,10 @@
+configuration:
+  admin_token:
+    name: Admin token
+    description: >-
+      Managed automatically by the Byonk Home Assistant integration. Leave this
+      blank — you do not need to set it by hand. While empty, the management API
+      stays disabled.
+  log_level:
+    name: Log level
+    description: Verbosity of the Byonk server log.

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: Byonk Add-ons
+url: https://github.com/oetiker/byonk
+maintainer: Tobias Oetiker <tobi@oetiker.ch>

--- a/src/addon_options.rs
+++ b/src/addon_options.rs
@@ -1,0 +1,193 @@
+//! Reads Home Assistant add-on options from `/data/options.json`.
+//!
+//! When byonk runs as an HA Supervisor add-on, Supervisor writes the Configuration
+//! tab values to `/data/options.json`. This module reads two of them — `admin_token`
+//! and `log_level` — and feeds them into byonk's existing mechanisms (the in-memory
+//! `AppConfig.admin.token` and the tracing filter). It never writes the file, never
+//! generates a token, and never logs one. Outside HA (file absent) it is a no-op.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::models::AppConfig;
+
+/// Subset of the add-on options byonk consumes. Unknown keys are ignored.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AddonOptions {
+    #[serde(default)]
+    pub admin_token: Option<String>,
+    #[serde(default)]
+    pub log_level: Option<String>,
+}
+
+/// Outcome of attempting to read the options file.
+#[derive(Debug)]
+pub enum ReadResult {
+    /// No options file present (normal for non-add-on runs).
+    Missing,
+    /// File present and parsed successfully.
+    Parsed(AddonOptions),
+    /// File present but unreadable or not valid JSON. Carries a human message.
+    Malformed(String),
+}
+
+/// Default in-container path Supervisor writes options to.
+const DEFAULT_OPTIONS_PATH: &str = "/data/options.json";
+
+/// Resolve the options file path. `BYONK_OPTIONS_FILE` overrides the default
+/// (used by tests and as an escape hatch).
+pub fn options_path() -> PathBuf {
+    std::env::var("BYONK_OPTIONS_FILE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_OPTIONS_PATH))
+}
+
+/// Read and parse the options file at `path`. Never panics.
+pub fn read_options(path: &Path) -> ReadResult {
+    match std::fs::read_to_string(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => ReadResult::Missing,
+        Err(e) => ReadResult::Malformed(format!("cannot read {}: {e}", path.display())),
+        Ok(text) => match serde_json::from_str::<AddonOptions>(&text) {
+            Ok(opts) => ReadResult::Parsed(opts),
+            Err(e) => ReadResult::Malformed(format!("invalid JSON in {}: {e}", path.display())),
+        },
+    }
+}
+
+/// Map a log-level word to byonk's tracing filter string, or `None` if unknown.
+fn level_to_filter(level: &str) -> Option<String> {
+    let l = level.trim().to_ascii_lowercase();
+    match l.as_str() {
+        "trace" | "debug" | "info" | "warn" | "error" => Some(format!("byonk={l},tower_http={l}")),
+        _ => None,
+    }
+}
+
+/// Tracing filter implied by the options, if a valid `log_level` is present.
+/// `None` when there is no options file, no `log_level`, or an unknown level.
+pub fn log_filter(result: &ReadResult) -> Option<String> {
+    match result {
+        ReadResult::Parsed(opts) => opts.log_level.as_deref().and_then(level_to_filter),
+        _ => None,
+    }
+}
+
+/// Apply add-on options to the in-memory config. Only a non-empty `admin_token`
+/// has an effect — it sets `config.admin.token`. byonk never persists this.
+pub fn apply_to_config(result: &ReadResult, config: &mut AppConfig) {
+    if let ReadResult::Parsed(opts) = result {
+        if let Some(token) = opts.admin_token.as_deref() {
+            let token = token.trim();
+            if !token.is_empty() {
+                config.admin.token = Some(token.to_string());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assets::AssetLoader;
+    use crate::models::AppConfig;
+
+    fn embedded_config() -> AppConfig {
+        let loader = AssetLoader::new(None, None, None);
+        AppConfig::load_from_assets(&loader).expect("load embedded config")
+    }
+
+    #[test]
+    fn missing_file_is_missing() {
+        let result = read_options(std::path::Path::new("/no/such/options.json"));
+        assert!(matches!(result, ReadResult::Missing));
+    }
+
+    #[test]
+    fn valid_json_parses_both_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("options.json");
+        std::fs::write(&path, r#"{"admin_token":"secret","log_level":"info"}"#).unwrap();
+        match read_options(&path) {
+            ReadResult::Parsed(opts) => {
+                assert_eq!(opts.admin_token.as_deref(), Some("secret"));
+                assert_eq!(opts.log_level.as_deref(), Some("info"));
+            }
+            other => panic!("expected Parsed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_keys_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("options.json");
+        std::fs::write(&path, r#"{"port":3000,"log_level":"warn"}"#).unwrap();
+        match read_options(&path) {
+            ReadResult::Parsed(opts) => {
+                assert_eq!(opts.admin_token, None);
+                assert_eq!(opts.log_level.as_deref(), Some("warn"));
+            }
+            other => panic!("expected Parsed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_json_is_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("options.json");
+        std::fs::write(&path, "{ not json").unwrap();
+        assert!(matches!(read_options(&path), ReadResult::Malformed(_)));
+    }
+
+    #[test]
+    fn log_filter_maps_known_level() {
+        let r = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("info".to_string()),
+        });
+        assert_eq!(
+            log_filter(&r).as_deref(),
+            Some("byonk=info,tower_http=info")
+        );
+    }
+
+    #[test]
+    fn log_filter_none_for_unknown_level_or_missing() {
+        let unknown = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("verbose".to_string()),
+        });
+        assert_eq!(log_filter(&unknown), None);
+        assert_eq!(log_filter(&ReadResult::Missing), None);
+    }
+
+    #[test]
+    fn apply_sets_token_when_present() {
+        let r = ReadResult::Parsed(AddonOptions {
+            admin_token: Some("secret".to_string()),
+            log_level: None,
+        });
+        let mut config = embedded_config();
+        config.admin.token = None;
+        apply_to_config(&r, &mut config);
+        assert_eq!(config.admin.token.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn apply_ignores_blank_token_and_missing() {
+        let mut config = embedded_config();
+        config.admin.token = Some("keep".to_string());
+
+        // Blank/whitespace token must not clobber an existing value.
+        let blank = ReadResult::Parsed(AddonOptions {
+            admin_token: Some("   ".to_string()),
+            log_level: None,
+        });
+        apply_to_config(&blank, &mut config);
+        assert_eq!(config.admin.token.as_deref(), Some("keep"));
+
+        // Missing options file leaves config untouched.
+        apply_to_config(&ReadResult::Missing, &mut config);
+        assert_eq!(config.admin.token.as_deref(), Some("keep"));
+    }
+}

--- a/src/addon_options.rs
+++ b/src/addon_options.rs
@@ -73,16 +73,39 @@ pub fn log_filter(result: &ReadResult) -> Option<String> {
     }
 }
 
-/// Apply add-on options to the in-memory config. Only a non-empty `admin_token`
-/// has an effect — it sets `config.admin.token`. byonk never persists this.
-pub fn apply_to_config(result: &ReadResult, config: &mut AppConfig) {
+/// The configured `log_level` string when it is present but not a recognized
+/// level, so the caller can warn before falling back to the default filter.
+/// `None` when the level is absent, blank, valid, or there is no options file.
+pub fn invalid_log_level(result: &ReadResult) -> Option<String> {
     if let ReadResult::Parsed(opts) = result {
-        if let Some(token) = opts.admin_token.as_deref() {
-            let token = token.trim();
-            if !token.is_empty() {
-                config.admin.token = Some(token.to_string());
+        if let Some(level) = opts.log_level.as_deref() {
+            if !level.trim().is_empty() && level_to_filter(level).is_none() {
+                return Some(level.to_string());
             }
         }
+    }
+    None
+}
+
+/// Apply add-on options to the in-memory config.
+///
+/// When an options file was successfully parsed (byonk is running as an HA
+/// add-on), the `admin_token` option is **authoritative**: a non-empty value
+/// sets `config.admin.token`; a blank or absent value **clears** it so the admin
+/// API stays dormant — the add-on option is the single source of truth. An
+/// explicit `BYONK_ADMIN_TOKEN` env var still wins (resolved before
+/// `config.admin.token` in `server.rs`). When there is no options file
+/// (`Missing`) or it could not be parsed (`Malformed`), the config is left
+/// untouched so non-add-on runs keep their Phase 1 behavior. byonk never
+/// persists the token.
+pub fn apply_to_config(result: &ReadResult, config: &mut AppConfig) {
+    if let ReadResult::Parsed(opts) = result {
+        config.admin.token = opts
+            .admin_token
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(str::to_string);
     }
 }
 
@@ -174,20 +197,74 @@ mod tests {
     }
 
     #[test]
-    fn apply_ignores_blank_token_and_missing() {
-        let mut config = embedded_config();
-        config.admin.token = Some("keep".to_string());
-
-        // Blank/whitespace token must not clobber an existing value.
+    fn apply_blank_or_absent_token_clears_existing() {
+        // In add-on mode (Parsed) the option is authoritative: a blank or absent
+        // admin_token must clear any pre-existing config token so the admin API
+        // stays dormant — the add-on option is the single source of truth.
         let blank = ReadResult::Parsed(AddonOptions {
             admin_token: Some("   ".to_string()),
             log_level: None,
         });
+        let mut config = embedded_config();
+        config.admin.token = Some("stale".to_string());
         apply_to_config(&blank, &mut config);
-        assert_eq!(config.admin.token.as_deref(), Some("keep"));
+        assert_eq!(
+            config.admin.token, None,
+            "blank option must clear the token"
+        );
 
-        // Missing options file leaves config untouched.
+        let absent = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("info".to_string()),
+        });
+        let mut config = embedded_config();
+        config.admin.token = Some("stale".to_string());
+        apply_to_config(&absent, &mut config);
+        assert_eq!(
+            config.admin.token, None,
+            "absent option must clear the token"
+        );
+    }
+
+    #[test]
+    fn apply_missing_or_malformed_leaves_token_untouched() {
+        // Non-add-on runs (no options file) and unreadable files must keep the
+        // Phase 1 config token rather than disabling the admin API.
+        let mut config = embedded_config();
+        config.admin.token = Some("keep".to_string());
+
         apply_to_config(&ReadResult::Missing, &mut config);
         assert_eq!(config.admin.token.as_deref(), Some("keep"));
+
+        apply_to_config(&ReadResult::Malformed("bad json".to_string()), &mut config);
+        assert_eq!(config.admin.token.as_deref(), Some("keep"));
+    }
+
+    #[test]
+    fn invalid_log_level_reports_only_present_unknown() {
+        let unknown = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("verbose".to_string()),
+        });
+        assert_eq!(invalid_log_level(&unknown).as_deref(), Some("verbose"));
+
+        let valid = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("info".to_string()),
+        });
+        assert_eq!(invalid_log_level(&valid), None);
+
+        let blank = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: Some("  ".to_string()),
+        });
+        assert_eq!(invalid_log_level(&blank), None);
+
+        let absent = ReadResult::Parsed(AddonOptions {
+            admin_token: None,
+            log_level: None,
+        });
+        assert_eq!(invalid_log_level(&absent), None);
+        assert_eq!(invalid_log_level(&ReadResult::Missing), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! SVG-based content server for TRMNL e-ink devices.
 //! This library exposes modules for integration testing.
 
+pub mod addon_options;
 pub mod api;
 pub mod assets;
 pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -637,6 +637,9 @@ async fn run_server() -> anyhow::Result<()> {
     if let byonk::addon_options::ReadResult::Malformed(msg) = &addon {
         tracing::warn!("Ignoring add-on options: {msg}");
     }
+    if let Some(level) = byonk::addon_options::invalid_log_level(&addon) {
+        tracing::warn!("Ignoring unknown add-on log_level '{level}'; using default");
+    }
 
     // Create asset loader with optional external paths from env vars
     let screens_dir = std::env::var("SCREENS_DIR").ok().map(PathBuf::from);

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,14 +619,24 @@ fn run_status_command() {
 async fn run_server() -> anyhow::Result<()> {
     use byonk::assets::AssetLoader;
 
-    // Initialize tracing
+    // Read HA add-on options (no-op outside the add-on). Read before tracing init
+    // so `log_level` can shape the default filter; defer the warning until logging is up.
+    let addon = byonk::addon_options::read_options(&byonk::addon_options::options_path());
+    let default_filter = byonk::addon_options::log_filter(&addon)
+        .unwrap_or_else(|| "byonk=debug,tower_http=debug".to_string());
+
+    // Initialize tracing (RUST_LOG env wins; else add-on log_level; else default)
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "byonk=debug,tower_http=debug".into()),
+                .unwrap_or_else(|_| default_filter.into()),
         )
         .with(tracing_subscriber::fmt::layer())
         .init();
+
+    if let byonk::addon_options::ReadResult::Malformed(msg) = &addon {
+        tracing::warn!("Ignoring add-on options: {msg}");
+    }
 
     // Create asset loader with optional external paths from env vars
     let screens_dir = std::env::var("SCREENS_DIR").ok().map(PathBuf::from);
@@ -664,8 +674,11 @@ async fn run_server() -> anyhow::Result<()> {
         _ => {}
     }
 
-    // Create application state using shared server module
-    let state = server::create_app_state(asset_loader)?;
+    // Create application state, injecting the add-on admin token (if any) into config.
+    // Explicit BYONK_ADMIN_TOKEN env still wins (server resolves env before config.admin.token).
+    let mut config = byonk::models::AppConfig::load_from_assets(&asset_loader)?;
+    byonk::addon_options::apply_to_config(&addon, &mut config);
+    let state = server::create_app_state_with_config(asset_loader, std::sync::Arc::new(config))?;
 
     // Build router: start with shared API routes, add production-only routes
     let app = server::build_router(state)

--- a/tests/addon_manifest_test.rs
+++ b/tests/addon_manifest_test.rs
@@ -75,15 +75,18 @@ fn addon_config_matches_design() {
         Some("0.0.0.0:3000")
     );
 
-    // exactly the two intended options exist in the schema
-    assert!(
-        cfg["schema"].get("admin_token").is_some(),
-        "schema.admin_token"
-    );
-    assert!(cfg["schema"].get("log_level").is_some(), "schema.log_level");
-    assert!(
-        cfg["schema"].get("registration").is_none()
-            && cfg["schema"].get("default_screen").is_none(),
-        "schema must not duplicate integration-owned settings"
+    // schema exposes EXACTLY the two intended options — nothing the Phase 3
+    // integration owns (registration_enabled, auth_mode, default_screen, ...).
+    let schema_keys: std::collections::BTreeSet<&str> = cfg["schema"]
+        .as_mapping()
+        .expect("schema mapping")
+        .keys()
+        .filter_map(Value::as_str)
+        .collect();
+    let expected: std::collections::BTreeSet<&str> =
+        ["admin_token", "log_level"].into_iter().collect();
+    assert_eq!(
+        schema_keys, expected,
+        "add-on schema must expose exactly admin_token + log_level"
     );
 }

--- a/tests/addon_manifest_test.rs
+++ b/tests/addon_manifest_test.rs
@@ -1,0 +1,89 @@
+//! Validates the HA add-on package manifest stays consistent with the design.
+
+use serde_yaml::Value;
+use std::path::Path;
+
+fn load_yaml(rel: &str) -> Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+#[test]
+fn repository_yaml_has_required_keys() {
+    let repo = load_yaml("repository.yaml");
+    assert!(repo.get("name").and_then(Value::as_str).is_some(), "name");
+    assert!(repo.get("url").and_then(Value::as_str).is_some(), "url");
+}
+
+#[test]
+fn addon_config_matches_design() {
+    let cfg = load_yaml("homeassistant/byonk/config.yaml");
+
+    assert_eq!(cfg["slug"].as_str(), Some("byonk"));
+    assert_eq!(cfg["image"].as_str(), Some("ghcr.io/oetiker/byonk"));
+
+    // version must be a concrete, non-empty image tag
+    assert!(
+        cfg["version"]
+            .as_str()
+            .map(|v| !v.is_empty())
+            .unwrap_or(false),
+        "version must be a non-empty string"
+    );
+
+    // arch includes amd64 + aarch64
+    let arch: Vec<&str> = cfg["arch"]
+        .as_sequence()
+        .expect("arch seq")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        arch.contains(&"amd64") && arch.contains(&"aarch64"),
+        "arch={arch:?}"
+    );
+
+    // ports maps 3000/tcp -> 3000
+    assert_eq!(cfg["ports"]["3000/tcp"].as_u64(), Some(3000));
+
+    // editable persistent config
+    let map: Vec<&str> = cfg["map"]
+        .as_sequence()
+        .expect("map seq")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(map.contains(&"addon_config:rw"), "map={map:?}");
+
+    // environment wires byonk's paths + bind
+    assert_eq!(
+        cfg["environment"]["CONFIG_FILE"].as_str(),
+        Some("/config/config.yaml")
+    );
+    assert_eq!(
+        cfg["environment"]["SCREENS_DIR"].as_str(),
+        Some("/config/screens")
+    );
+    assert_eq!(
+        cfg["environment"]["FONTS_DIR"].as_str(),
+        Some("/config/fonts")
+    );
+    assert_eq!(
+        cfg["environment"]["BIND_ADDR"].as_str(),
+        Some("0.0.0.0:3000")
+    );
+
+    // exactly the two intended options exist in the schema
+    assert!(
+        cfg["schema"].get("admin_token").is_some(),
+        "schema.admin_token"
+    );
+    assert!(cfg["schema"].get("log_level").is_some(), "schema.log_level");
+    assert!(
+        cfg["schema"].get("registration").is_none()
+            && cfg["schema"].get("default_screen").is_none(),
+        "schema must not duplicate integration-owned settings"
+    );
+}

--- a/tests/addon_options_test.rs
+++ b/tests/addon_options_test.rs
@@ -49,3 +49,28 @@ async fn blank_options_token_keeps_admin_dormant() {
         .await;
     assert_eq!(resp.status, StatusCode::NOT_FOUND);
 }
+
+#[tokio::test]
+async fn blank_option_clears_preexisting_config_token() {
+    // A token sitting in config (e.g. a user-edited /config/config.yaml) must NOT
+    // keep the admin API alive when the add-on option is blank — the add-on option
+    // is the single source of truth, so a blank option disables the API.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("options.json");
+    std::fs::write(&path, r#"{"admin_token":""}"#).expect("write options");
+    let result = read_options(&path);
+
+    let loader = Arc::new(AssetLoader::new(None, None, None));
+    let mut config = AppConfig::load_from_assets(&loader).expect("load config");
+    config.admin.token = Some("stale-config-token".to_string());
+    apply_to_config(&result, &mut config);
+
+    let app = TestApp::from_config(config);
+    let resp = app
+        .get_with_headers(
+            "/api/admin/devices",
+            &[("Authorization", "Bearer stale-config-token")],
+        )
+        .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}

--- a/tests/addon_options_test.rs
+++ b/tests/addon_options_test.rs
@@ -1,0 +1,51 @@
+//! Integration: HA add-on options.json feeds the admin token into the running server.
+
+mod common;
+
+use axum::http::StatusCode;
+use byonk::addon_options::{apply_to_config, read_options};
+use byonk::assets::AssetLoader;
+use byonk::models::AppConfig;
+use common::TestApp;
+use std::sync::Arc;
+
+/// Build a TestApp as `run_server` would: read an options.json, apply it to the
+/// freshly loaded config, then build the app.
+fn app_with_options(json: &str) -> TestApp {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("options.json");
+    std::fs::write(&path, json).expect("write options");
+    let result = read_options(&path);
+
+    let loader = Arc::new(AssetLoader::new(None, None, None));
+    let mut config = AppConfig::load_from_assets(&loader).expect("load config");
+    apply_to_config(&result, &mut config);
+    TestApp::from_config(config)
+}
+
+#[tokio::test]
+async fn options_token_activates_admin_api() {
+    let app = app_with_options(r#"{"admin_token":"secret","log_level":"info"}"#);
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer secret")])
+        .await;
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn options_token_rejects_wrong_bearer() {
+    let app = app_with_options(r#"{"admin_token":"secret"}"#);
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer nope")])
+        .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn blank_options_token_keeps_admin_dormant() {
+    let app = app_with_options(r#"{"admin_token":"","log_level":"info"}"#);
+    let resp = app
+        .get_with_headers("/api/admin/devices", &[("Authorization", "Bearer secret")])
+        .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}

--- a/tests/common/app.rs
+++ b/tests/common/app.rs
@@ -145,6 +145,21 @@ impl TestApp {
         }
     }
 
+    /// Build a test app from an arbitrary config (embedded assets, in-memory).
+    pub fn from_config(config: AppConfig) -> Self {
+        let asset_loader = Arc::new(AssetLoader::new(None, None, None));
+        let state =
+            create_app_state_with_config(asset_loader, Arc::new(config)).expect("create state");
+        let registry = state.registry.clone();
+        let content_cache = state.content_cache.clone();
+        let router = build_router(state);
+        Self {
+            router,
+            registry,
+            content_cache,
+        }
+    }
+
     /// Admin app backed by a real config FILE seeded from the embedded default
     /// (writes succeed). Returns (app, config_path). `dir` must outlive the app.
     pub fn new_admin_with_file(token: &str, dir: &std::path::Path) -> (Self, std::path::PathBuf) {


### PR DESCRIPTION
## Summary

Phase 2 of the byonk ↔ Home Assistant effort: package byonk as a Home Assistant **Supervisor add-on** that runs the prebuilt `ghcr.io/oetiker/byonk` image directly, plus a minimal byonk change to read add-on options from `/data/options.json`.

Builds on Phase 1 (admin API, #19). Spec and plan are in `docs/superpowers/`.

## What's in here

- **`src/addon_options.rs`** — small, read-only reader for `/data/options.json` (`admin_token`, `log_level`). Pure + unit-tested. Absent file → complete no-op (byonk stays usable outside HA).
- **`run_server()` wiring** — reads options once at startup: `log_level` shapes the tracing filter (`RUST_LOG` still wins); `admin_token` is injected into the in-memory `AppConfig.admin.token`. No `set_var`, `server.rs` untouched, so an explicit `BYONK_ADMIN_TOKEN` env still takes precedence. Integration-tested through the real admin gate (bearer → 200, wrong → 401, blank → 404).
- **Add-on package** — `repository.yaml` (repo root) + `homeassistant/byonk/` (`config.yaml`, `DOCS.md`, `CHANGELOG.md`, `translations/en.yaml`). `image: ghcr.io/oetiker/byonk`, `arch: [amd64, aarch64]`, static `environment:` for paths/bind, `map: [addon_config:rw]` → editable `/config`, `ports: {3000/tcp: 3000}` for LAN devices. Manifest-validation test guards the invariants.
- **Docs** — new *Getting Started → Home Assistant Add-on* page + changelog.

## Design: zero-touch trust, no redundancy

The admin token has a **single source of truth — the add-on option**. byonk only *reads* it; it never generates, persists, or logs a token. A blank token leaves the admin API dormant (404). The forthcoming Phase 3 integration will provision the token automatically via the Supervisor API (the user never sees or sets a token). Paths/bind come from static `environment:`; device mappings/screens/settings stay in `config.yaml`, managed via the admin API. Nothing is configured in two places.

## Out of scope (later phases)

- No HA **integration** (`custom_components/`) yet — Phase 3.
- No Ingress / `/dev` exposure.
- Add-on `version:` ↔ image-tag release automation — Phase 4.

## Testing

- `make check` — fmt + clippy + full suite green (incl. new `addon_options_test`, `addon_manifest_test`).
- `make docs` — clean mdBook build.

Built task-by-task with TDD; each task individually reviewed plus a final whole-branch review (verdict: ready to merge, no Critical/Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)