### PR TITLE
feat(gphoto): show album photos in order instead of randomly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Google Photos screen now displays photos in album order** instead of picking
+  a random one each refresh. The position advances by one per refresh interval and
+  is derived statelessly from the clock (no persistent state needed), so it
+  survives server restarts and wraps around at the end of the album.
 - **Panel auto-detection now also matches the `Model` header.** Previously a panel's `match:` was only compared against the firmware `Board` header. The reTerminal E1004 reports its panel identity in `Model` (and sends no `Board` header), so it could never auto-detect a panel and fell back to the greyscale default. Matching now tries `Board` first, then `Model`.
 - The "Device not registered" log line now includes the device's `Board`, `Model`, `Colors` headers and resolved `width`/`height`. This makes it possible to author a matching panel profile (`match:`, `colors:`) for a brand-new device directly from the server log, before it has been registered.
 - Refreshed all dependencies in `Cargo.lock` to the latest versions compatible with the existing `Cargo.toml` ranges (`cargo update`), including the `rustls-webpki` 0.103.10 → 0.103.13 security bump. No source changes required; full check suite passes.

--- a/docs/src/tutorial/advanced.md
+++ b/docs/src/tutorial/advanced.md
@@ -421,10 +421,10 @@ devices:
 
 The script scrapes the shared album HTML page to extract `lh3.googleusercontent.com` image URLs, then:
 
-1. Selects an image from the album in order, advancing by one each refresh interval (derived statelessly from the clock, so it survives restarts)
+1. Selects an image from the album in order, advancing by one each refresh interval (derived statelessly from the system clock, so it survives restarts)
 2. Appends size parameters (`=w{width}-h{height}-no`) to request device-sized images
 3. Fetches and base64-encodes the image for embedding in SVG
-4. Caches album HTML for 1 hour and images for 24 hours
+4. Fetches album HTML without caching and caches images for 24 hours
 
 This approach works because Google's shared album pages embed image URLs directly in the HTML, even though the Photos API sharing features were deprecated in March 2025.
 

--- a/docs/src/tutorial/advanced.md
+++ b/docs/src/tutorial/advanced.md
@@ -421,7 +421,7 @@ devices:
 
 The script scrapes the shared album HTML page to extract `lh3.googleusercontent.com` image URLs, then:
 
-1. Selects a random image from the album
+1. Selects an image from the album in order, advancing by one each refresh interval (derived statelessly from the clock, so it survives restarts)
 2. Appends size parameters (`=w{width}-h{height}-no`) to request device-sized images
 3. Fetches and base64-encodes the image for embedding in SVG
 4. Caches album HTML for 1 hour and images for 24 hours

--- a/screens/gphoto.lua
+++ b/screens/gphoto.lua
@@ -17,7 +17,7 @@ refresh_rate:
   mode: box
 ]]
 -- Google Photos shared album display
--- Fetches random photos from a shared Google Photos album
+-- Shows photos from a shared Google Photos album in order, one per refresh
 -- Uses HTML scraping of the shared album page (no OAuth required)
 
 local width = layout.width
@@ -99,12 +99,13 @@ if #image_urls == 0 then
   return error_return("No images found in album")
 end
 
--- Select random image using real system time (not overrideable time_now)
-local seed = os.time()
-math.randomseed(seed)
-local idx = math.random(#image_urls)
+-- Select image in album order, advancing one per refresh interval.
+-- Stateless: the "pointer" is derived from real system time (not overrideable
+-- time_now), so it survives restarts. floor(now/refresh_rate) ticks up by one
+-- each interval, walking the album in order and wrapping at the end.
+local idx = (math.floor(os.time() / refresh_rate) % #image_urls) + 1
 local selected_url = image_urls[idx]
-log_info("Random: seed=" .. seed .. " idx=" .. idx .. "/" .. #image_urls)
+log_info("Sequential: idx=" .. idx .. "/" .. #image_urls)
 
 -- Append size parameters for device dimensions
 local sized_url = selected_url .. "=w" .. width .. "-h" .. height .. "-no"

--- a/screens/gphoto.lua
+++ b/screens/gphoto.lua
@@ -103,6 +103,8 @@ end
 -- Stateless: the "pointer" is derived from real system time (not overrideable
 -- time_now), so it survives restarts. floor(now/refresh_rate) ticks up by one
 -- each interval, walking the album in order and wrapping at the end.
+refresh_rate = tonumber(refresh_rate) or 3600
+if refresh_rate <= 0 then refresh_rate = 3600 end
 local idx = (math.floor(os.time() / refresh_rate) % #image_urls) + 1
 local selected_url = image_urls[idx]
 log_info("Sequential: idx=" .. idx .. "/" .. #image_urls)


### PR DESCRIPTION
## Summary

The Google Photos screen (`screens/gphoto.lua`) previously picked a **random** image from the shared album on every refresh. This changes it to walk the album **in order**, advancing one photo per refresh interval.

byonk runs each screen script fresh with no writable state — the only persistence is the HTTP cache, which can't hold a custom cursor. So instead of a stored pointer, the index is derived statelessly from the clock:

```lua
local idx = (math.floor(os.time() / refresh_rate) % #image_urls) + 1
```

Each `refresh_rate` seconds the bucket ticks up by one, walking the album in scrape order and wrapping at the end. Because it's clock-based, it survives server restarts with no state file.

## Caveats

- "Order" is the order images appear in Google's scraped album HTML (stable run-to-run, but not user-chosen).
- If the album's photo count changes, positions shift.
- Clock-bucket timing can occasionally repeat or skip one photo at an interval boundary if device poll timing drifts. Acceptable for a photo frame.

For true exactly-once-per-fetch semantics we'd need a real persistence API (`state_get`/`state_set`) in the Rust runtime — out of scope here.

## Changes

- `screens/gphoto.lua` — sequential clock-derived index; updated header comment.
- `docs/src/tutorial/advanced.md` — updated "How It Works" wording.
- `CHANGES.md` — added a "Changed" entry.

Lua/docs-only change; no rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)