### PR TITLE
ci(release): push to main with RELEASE_TOKEN (bypass ruleset)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # This job pushes the version-bump commit + tag to the protected
+          # `main` branch. The default GITHUB_TOKEN cannot push under the
+          # `main-protect` ruleset, so use RELEASE_TOKEN — a PAT whose owner is
+          # on the ruleset's bypass list. See docs/superpowers/ha-publishing.md.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Verify main branch
         run: |
@@ -280,6 +285,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+          # Pushes the add-on version bump to protected `main`; needs the
+          # bypass PAT, same as the version job above.
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Bump add-on config + changelog
         run: |


### PR DESCRIPTION
The release workflow's `version` and `update-addon-version` jobs push directly to `main` (version bump + tag, add-on config bump). The new `main-protect` ruleset rejects that with the default GITHUB_TOKEN (`GH013`), which is why the 0.16.0 release run failed at *Bump Version → Commit and tag*.

This checks out those two jobs with `secrets.RELEASE_TOKEN` (a PAT on the ruleset bypass list) so the pushes are allowed. No other job changes.

**Before this can be used, @oetiker must:**
1. Create a fine-grained PAT scoped to this repo with **Contents: read and write**.
2. Add its owner to the *main-protect* ruleset **Bypass list** (Settings → Rules → Rulesets → main-protect).
3. Save the PAT as the repo secret **`RELEASE_TOKEN`**.

Then re-run the Release workflow (type: feature → 0.16.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)