### PR TITLE
Fix broken screen-repo fetch + rename "packages" to "screen repos"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New
 
+- **Failing screen repos are now visible in Home Assistant.** When Byonk cannot
+  fetch a screen repo, the integration raises a Home Assistant *Repair* issue
+  showing the repo and the actual error, and clears it automatically once the
+  repo updates successfully. Previously the error was only visible as an
+  attribute on a diagnostic sensor.
+
 ### Changed
+
+- **"Packages" are now called "screen repos".** A screen repo is a git
+  repository of screens, so the clearer name is used everywhere: the admin API
+  (`/api/admin/screen-repos`), the `config.yaml` keys (`screen_repos:`,
+  `screen_repo_refresh_interval:`), the Home Assistant add-on options, and the
+  integration UI (the "Update screen repos" button and per-repo status sensors).
+  Existing add-on options set under `packages` / `package_refresh_interval` must
+  be re-entered under the new `screen_repos` / `screen_repo_refresh_interval`
+  keys.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Screen packages could never be fetched from the published container image.**
+  The release image is built `FROM scratch` and has no `/tmp` directory, so the
+  intermediate git clone (which used the system temp dir) failed with an opaque
+  `Could not open data at '/tmp/…'` and every package showed status `error`. The
+  clone now runs beside the package cache under the persistent data directory, so
+  fetching works in the container. Fetch failures are also written to the log now,
+  instead of only appearing in the per-package status.
+
 ## 0.16.0 - 2026-07-17
 
 ### New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byonk"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/custom_components/byonk/api.py
+++ b/custom_components/byonk/api.py
@@ -96,20 +96,20 @@ class ByonkClient:
     async def async_update_settings(self, payload: dict) -> dict:
         return await self._request("PATCH", "/api/admin/settings", json=payload)
 
-    async def async_get_packages(self) -> list[dict]:
-        return await self._request("GET", "/api/admin/packages")
+    async def async_get_screen_repos(self) -> list[dict]:
+        return await self._request("GET", "/api/admin/screen-repos")
 
-    async def async_add_package(self, payload: dict) -> dict:
-        return await self._request("POST", "/api/admin/packages", json=payload)
+    async def async_add_screen_repo(self, payload: dict) -> dict:
+        return await self._request("POST", "/api/admin/screen-repos", json=payload)
 
-    async def async_update_package(self, handle: str, payload: dict) -> dict:
-        return await self._request("PATCH", f"/api/admin/packages/{handle}", json=payload)
+    async def async_update_screen_repo(self, handle: str, payload: dict) -> dict:
+        return await self._request("PATCH", f"/api/admin/screen-repos/{handle}", json=payload)
 
-    async def async_delete_package(self, handle: str) -> dict:
-        return await self._request("DELETE", f"/api/admin/packages/{handle}")
+    async def async_delete_screen_repo(self, handle: str) -> dict:
+        return await self._request("DELETE", f"/api/admin/screen-repos/{handle}")
 
-    async def async_update_packages(self) -> dict:
-        return await self._request("POST", "/api/admin/packages/update")
+    async def async_update_screen_repos(self) -> dict:
+        return await self._request("POST", "/api/admin/screen-repos/update")
 
 
 async def _safe_json(resp: aiohttp.ClientResponse) -> dict:

--- a/custom_components/byonk/button.py
+++ b/custom_components/byonk/button.py
@@ -20,20 +20,20 @@ async def async_setup_entry(
 ) -> None:
     if CONF_DEVICE_KEY in entry.data:
         return  # device entries have no hub buttons
-    async_add_entities([ByonkUpdatePackagesButton(entry.runtime_data)])
+    async_add_entities([ByonkUpdateScreenReposButton(entry.runtime_data)])
 
 
-class ByonkUpdatePackagesButton(ByonkHubEntity, ButtonEntity):
-    _attr_translation_key = "update_packages"
+class ByonkUpdateScreenReposButton(ByonkHubEntity, ButtonEntity):
+    _attr_translation_key = "update_screen_repos"
 
     def __init__(self, coordinator) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.entry.entry_id}_update_packages"
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_update_screen_repos"
 
     async def async_press(self) -> None:
         try:
-            await self.coordinator.client.async_update_packages()
+            await self.coordinator.client.async_update_screen_repos()
         except ByonkApiError as err:
-            _LOGGER.warning("update packages failed: %s", err)
+            _LOGGER.warning("update screen repos failed: %s", err)
             return
         await self.coordinator.async_request_refresh()

--- a/custom_components/byonk/coordinator.py
+++ b/custom_components/byonk/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import ByonkApiError, ByonkAuthError, ByonkClient
@@ -32,7 +33,7 @@ class ByonkData:
     panels: list[dict]
     dither: list[str]
     config: dict
-    packages: list[dict]
+    screen_repos: list[dict]
 
     def screen_names(self) -> list[str]:
         # Screens are addressed by their qualified `handle/path` ref.
@@ -53,13 +54,13 @@ class ByonkData:
     def auth_mode(self) -> str | None:
         return self.config.get("auth_mode")
 
-    def non_builtin_packages(self) -> list[dict]:
-        return [p for p in self.packages if not p.get("builtin")]
+    def non_builtin_screen_repos(self) -> list[dict]:
+        return [r for r in self.screen_repos if not r.get("builtin")]
 
-    def package(self, handle: str) -> dict | None:
-        for p in self.packages:
-            if p.get("handle") == handle:
-                return p
+    def screen_repo(self, handle: str) -> dict | None:
+        for r in self.screen_repos:
+            if r.get("handle") == handle:
+                return r
         return None
 
 
@@ -82,23 +83,23 @@ class ByonkCoordinator(DataUpdateCoordinator[ByonkData]):
 
     async def _async_update_data(self) -> ByonkData:
         try:
-            devices, pending, screens, config, packages = await asyncio.gather(
+            devices, pending, screens, config, screen_repos = await asyncio.gather(
                 self.client.async_get_devices(),
                 self.client.async_get_pending(),
                 self.client.async_get_screens(),
                 self.client.async_get_config(),
-                self.client.async_get_packages(),
+                self.client.async_get_screen_repos(),
             )
         except ByonkAuthError as err:
             raise ConfigEntryAuthFailed(str(err)) from err
         except ByonkApiError as err:
             raise UpdateFailed(str(err)) from err
-        # The admin API now groups screens by package: {packages: [{screens: [...]}]}.
+        # The admin API groups screens by screen repo: {screen_repos: [{screens: [...]}]}.
         # Flatten to a single list; each screen carries its qualified `ref`.
         flat_screens = [
             screen
-            for pkg in screens.get("packages", [])
-            for screen in pkg.get("screens", [])
+            for repo in screens.get("screen_repos", [])
+            for screen in repo.get("screens", [])
         ]
         data = ByonkData(
             devices=devices,
@@ -107,7 +108,7 @@ class ByonkCoordinator(DataUpdateCoordinator[ByonkData]):
             panels=screens.get("panels", []),
             dither=screens.get("dither_algorithms", []),
             config=config,
-            packages=packages,
+            screen_repos=screen_repos,
         )
         # Skip device reconcile on the very first refresh: entry.runtime_data is not
         # yet set at that point (it is set in __init__.py after
@@ -119,7 +120,43 @@ class ByonkCoordinator(DataUpdateCoordinator[ByonkData]):
             await self._async_reconcile(data)
         self._async_sync_discovery(data)
         self._async_provision_default(data)
+        self._async_reconcile_repo_issues(data)
         return data
+
+    def _async_reconcile_repo_issues(self, data: ByonkData) -> None:
+        """Raise a repair issue for every screen repo currently in `error`, and
+        clear it once the repo recovers. The per-repo status sensor still carries
+        the detail, but a failing fetch is easy to miss there — a repair surfaces
+        it prominently in Settings > Repairs with the actual error message."""
+        active = set()
+        for repo in data.non_builtin_screen_repos():
+            if repo.get("status") != "error":
+                continue
+            handle = repo.get("handle") or "?"
+            issue_id = f"screen_repo_error_{handle}"
+            active.add(issue_id)
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                issue_id,
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="screen_repo_error",
+                translation_placeholders={
+                    "handle": handle,
+                    "repo": repo.get("repo") or "",
+                    "error": repo.get("error") or "unknown error",
+                },
+            )
+        # Delete issues for repos that recovered or are no longer registered.
+        registry = ir.async_get(self.hass)
+        for domain, issue_id_str in list(registry.issues):
+            if (
+                domain == DOMAIN
+                and issue_id_str.startswith("screen_repo_error_")
+                and issue_id_str not in active
+            ):
+                ir.async_delete_issue(self.hass, DOMAIN, issue_id_str)
 
     def _device_entries(self) -> dict[str, ConfigEntry]:
         return {

--- a/custom_components/byonk/screen_repo_entities.py
+++ b/custom_components/byonk/screen_repo_entities.py
@@ -1,4 +1,4 @@
-"""Dynamic per-package status sensors on the hub device."""
+"""Dynamic per-screen-repo status sensors on the hub device."""
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
@@ -11,59 +11,59 @@ from .coordinator import ByonkConfigEntry, ByonkCoordinator
 from .entity import ByonkHubEntity
 
 
-class ByonkPackageStatusSensor(ByonkHubEntity, SensorEntity):
-    """One sensor per non-builtin package: state = fetch status."""
+class ByonkScreenRepoStatusSensor(ByonkHubEntity, SensorEntity):
+    """One sensor per non-builtin screen repo: state = fetch status."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_translation_key = "package_status"
+    _attr_translation_key = "screen_repo_status"
 
     def __init__(self, coordinator: ByonkCoordinator, handle: str) -> None:
         super().__init__(coordinator)
         self._handle = handle
-        self._attr_unique_id = f"{coordinator.entry.entry_id}_pkg_{handle}_status"
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_repo_{handle}_status"
         self._attr_translation_placeholders = {"handle": handle}
         self._attr_name = f"{handle}: status"
 
     @property
-    def _pkg(self) -> dict | None:
-        return self.coordinator.data.package(self._handle)
+    def _repo(self) -> dict | None:
+        return self.coordinator.data.screen_repo(self._handle)
 
     @property
     def available(self) -> bool:
-        return super().available and self._pkg is not None
+        return super().available and self._repo is not None
 
     @property
     def native_value(self) -> str | None:
-        pkg = self._pkg
-        return pkg.get("status") if pkg else None
+        repo = self._repo
+        return repo.get("status") if repo else None
 
     @property
     def extra_state_attributes(self) -> dict:
-        pkg = self._pkg or {}
-        lf = pkg.get("last_fetched")
+        repo = self._repo or {}
+        lf = repo.get("last_fetched")
         return {
-            "resolved_sha": pkg.get("resolved_sha"),
+            "resolved_sha": repo.get("resolved_sha"),
             "last_fetched": dt_util.parse_datetime(lf) if lf else None,
-            "error": pkg.get("error"),
-            "repo": pkg.get("repo"),
-            "pin": pkg.get("pin"),
-            "pin_kind": pkg.get("pin_kind"),
+            "error": repo.get("error"),
+            "repo": repo.get("repo"),
+            "pin": repo.get("pin"),
+            "pin_kind": repo.get("pin_kind"),
         }
 
 
-class PackageStatusManager:
-    """Add/remove a status sensor per non-builtin package as the registry changes."""
+class ScreenRepoStatusManager:
+    """Add/remove a status sensor per non-builtin screen repo as the registry changes."""
 
     def __init__(self, coordinator: ByonkCoordinator, async_add_entities) -> None:
         self._coordinator = coordinator
         self._async_add_entities = async_add_entities
-        self._entities: dict[str, ByonkPackageStatusSensor] = {}
+        self._entities: dict[str, ByonkScreenRepoStatusSensor] = {}
 
     @callback
     def reconcile(self) -> None:
-        desired = {p["handle"] for p in self._coordinator.data.non_builtin_packages()}
+        desired = {r["handle"] for r in self._coordinator.data.non_builtin_screen_repos()}
         new = {
-            h: ByonkPackageStatusSensor(self._coordinator, h)
+            h: ByonkScreenRepoStatusSensor(self._coordinator, h)
             for h in desired
             if h not in self._entities
         }
@@ -75,7 +75,7 @@ class PackageStatusManager:
             if h not in desired:
                 self._remove(self._entities.pop(h))
 
-    def _remove(self, entity: ByonkPackageStatusSensor) -> None:
+    def _remove(self, entity: ByonkScreenRepoStatusSensor) -> None:
         registry = er.async_get(self._coordinator.hass)
         if entity.entity_id and registry.async_get(entity.entity_id):
             registry.async_remove(entity.entity_id)
@@ -85,8 +85,8 @@ class PackageStatusManager:
             )
 
 
-def setup_package_status_platform(entry: ByonkConfigEntry, async_add_entities) -> None:
+def setup_screen_repo_status_platform(entry: ByonkConfigEntry, async_add_entities) -> None:
     coordinator = entry.runtime_data
-    manager = PackageStatusManager(coordinator, async_add_entities)
+    manager = ScreenRepoStatusManager(coordinator, async_add_entities)
     manager.reconcile()
     entry.async_on_unload(coordinator.async_add_listener(manager.reconcile))

--- a/custom_components/byonk/sensor.py
+++ b/custom_components/byonk/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.util import dt as dt_util
 from .const import CONF_DEVICE_KEY
 from .coordinator import ByonkConfigEntry
 from .entity import ByonkDeviceEntity
-from .package_entities import setup_package_status_platform
+from .screen_repo_entities import setup_screen_repo_status_platform
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -74,7 +74,7 @@ async def async_setup_entry(
             ByonkDeviceSensor(coordinator, key, desc) for desc in DEVICE_SENSORS
         )
         return
-    setup_package_status_platform(entry, async_add_entities)
+    setup_screen_repo_status_platform(entry, async_add_entities)
 
 
 class ByonkDeviceSensor(ByonkDeviceEntity, SensorEntity):

--- a/custom_components/byonk/strings.json
+++ b/custom_components/byonk/strings.json
@@ -31,7 +31,7 @@
   },
   "entity": {
     "button": {
-      "update_packages": { "name": "Update packages" }
+      "update_screen_repos": { "name": "Update screen repos" }
     },
     "switch": {
       "registration_enabled": {
@@ -65,12 +65,18 @@
       "model": {
         "name": "Model"
       },
-      "package_status": { "name": "{handle}: status" }
+      "screen_repo_status": { "name": "{handle}: status" }
     },
     "text": {
       "refresh": {
         "name": "Refresh"
       }
+    }
+  },
+  "issues": {
+    "screen_repo_error": {
+      "title": "Screen repo \"{handle}\" failed to update",
+      "description": "Byonk could not fetch the screen repo \"{handle}\" ({repo}).\n\nError: {error}\n\nCheck the repo URL, pin (branch/tag/commit) and access token in the Byonk add-on configuration, then use the \"Update screen repos\" button to retry."
     }
   }
 }

--- a/custom_components/byonk/translations/en.json
+++ b/custom_components/byonk/translations/en.json
@@ -31,7 +31,7 @@
   },
   "entity": {
     "button": {
-      "update_packages": { "name": "Update packages" }
+      "update_screen_repos": { "name": "Update screen repos" }
     },
     "switch": {
       "registration_enabled": {
@@ -65,12 +65,18 @@
       "model": {
         "name": "Model"
       },
-      "package_status": { "name": "{handle}: status" }
+      "screen_repo_status": { "name": "{handle}: status" }
     },
     "text": {
       "refresh": {
         "name": "Refresh"
       }
+    }
+  },
+  "issues": {
+    "screen_repo_error": {
+      "title": "Screen repo \"{handle}\" failed to update",
+      "description": "Byonk could not fetch the screen repo \"{handle}\" ({repo}).\n\nError: {error}\n\nCheck the repo URL, pin (branch/tag/commit) and access token in the Byonk add-on configuration, then use the \"Update screen repos\" button to retry."
     }
   }
 }

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,6 +1,11 @@
 # Handover — Byonk
 
-_Last updated: 2026-07-17 — **Fetch bug fix + "packages" → "screen repos" rename (everything incl. API) + HA error-visibility feature.** Branch `fix/screen-repos-and-fetch-scratch` @ `5b9fec7`, off `main` (`e61658d`). Tree clean. All local gates green. NOT pushed, NOT merged. Remaining: optional VM live-verify, then push/PR/release 0.16.1._
+_Last updated: 2026-07-17 — **Fetch bug fix + "packages" → "screen repos" rename (everything incl. API) + HA error-visibility feature. VM-verified live; PR #27 OPEN.** Branch `fix/screen-repos-and-fetch-scratch` (off `main` `e61658d`), pushed. All local gates green; VM live-verify passed via the from-source add-on. Remaining: PR #27 CI + review → squash-merge → release 0.16.1._
+
+## Status: PR #27 open, VM-verified
+- **PR:** https://github.com/oetiker/byonk/pull/27 — CI running at hand-off.
+- **VM live-verify (from-source `local_byonk`):** Supervisor accepted the new `screen_repos` schema; `GET /api/admin/screen-repos` serves the `tobitest` repo (`https://github.com/oetiker/byonk-dist-test.git`) at `status: ready`, sha `97578c5f`, serving `tobitest/hello`; old `/api/admin/packages` → 404; `GET /screens` wrapper field is `screen_repos`. The `/tmp` fetch error is gone. **VM state now:** `local_byonk` running (my branch, throwaway admin_token `verifytoken123` + tobitest), published `43664941_byonk` **stopped**, the existing integration entry still points at the stopped published add-on (in error) — re-onboard the integration (needs HA UI login) to see the renamed entities/button/repair issue, or restore by `ha addons stop local_byonk && ha addons start 43664941_byonk`.
+- Integration UI not verified live (HA login = password entry, disallowed) but covered by 77 pytest + the API wire check.
 
 ## TL;DR — what happened this session
 

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,82 +1,34 @@
 # Handover — Byonk
 
-_Last updated: 2026-07-17 — **HA Distribution Readiness: code/doc tasks 1–8 DONE + reviewed clean, AND Task 9 (fresh-VM end-to-end validation) DONE — 9/10 checklist items PASS on a clean HAOS build-from-source; item 1 (published image) is inherently post-release.** Branch `feat/ha-distribution-readiness` @ `01d8d1c` (pushed, PR #23 OPEN, CI green), tree clean, not merged. Remaining: Task 10 (merge → release 0.16.0) and Task 11 (external brands/HACS PRs, post-release). Two findings surfaced during validation — see below._
+_Last updated: 2026-07-17 — **Fetch bug fix + "packages" → "screen repos" rename (everything incl. API) + HA error-visibility feature.** Branch `fix/screen-repos-and-fetch-scratch` @ `5b9fec7`, off `main` (`e61658d`). Tree clean. All local gates green. NOT pushed, NOT merged. Remaining: optional VM live-verify, then push/PR/release 0.16.1._
 
-## TL;DR — resume here
+## TL;DR — what happened this session
 
-The distribution plan `docs/superpowers/plans/2026-07-06-ha-distribution-readiness.md` has 11 tasks. **Tasks 1–9 are DONE.** What remains is manual:
+User reported: added a screen-repo (their `byonk-dist-test` repo) in the add-on, clicked refresh, got "an error but no further information." Root-caused and fixed, then did a full user-requested rename.
 
-1. ~~**Task 9 — VM validation.**~~ **DONE 2026-07-17** on a wiped/fresh HAOS VM, byonk built from current source as a local add-on (see "VM validation results" below). Zero-touch install→trust→device-discovery→reauth→removal-grace all validated end-to-end.
-2. **Task 10 — Merge + release (do next).** `superpowers:finishing-a-development-branch`. PR #23 carries Plan 1+2+3+A+B + distribution work; merges to `main` together. Confirm the `home-assistant` (hassfest+HACS) and `release-scripts` CI jobs stay green on the merge. Then trigger the release (`workflow_dispatch` on `release.yml`, minor → **0.16.0**) for the first (non-publicised) release.
-3. **Task 11 — External PRs (post-first-release), maintainer-filed.** Follow `docs/superpowers/ha-publishing.md`: file `home-assistant/brands` PR (this is what lights up the currently-missing integration icon — see finding B), then `hacs/default`, then remove `ignore: brands` from `ci.yml` and switch `ha-integration.md` to default-store wording.
+1. **Bug fix (`1b2ed93`)** — screen-repo fetch was **completely broken in the published container**: the release image is `FROM scratch` (no `/tmp`), and `git_fetch.rs` cloned the intermediate bare repo into `std::env::temp_dir()` (`/tmp/…`), which gix can't create there → `Could not open data at '/tmp/byonk-git-fetch-…'`, status `error`. Fix: clone into a **sibling of `dest`** (under the package cache on `/data`, guaranteed to exist). Also added `tracing` warn/info so fetch failures hit the add-on log, not only `GET`.
+   - **Proven**: identical fetch succeeded on Mac; and with `TMPDIR=/no/such/tmp` (simulating the scratch container) the fixed fetch returns `PROBE_OK`. Unit test `test_scratch_is_sibling_of_dest_not_system_temp`.
 
-## VM validation results (2026-07-17, fresh HAOS + from-source add-on)
+2. **Rename "packages" → "screen repos" (`ae57f43`, `f685be9`, `5b9fec7`)** — user chose: term **"Screen Repos"**, scope **everything incl. the HTTP API**, and **surface errors visibly**. A screen repo = a git repository of screens.
+   - **API**: `/api/admin/packages*` → `/api/admin/screen-repos*`; `GET /screens` grouping wrapper field `packages` → `screen_repos`; settings field `package_refresh_interval` → `screen_repo_refresh_interval`. Per-repo fields (handle, repo, pin, builtin, status, error, …) unchanged.
+   - **config.yaml / add-on options + schema**: `packages` → `screen_repos`, `package_refresh_interval` → `screen_repo_refresh_interval`; env `PACKAGES_CACHE_DIR` → `SCREEN_REPOS_CACHE_DIR` (value `/data/packages` kept).
+   - **Rust internals**: `Package{Manager,Loader,Cache,Status,State,Ref,Manifest,Info,Source}` → `ScreenRepo*`; files `src/services/screen_repo_*.rs`, `src/models/screen_repo_manifest.rs`; `config_writer` upsert/remove fns renamed.
+   - **HA integration**: API client, coordinator (`screen_repos`, `non_builtin_screen_repos`, `screen_repo()`), `screen_repo_entities.py` / `ByonkScreenRepoStatusSensor`, button "Update screen repos", strings/translations.
+   - **KEPT**: `byonk-builtin` handle value, `byonk-screens.yaml` filename, `/data/packages` path value — so device screen paths and on-disk layout are unaffected.
 
-Method: `make ha-vm-clean` + fresh boot; onboarded via Chrome; Samba + Terminal&SSH add-ons installed; byonk built **from current source** as local add-on `local_byonk` (published-image path is post-release only). Checklist (`tools/ha-vm/README.md`):
+3. **Error-visibility feature (`f685be9`)** — a screen repo in `error` state now raises a **HA Repair issue** ("Screen repo X failed to update") carrying the real fetch error, auto-cleared on recovery. Translation `issues.screen_repo_error` in strings.json/en.json. Tests: `tests_ha/test_screen_repo_issues.py`.
 
-| # | Item | Result |
-|---|------|--------|
-| 1 | Add-on store / published image | ⏭️ deferred — post-release only (built from source) |
-| 2 | Integration discovery | ✅ |
-| 3 | Zero-touch trust (no token entry) | ✅ token auto-provisioned into add-on options |
-| 4 | Add-on-owned global config | ✅ settings/packages writes → **409** "edit in add-on Configuration tab" |
-| 5 | Reserved DEFAULT device | ✅ `reserved:true`, PATCH→200, DELETE→**409**, "Byonk Default" auto-provisioned |
-| 6 | Screen resolution (unregistered) | ✅ device shows pairing code; display→200 |
-| 7 | HA-owned per-device flow | ✅ Discovered card → Add → per-device entry (9 entities), code-labeled onboarding |
-| 8 | Screen packages | ✅ external git package fetched (`disttest` ready, screen served) — **see finding A** |
-| 9 | Re-authentication | ✅ blanked token → integration **auto-re-provisioned** (self-heal, no manual input) |
-| 10 | Removal grace | ✅ device disappeared → HA entry survived 1 cycle, pruned at strike 2 (`REMOVE_STRIKES=2`×60s) |
+## Verification status (all GREEN at `5b9fec7`)
+- Rust: `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test` (73/5/2/… all ok) — green.
+- HA: `make ha-check` (ruff + **77 pytest**) — green.
+- Docs: `make docs` (mdbook) — clean (only harmless mermaid version warning).
+- Fetch fix functionally proven via `TMPDIR=/no/such/tmp` probe (`PROBE_OK`).
 
-### Findings (not merge-blockers for a non-publicised release; consider fast-follow)
-
-- **Finding A — schemeless package `repo:` URLs — FIXED (validate, not normalize).** `repo: github.com/…` used to be handed to gix as a **local path** (`/app/github.com/…`) → obscure `status:error`. Now `git_fetch::fetch` calls `validate_repo()` up front: a `repo:` must carry an explicit scheme (`https://`/`http://`/`git://`/`ssh://`/`file://`) or be scp-like (`git@host:owner/repo`); schemeless values and bare paths are rejected with a clear message ("…must be `https://…`; a local repository must be `file:///path`"). Local repos now require `file:///` (per user direction — no normalization). Docs (`configuration.md`) updated; unit tests added; `make check` green. **Not yet committed** (working tree on `feat/ha-distribution-readiness`).
-- **Finding B — integration icon missing until brands PR.** Fresh integration shows "icon not available" because HA fetches integration icons from `brands.home-assistant.io/byonk/` (populated by the Task-11 `home-assistant/brands` PR). The **add-on** icon renders fine (ships locally). Expected; not a blocker; assets are staged in `homeassistant/brands/`.
-- **Finding D — packages not fetched on startup — FIXED.** byonk's package refresh ran only on the periodic loop, which `sleep`s first and is a **no-op when `package_refresh_interval == 0`** (manual mode, the default). There was **no startup fetch**, and boot leaves package status empty (the on-disk cache isn't loaded into a "ready" state), so *any* restart (add-on update, HA reboot, Options change, re-auth) dropped external package screens until the user pressed "Update packages". Fix (`src/main.rs`, production `serve` path): run `refresh_all(false)` once at startup in a spawned blocking task (reuses the cache for immutable pins). Verified live: after a fresh dev5 boot, `disttest` reached `ready` in ~5s with no manual trigger. (Edge case not addressed: network down *at boot* still errors, since a fresh start has no cached status to fall back on.)
-- **Finding C — device entries stuck "unavailable" after a hub reload — FIXED.** Device entries (incl. the reserved DEFAULT) share the hub's coordinator (`entry.runtime_data = hass.data[DOMAIN][hub_id]`). A hub reload (e.g. re-auth token re-provision from the item-9 flow) builds a NEW coordinator, but LOADED device entries kept a stale reference to the old/dead one → their entities were unavailable forever until a manual reload. Fix (`__init__.py` `_async_setup_hub_entry`): the hub now reloads dependent device entries in **LOADED** state too (previously only `SETUP_RETRY`), so they rebind to the live coordinator. Regression test added (`test_device_entry_rebinds_after_hub_reload`); `make ha-check` green; verified live on the VM (token-blank → DEFAULT device auto-recovered in ~1s). **This is the device-side half of item 9 that the first validation pass missed.**
-
-### From-source add-on build notes (for repeatable fresh-VM validation)
-
-The local-add-on build-from-source path is **not committed** and had to be authored this session (scaffold in scratch: `config.yaml` sans `image:` + a Dockerfile). Key requirements discovered:
-- Build context = the full source tree byonk embeds at compile time via rust-embed (`screens/ fonts/ byonk-base/ static/` + `src crates Cargo.toml Cargo.lock default-config.yaml`) — exactly what `rebuild.sh` syncs.
-- Use a **Debian** rust base (`rust:1.88-slim-bookworm` + `apt install curl gcc libc6-dev`): `utoipa-swagger-ui`'s build script downloads Swagger UI via **`curl`** (Alpine attempts failed / were cache-replayed).
-- BuildKit **replays cached failed layers** across Dockerfile edits — bump the add-on `version:` (changes the `BUILD_VERSION` build-arg referenced before `cargo build`) to force a real rebuild; a bare `ha store reload` won't re-read the manifest, need `ha supervisor restart` (see `ha-vm-addon-manifest-sync-gap`).
-- **Consider committing** a `homeassistant/byonk/` local-build variant + wiring `make ha-rebuild` to scaffold it, so Task-9-style validation is one command next time.
-
-## What the distribution work shipped (Tasks 1–8, range `586e3d3..2667b89`)
-
-- **Version automation (4b):** two tested bash scripts — `tools/release/bump-addon-version.sh` and `bump-integration-version.sh` — wired into `release.yml`. The integration `manifest.json` bumps in the `version` job **before the tag** (HACS installs from the tag); the add-on `config.yaml` bumps in a new `update-addon-version` job `needs:[version,build-container]`, committing to `main` **after** the image publishes (so the add-on `version:` always equals a published `ghcr.io/oetiker/byonk` tag). All three versions now track the byonk release version.
-- **Validation CI (4c):** new `ci.yml` jobs — `home-assistant` (hassfest + `hacs/action`, with `ignore: brands` until the brands PR merges + `GITHUB_TOKEN` passed) and `release-scripts` (runs both bump-script test harnesses). The add-on `config.yaml` is already validated by the existing `tests/addon_manifest_test.rs` (extended with a semver guard).
-- **Brand assets (4c):** `homeassistant/brands/` — **user-supplied pixel-art** (a shinkansen departure board with the green **BYONK** sign), committed as `*.src.png` masters (1024px) + `rasterize.sh` (sips resize) → brands `icon.png`/`icon@2x`/`logo`/`logo@2x` + add-on `icon.png`/`logo.png`.
-- **Runbook + docs (4c/4d):** `docs/superpowers/ha-publishing.md` (brands + hacs/default PR steps); `ha-integration.md` HACS custom-repo install note; `CHANGES.md` Unreleased bullet; refreshed 10-item VM checklist.
-
-## Verification status (local, all GREEN at `2667b89`)
-
-- Bump scripts: `tools/release/test-bump-addon-version.sh` + `test-bump-integration-version.sh` pass.
-- Rust: `cargo test --test addon_manifest_test` passes (2/2). Full `make check` not re-run this session (no `src/` change — only a test file); known pre-existing flaky `tests/e2e_flow_test.rs::test_content_cache_reuse` is unrelated.
-- Docs: `make docs` clean.
-- **Whole-branch review (opus, `8ddba14..2667b89`): READY TO MERGE**, no Critical/Important; release timing verified sound.
-
-## Deferred Minors (fast-follow — do NOT gate the merge)
-
-- **M1 (most useful):** `update-addon-version` is a leaf job. If it FAILS, the release still tags/publishes/creates the GitHub release, but the add-on `config.yaml` on `main` stays at the old version — silently re-introducing the exact "add-on never offers the update" rot this work fixes. Recoverable (re-run from clean `main`, idempotent). **Fix:** a runbook line that a red `update-addon-version` must be re-run before a release counts as done.
-- **M2:** `bump-addon-version.sh` major-bump EOF append (`printf >> config.yaml`) is newline-fragile if `config.yaml` ever loses its trailing newline (safe today). Fix: guarded newline / perl append.
-- **M3:** hassfest + `hacs/action` are first exercised only on the Task-10 PR run (unverifiable locally).
-
-## Branch / merge state
-
-- **Branch `feat/ha-distribution-readiness` @ `2667b89`** (tree clean). Stacked on `feat/screen-packages-p2-distribution` (Plan B). Local-only, not pushed, not merged.
-- Distribution range **`586e3d3..2667b89`** = 11 commits (spec + plan + 8 tasks + 1 fix). Fork point from Plan B = `8ddba14`.
+## Remaining
+1. **(optional) VM live-verify** — needs the **from-source** local add-on (`local_byonk`) rebuilt on the QEMU VM (the VM currently runs the *published* 0.16.0 scratch image with the OLD naming + the bug). Recipe: memory `ha-vm-from-source-addon-build` + `tools/ha-vm/README.md`; re-scaffold `local_byonk` (config.yaml sans `image:` + Debian Dockerfile), `SMB_USER=byonk SMB_PASS=byonk make ha-rebuild`, `make ha-deploy`. Then in the add-on Config tab add a `screen_repos:` entry for `https://github.com/oetiker/byonk-dist-test.git` and confirm it fetches + shows as a screen repo + the button works; point at a bad repo to see the Repair issue. NOTE: the Debian from-source image HAS `/tmp`, so it validates the **rename/boundary**, not the scratch `/tmp` fix (already proven by the probe). The scratch fix is confirmed in production only at the 0.16.1 release image.
+2. **Push + PR + release 0.16.1** — not started; user not yet asked. Branch is off `main`; `main-protect` ruleset blocks direct pushes (use PR; release uses `RELEASE_TOKEN` + admin bypass, per the 0.16.0 memory).
 
 ## Reference
-
-- **Plan (executed 1–8):** `docs/superpowers/plans/2026-07-06-ha-distribution-readiness.md`.
-- **Spec:** `docs/superpowers/specs/2026-07-06-ha-distribution-readiness-design.md` (revised Phase 4; §4a = the VM checklist).
-- **SDD ledger:** `.superpowers/sdd/progress.md` — per-task review record + the deferred-Minor detail. Trust it + `git log` over memory after a compaction.
-- **Publishing runbook (Task 11):** `docs/superpowers/ha-publishing.md`.
-- **Memories:** `ha-addon-owned-global-config`, `ha-addon-phase2`, `ha-vm-admin-api-testing`, `ha-vm-addon-manifest-sync-gap`, `byonk-is-ours-change-apis-freely`, `no-git-add-all`.
-
-## Build / verify quick ref
-
-- Bump scripts: `tools/release/test-bump-addon-version.sh && tools/release/test-bump-integration-version.sh`.
-- Rust test: `cargo test --test addon_manifest_test`. Docs: `make docs`. Brand assets: `homeassistant/brands/rasterize.sh` (needs `sips`).
-- VM deploy: `SMB_USER=byonk SMB_PASS=byonk make ha-rebuild` (add-on) / `make ha-deploy` (integration).
+- Rename mapping spec (durable): `…/scratchpad/rename-spec.md` (session scratch).
+- Memories: `ha-vm-from-source-addon-build`, `ha-vm-addon-manifest-sync-gap`, `ha-addon-owned-global-config`, `ha-vm-admin-api-testing`, `changelog-user-facing-only`, `no-git-add-all`, `byonk-is-ours-change-apis-freely`.
+- Build/verify: `make check` (Rust), `make ha-check` (Python), `make docs`.

--- a/docs/src/api/admin-api.md
+++ b/docs/src/api/admin-api.md
@@ -120,7 +120,7 @@ Return the effective configuration as JSON, parsed from the on-disk `config.yaml
 
 ### GET /api/admin/screens
 
-Return the available screens **grouped by package**, plus panel profiles and supported
+Return the available screens **grouped by screen repo**, plus panel profiles and supported
 dither algorithms. Every screen is addressed by its canonical `handle/path` reference — the
 value a device's `screen` field is set to.
 
@@ -128,7 +128,7 @@ value a device's `screen` field is set to.
 
 ```json
 {
-  "packages": [
+  "screen_repos": [
     {
       "handle": "byonk-builtin",
       "name": "byonk-builtin",
@@ -191,8 +191,8 @@ value a device's `screen` field is set to.
 ```
 
 Field notes:
-- Screens are grouped under the package that provides them. The package-level `name`,
-  `description`, `author`, and `license` come from that package's `byonk-screens.yaml`
+- Screens are grouped under the screen repo that provides them. The repo-level `name`,
+  `description`, `author`, and `license` come from that screen repo's `byonk-screens.yaml`
   manifest.
 - `ref` is the canonical `handle/path` reference (e.g. `byonk-builtin/useful/gphoto`) — the
   assignable screen id, and what `screen` is set to on a device.
@@ -207,13 +207,13 @@ Field notes:
 
 ---
 
-### GET /api/admin/packages
+### GET /api/admin/screen-repos
 
-List the registered screen packages. `byonk-builtin` is always present (it is the embedded
-built-in package, registered even without a `packages:` config entry); any additional entries
-come from the `packages:` config section.
+List the registered screen repos. `byonk-builtin` is always present (it is the embedded
+built-in screen repo, registered even without a `screen_repos:` config entry); any additional
+entries come from the `screen_repos:` config section.
 
-**Response 200** — array of package objects:
+**Response 200** — array of screen repo objects:
 
 ```json
 [
@@ -248,29 +248,29 @@ come from the `packages:` config section.
 
 Field notes:
 - `handle` — the short registry key; also the first segment of every `handle/path` screen ref.
-- `repo` / `pin` — the source repo and pin for remote packages; both `null` for the embedded
-  built-in.
-- `builtin` — `true` for the embedded `byonk-builtin` handle (or any package without a remote
-  repo).
-- `token_set` — whether an auth token is configured for the package. The token itself is
+- `repo` / `pin` — the source repo and pin for remote screen repos; both `null` for the
+  embedded built-in.
+- `builtin` — `true` for the embedded `byonk-builtin` handle (or any screen repo without a
+  remote repo).
+- `token_set` — whether an auth token is configured for the screen repo. The token itself is
   **never** serialized in any response; only this boolean is exposed.
-- `screen_count` — number of screens the loader discovered in the package.
+- `screen_count` — number of screens the loader discovered in the screen repo.
 - `status` — one of:
   - `"ready"` — fetched (or embedded) and currently serving.
   - `"fetching"` — a fetch is in progress right now.
-  - `"error"` — the package has never been fetched successfully (e.g. just
+  - `"error"` — the screen repo has never been fetched successfully (e.g. just
     registered and the background fetch hasn't completed yet, or every fetch
     attempt has failed and nothing is cached). It is not currently serving.
   - `"offline"` — the most recent refresh attempt failed, but a previously
     fetched checkout is still cached and continues to serve. A fetch failure
-    never takes down an already-cached package.
+    never takes down an already-cached screen repo.
 - `pin_kind` — how `pin` was resolved: `"sha"`, `"tag"`, `"branch"`, or
-  `"embedded"` for the built-in package. `null` if the package has never been
+  `"embedded"` for the built-in screen repo. `null` if the screen repo has never been
   successfully fetched. **A full commit `sha` pin is immutable** — it is
   fetched once and cached forever, never re-fetched. **A `tag` or `branch`
   pin is mutable** — it is re-fetched on demand (via the update endpoints
-  below) and automatically every `package_refresh_interval` seconds.
-- `resolved_sha` — the commit sha the package is currently pinned/fetched at,
+  below) and automatically every `screen_repo_refresh_interval` seconds.
+- `resolved_sha` — the commit sha the screen repo is currently pinned/fetched at,
   or `null` if never successfully fetched. The cache is keyed by `repo` +
   `resolved_sha`.
 - `last_fetched` — RFC3339 timestamp of the last successful fetch, or `null`
@@ -280,12 +280,12 @@ Field notes:
 
 ---
 
-### POST /api/admin/packages
+### POST /api/admin/screen-repos
 
-Register a new remote screen package. Triggers an asynchronous background
+Register a new remote screen repo. Triggers an asynchronous background
 fetch (fire-and-forget) — the response reflects whatever status exists at
 that instant (typically no status yet, since the fetch hasn't completed).
-Poll `GET /api/admin/packages` for the settled result.
+Poll `GET /api/admin/screen-repos` for the settled result.
 
 **Request body**:
 
@@ -299,23 +299,23 @@ Poll `GET /api/admin/packages` for the settled result.
 ```
 
 Required field: `handle`. `repo`, `pin`, and `token` are optional (though a
-package needs `repo`/`pin` to have anything to fetch). `token` is used for
-authenticating against a private repo and — like every package `token` — is
+screen repo needs `repo`/`pin` to have anything to fetch). `token` is used for
+authenticating against a private repo and — like every screen repo `token` — is
 never echoed back in any response.
 
 **Responses**:
 
 | Status | Meaning |
 |--------|---------|
-| `200` | Registered — returns the package's `PackageInfo` (same shape as `GET /api/admin/packages` entries) |
+| `200` | Registered — returns the screen repo's `ScreenRepoInfo` (same shape as `GET /api/admin/screen-repos` entries) |
 | `400` | Validation error (missing `handle`) |
-| `409` | `handle` is `byonk-builtin` (reserved), a package with that `handle` already exists, or config is embedded/read-only (`set CONFIG_FILE`) |
+| `409` | `handle` is `byonk-builtin` (reserved), a screen repo with that `handle` already exists, or config is embedded/read-only (`set CONFIG_FILE`) |
 
 ---
 
-### PATCH /api/admin/packages/:handle
+### PATCH /api/admin/screen-repos/:handle
 
-Update an existing package's `repo`, `pin`, or `token`. All fields are
+Update an existing screen repo's `repo`, `pin`, or `token`. All fields are
 optional; an **omitted field keeps its current value** — in particular, an
 omitted `token` is never cleared.
 
@@ -328,21 +328,21 @@ omitted `token` is never cleared.
 ```
 
 If `repo` or `pin` changes, a background re-fetch is triggered (same
-fire-and-forget semantics as `POST /api/admin/packages`).
+fire-and-forget semantics as `POST /api/admin/screen-repos`).
 
 **Responses**:
 
 | Status | Meaning |
 |--------|---------|
-| `200` | Updated — returns the package's `PackageInfo` |
-| `404` | No package with that handle |
+| `200` | Updated — returns the screen repo's `ScreenRepoInfo` |
+| `404` | No screen repo with that handle |
 | `409` | `handle` is `byonk-builtin` (reserved), or config is embedded/read-only |
 
 ---
 
-### DELETE /api/admin/packages/:handle
+### DELETE /api/admin/screen-repos/:handle
 
-Remove a package registration. Rejected if any device's `screen` still
+Remove a screen repo registration. Rejected if any device's `screen` still
 references the handle (`<handle>/...`) — delete or repoint those device
 mappings first. On success, the in-memory loader is rebuilt immediately so
 the handle's screens stop resolving right away (the cached checkout on disk
@@ -353,41 +353,41 @@ is left in place).
 | Status | Meaning |
 |--------|---------|
 | `200` | Deleted — `{"ok": true}` |
-| `404` | No package with that handle |
+| `404` | No screen repo with that handle |
 | `409` | `handle` is `byonk-builtin` (reserved); a device references the handle (message names the offending device); or config is embedded/read-only |
 
 ---
 
-### POST /api/admin/packages/:handle/update
+### POST /api/admin/screen-repos/:handle/update
 
-Trigger a re-fetch of a single package handle. Fire-and-forget: the fetch
+Trigger a re-fetch of a single screen repo handle. Fire-and-forget: the fetch
 runs in the background, and the response reflects whatever status exists at
-that instant. Poll `GET /api/admin/packages` for the settled status. Calling
-this on `byonk-builtin` is accepted but is a no-op (the embedded package is
+that instant. Poll `GET /api/admin/screen-repos` for the settled status. Calling
+this on `byonk-builtin` is accepted but is a no-op (the embedded screen repo is
 never fetched).
 
 **Responses**:
 
 | Status | Meaning |
 |--------|---------|
-| `200` | Refresh triggered — returns the package's `PackageInfo` (pre-refresh snapshot) |
-| `404` | No package with that handle |
+| `200` | Refresh triggered — returns the screen repo's `ScreenRepoInfo` (pre-refresh snapshot) |
+| `404` | No screen repo with that handle |
 
 ---
 
-### POST /api/admin/packages/update
+### POST /api/admin/screen-repos/update
 
-Trigger a forced re-fetch of every registered non-builtin package
+Trigger a forced re-fetch of every registered non-builtin screen repo
 (fire-and-forget, runs in the background). Forcing bypasses the "already
 cached and immutable" skip that a normal periodic refresh applies to sha
-pins — every handle gets a real fetch attempt. Poll `GET /api/admin/packages`
-for the settled status of each package.
+pins — every handle gets a real fetch attempt. Poll `GET /api/admin/screen-repos`
+for the settled status of each screen repo.
 
 **Responses**:
 
 | Status | Meaning |
 |--------|---------|
-| `200` | Refresh triggered for all packages — `{"ok": true}` |
+| `200` | Refresh triggered for all screen repos — `{"ok": true}` |
 
 ---
 
@@ -480,7 +480,7 @@ changed.
 {
   "registration_enabled": true,
   "auth_mode": "api_key",
-  "package_refresh_interval": 3600
+  "screen_repo_refresh_interval": 3600
 }
 ```
 
@@ -488,7 +488,7 @@ changed.
 |-------|------|---------------|
 | `registration_enabled` | boolean | `true` / `false` |
 | `auth_mode` | string | `"api_key"` or `"ed25519"` |
-| `package_refresh_interval` | integer | seconds between automatic re-fetches of mutable (tag/branch) package pins; `0` disables periodic refresh (the default) |
+| `screen_repo_refresh_interval` | integer | seconds between automatic re-fetches of mutable (tag/branch) screen repo pins; `0` disables periodic refresh (the default) |
 
 There is no `default_screen` or `registration_screen` field here — the screen
 shown to un-onboarded or unassigned devices is the reserved `DEFAULT` device,

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -2,12 +2,12 @@
 
 Byonk embeds all screens, fonts, and configuration in the binary itself. This means you can run Byonk with zero configuration - it works out of the box.
 
-For customization, Byonk uses a YAML configuration file to map devices to screens and to register screen packages.
+For customization, Byonk uses a YAML configuration file to map devices to screens and to register screen repos.
 
-## Screens are packages, not config entries
+## Screens live in screen repos, not config entries
 
 There is **no `screens:` block** in `config.yaml`. A screen is a **folder** inside a screen
-package — a directory tree with a `byonk-screens.yaml` manifest at its root, where every
+repo — a directory tree with a `byonk-screens.yaml` manifest at its root, where every
 folder containing a `meta.yaml` is a screen. Each screen folder holds three fixed-name files:
 
 | File | Purpose |
@@ -18,8 +18,8 @@ folder containing a `meta.yaml` is a screen. Each screen folder holds three fixe
 
 Byonk auto-discovers these screens; you reference one by its **`handle/path`** ref (e.g.
 `byonk-builtin/useful/swiss-departure-board`). The bundled screens ship in the embedded
-`byonk-builtin` package. See [Your First Screen](../tutorial/first-screen.md) for how to
-author one, and [Admin API](../api/admin-api.md) for the package/screen listing endpoints.
+`byonk-builtin` screen repo. See [Your First Screen](../tutorial/first-screen.md) for how to
+author one, and [Admin API](../api/admin-api.md) for the screen repo/screen listing endpoints.
 
 ## Configuration Structure
 
@@ -41,9 +41,9 @@ devices:
   DEFAULT:
     screen: byonk-builtin/default
 
-# Optional: register additional screen packages (see below)
-packages:
-  byonk-builtin: {}                                  # the embedded built-in package
+# Optional: register additional screen repos (see below)
+screen_repos:
+  byonk-builtin: {}                                  # the embedded built-in screen repo
 ```
 
 ## Devices Section
@@ -132,14 +132,14 @@ If `devices.DEFAULT` is omitted, byonk falls back to its embedded
 `byonk-builtin/default` screen — a code-level fallback that always resolves, so
 there's no configuration state that leaves a device with nothing to show.
 
-## Packages Section
+## Screen Repos Section
 
-Screens are distributed as packages. The `packages:` block maps a short **handle** to a
-package source. The embedded `byonk-builtin` package is always available; register additional
-packages by repo and pin:
+Screens are distributed as screen repos. The `screen_repos:` block maps a short **handle** to
+a screen repo source. The embedded `byonk-builtin` screen repo is always available; register
+additional screen repos by repo and pin:
 
 ```yaml
-packages:
+screen_repos:
   byonk-builtin: {}                                       # embedded built-in (always present)
   weather:      { repo: https://github.com/acme/screens, pin: v1.4.0 }
   weather-beta: { repo: https://github.com/acme/screens, pin: v2.0.0 }  # same repo, different pin
@@ -153,8 +153,8 @@ packages:
 | `token` | No | Auth token for private repos (redacted in read APIs). |
 
 A screen ref's first segment is the handle: `weather/forecast` resolves the `forecast` screen
-in the `weather` package. Registering the same repo under two handles at different pins lets
-you run two versions side by side.
+in the `weather` screen repo. Registering the same repo under two handles at different pins
+lets you run two versions side by side.
 
 ## Device Registration
 
@@ -262,7 +262,7 @@ The `auth_mode` setting controls what `/api/setup` tells devices. The `/api/disp
 Byonk loads a screen's `script.lua` and `screen.svg` fresh on every request. You can edit
 those files without restarting the server.
 
-However, `config.yaml` is only loaded at startup. Changes to device mappings, the package
+However, `config.yaml` is only loaded at startup. Changes to device mappings, the screen repo
 registry, or other settings require a server restart (or use the [Admin API](../api/admin-api.md),
 which hot-reloads after writes).
 

--- a/docs/src/guide/ha-addon.md
+++ b/docs/src/guide/ha-addon.md
@@ -25,13 +25,13 @@ to `http://<your-home-assistant-host>:3000`.
 | `admin_token` | *(blank)* | **Leave blank.** Managed automatically by the Byonk integration. While blank, the management API is disabled — serving screens is unaffected. |
 | `log_level` | `info` | Server log verbosity (`trace`/`debug`/`info`/`warn`/`error`). |
 | `auth_mode` | `api_key` | Device authentication mode (`api_key` or `ed25519`). |
-| `package_refresh_interval` | `0` | Seconds between automatic screen-package refreshes (`0` = disabled — refresh only via the integration's **Update packages** button). |
-| `packages` | *(empty)* | The screen-package registry: a repeatable list of `handle` / `repo` / `pin` (branch, tag, or commit SHA) / `token` (optional, for private repos) rows — add one row per remote package. |
+| `screen_repo_refresh_interval` | `0` | Seconds between automatic screen repo refreshes (`0` = disabled — refresh only via the integration's **Update screen repos** button). |
+| `screen_repos` | *(empty)* | The screen repo registry: a repeatable list of `handle` / `repo` / `pin` (branch, tag, or commit SHA) / `token` (optional, for private repos) rows — add one row per remote screen repo. |
 
-## Global configuration: settings and screen packages
+## Global configuration: settings and screen repos
 
 **This Configuration tab is the source of truth for Byonk's server-global
-configuration** — `auth_mode`, `package_refresh_interval`, and the screen-package
+configuration** — `auth_mode`, `screen_repo_refresh_interval`, and the screen repo
 registry. Home Assistant Supervisor writes your changes to `/data/options.json`,
 and Byonk reads them back on startup.
 
@@ -39,13 +39,13 @@ and Byonk reads them back on startup.
 (this is a Home Assistant Supervisor limitation, not a Byonk one). Restart the
 add-on after saving to apply a change. The restart is quick, per-device screen
 mappings are unaffected (they're Byonk's own persisted state), and already-fetched
-package checkouts are cached on disk, so unchanged packages are not re-fetched.
+screen repo checkouts are cached on disk, so unchanged screen repos are not re-fetched.
 
 While running as the add-on, these settings are **read-only over the admin API** —
 attempts to change them there (including from the Byonk integration) are rejected
 with a 409 pointing back to this Configuration tab. This tab is the only editor.
 Per-device screen/dither/panel assignment and the two live operational controls
-(the registration switch, the "Update packages" button) are unaffected and
+(the registration switch, the "Update screen repos" button) are unaffected and
 continue to work from the [Byonk integration](ha-integration.md).
 
 ## Configuration, screens, and fonts
@@ -56,8 +56,8 @@ editor** or **Studio Code Server** add-on. Empty folders are seeded with the
 embedded defaults on first start. Edits to `config.yaml` are applied without a
 restart.
 
-> **Note:** while running as the add-on, the `packages:` section and the
-> `auth_mode` / `package_refresh_interval` settings in `config.yaml` are
+> **Note:** while running as the add-on, the `screen_repos:` section and the
+> `auth_mode` / `screen_repo_refresh_interval` settings in `config.yaml` are
 > **ignored** — those come from the Configuration tab above instead. `config.yaml`
 > still supplies everything else: per-device mappings (`devices:`, normally
 > managed by the [Byonk integration](ha-integration.md)), including the reserved
@@ -65,16 +65,16 @@ restart.
 > displays — set live from the **Byonk Default** device's Screen select in the
 > [Byonk integration](ha-integration.md), no restart needed.
 
-## Screen package cache persistence
+## Screen repo cache persistence
 
-If the `packages` list in the Configuration tab above references remote
-(git-backed) screen packages, their fetched git checkouts are cached on disk.
-The add-on ships with `PACKAGES_CACHE_DIR=/data/packages` set in its manifest —
+If the `screen_repos` list in the Configuration tab above references remote
+(git-backed) screen repos, their fetched git checkouts are cached on disk.
+The add-on ships with `SCREEN_REPOS_CACHE_DIR=/data/packages` set in its manifest —
 `/data` is the add-on's automatically-persistent private storage — so the cache
-survives restarts and rebuilds and packages are not re-fetched every boot. You
+survives restarts and rebuilds and screen repos are not re-fetched every boot. You
 do not need to configure anything.
 
-(For reference: when `PACKAGES_CACHE_DIR` is unset, byonk falls back to a
+(For reference: when `SCREEN_REPOS_CACHE_DIR` is unset, byonk falls back to a
 temp directory, so every fetched checkout would be lost and re-fetched on each
 restart. The shipped add-on sets it, so this caveat does not apply here.)
 
@@ -83,8 +83,8 @@ restart. The shipped add-on sets it, so this caveat does not apply here.)
 A companion Home Assistant **[integration](ha-integration.md)** establishes trust
 with Byonk automatically — you will not need to copy or set any token by hand —
 and manages per-device screen/dither/panel mappings from the Home Assistant UI.
-It also surfaces read-only monitoring for the config you set here (per-package
+It also surfaces read-only monitoring for the config you set here (per-screen-repo
 status sensors) and two live operational controls (a registration switch and an
-"Update packages" button). It does **not** edit `auth_mode`,
-`package_refresh_interval`, or the package registry — those are only editable
+"Update screen repos" button). It does **not** edit `auth_mode`,
+`screen_repo_refresh_interval`, or the screen repo registry — those are only editable
 here, in the add-on's Configuration tab.

--- a/docs/src/guide/ha-integration.md
+++ b/docs/src/guide/ha-integration.md
@@ -4,11 +4,11 @@ The Byonk Home Assistant integration connects Home Assistant to a Byonk server r
 as a Supervisor add-on. It manages the add-on lifecycle, provisions authentication
 automatically, and exposes Byonk devices as Home Assistant entities.
 
-Byonk's server-**global** configuration — `auth_mode`, `package_refresh_interval`,
-and the screen-package registry — is edited in the
+Byonk's server-**global** configuration — `auth_mode`, `screen_repo_refresh_interval`,
+and the screen repo registry — is edited in the
 **[Byonk add-on's Configuration tab](ha-addon.md)**, not here. This integration is
-read-only monitoring for that global config (per-package status sensors), plus two
-live operational controls (a registration switch and an "Update packages" button)
+read-only monitoring for that global config (per-screen-repo status sensors), plus two
+live operational controls (a registration switch and an "Update screen repos" button)
 and full read/write control over **per-device** screen/dither/panel/parameter
 assignment.
 
@@ -48,10 +48,10 @@ assignment.
 | Entity | Type | Description |
 |--------|------|-------------|
 | Registration enabled | Switch | Allow new TRMNL devices to register |
-| Update packages | Button | Trigger an immediate refresh of all screen packages (see below) |
-| *Package status* (one per package) | Sensor | Diagnostic sensor per non-builtin screen package — see *Monitoring screen packages* below |
+| Update screen repos | Button | Trigger an immediate refresh of all screen repos (see below) |
+| *Screen repo status* (one per screen repo) | Sensor | Diagnostic sensor per non-builtin screen repo — see *Monitoring screen repos* below |
 
-The remaining server-global settings — `auth_mode` and `package_refresh_interval` —
+The remaining server-global settings — `auth_mode` and `screen_repo_refresh_interval` —
 are **not** exposed as entities here; they're edited in the
 [Byonk add-on's Configuration tab](ha-addon.md) (changes apply on add-on restart).
 
@@ -120,24 +120,30 @@ when you change the device's screen.
 the usual way (device card → pencil icon) and byonk will mirror the name automatically
 when you rename the device in Home Assistant. No changes are needed in byonk's config directly.
 
-## Monitoring Screen Packages
+## Monitoring Screen Repos
 
-Screen packages (see [Packages Section](configuration.md#packages-section) in
+Screen repos (see [Screen Repos Section](configuration.md#screen-repos-section) in
 the Configuration guide) are **added, edited, and removed in the
 [Byonk add-on's Configuration tab](ha-addon.md)** — not here. This integration
 gives you read-only monitoring and one operational control:
 
-Each package gets a diagnostic **status sensor** (e.g.
+Each screen repo gets a diagnostic **status sensor** (e.g.
 `sensor.byonk_disttest_status`) on the *Byonk Server* hub device, whose state is
 the fetch status (`fetching`, `ready`, `error`, ...) and whose attributes include
 the resolved commit (`resolved_sha`), `last_fetched` time, `repo`, `pin`, and any
 `error`.
 
-Press the hub device's **Update packages** button to trigger an immediate
-content refresh of every already-configured package (a git pull on the existing
-pin — equivalent to waiting for the `package_refresh_interval` set in the add-on's
+When a screen repo fails to fetch, the integration raises a Home Assistant
+**Repair** issue (**Settings → System → Repairs**) carrying the fetch error, so a
+broken screen repo surfaces visibly rather than only in the status sensor's
+attributes. The issue clears automatically once the screen repo fetches
+successfully again.
+
+Press the hub device's **Update screen repos** button to trigger an immediate
+content refresh of every already-configured screen repo (a git pull on the existing
+pin — equivalent to waiting for the `screen_repo_refresh_interval` set in the add-on's
 Configuration tab); the status sensors update once the fetch completes. This
-button does not add, remove, or repin packages — only the add-on Configuration
+button does not add, remove, or repin screen repos — only the add-on Configuration
 tab does that.
 
 ## Re-authentication

--- a/homeassistant/byonk/config.yaml
+++ b/homeassistant/byonk/config.yaml
@@ -19,19 +19,19 @@ environment:
   SCREENS_DIR: /config/screens
   FONTS_DIR: /config/fonts
   BIND_ADDR: 0.0.0.0:3000
-  PACKAGES_CACHE_DIR: /data/packages
+  SCREEN_REPOS_CACHE_DIR: /data/packages
 options:
   admin_token: ""
   log_level: info
   auth_mode: api_key
-  package_refresh_interval: 0
-  packages: []
+  screen_repo_refresh_interval: 0
+  screen_repos: []
 schema:
   admin_token: "password?"
   log_level: "list(trace|debug|info|warn|error)"
   auth_mode: "list(api_key|ed25519)"
-  package_refresh_interval: "int(0,)"
-  packages:
+  screen_repo_refresh_interval: "int(0,)"
+  screen_repos:
     - handle: "str"
       repo: "str"
       pin: "str?"

--- a/src/addon_options.rs
+++ b/src/addon_options.rs
@@ -10,14 +10,14 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::models::config::PackageRef;
+use crate::models::config::ScreenRepoRef;
 use crate::models::AppConfig;
 
-/// One package entry as it appears in the add-on options `packages:` list.
+/// One screen repo entry as it appears in the add-on options `screen_repos:` list.
 /// The handle is a field here (HAOS list rows are flat objects); byonk stores
-/// packages keyed by handle, so `apply_to_config` folds these into a map.
+/// screen repos keyed by handle, so `apply_to_config` folds these into a map.
 #[derive(Debug, Clone, Default, Deserialize)]
-pub struct AddonPackage {
+pub struct AddonScreenRepo {
     #[serde(default)]
     pub handle: String,
     #[serde(default)]
@@ -38,9 +38,9 @@ pub struct AddonOptions {
     #[serde(default)]
     pub auth_mode: Option<String>,
     #[serde(default)]
-    pub package_refresh_interval: Option<u64>,
+    pub screen_repo_refresh_interval: Option<u64>,
     #[serde(default)]
-    pub packages: Vec<AddonPackage>,
+    pub screen_repos: Vec<AddonScreenRepo>,
 }
 
 /// Outcome of attempting to read the options file.
@@ -138,21 +138,21 @@ pub fn apply_to_config(result: &ReadResult, config: &mut AppConfig) {
                 config.auth_mode = mode.to_string();
             }
         }
-        if let Some(interval) = opts.package_refresh_interval {
-            config.package_refresh_interval = interval;
+        if let Some(interval) = opts.screen_repo_refresh_interval {
+            config.screen_repo_refresh_interval = interval;
         }
 
-        // In add-on mode the package registry is taken authoritatively from
-        // options.json: it always replaces config.packages, so an empty list
+        // In add-on mode the screen repo registry is taken authoritatively from
+        // options.json: it always replaces config.screen_repos, so an empty list
         // clears any pre-existing registry.
-        config.packages = opts
-            .packages
+        config.screen_repos = opts
+            .screen_repos
             .iter()
             .filter(|p| !p.handle.trim().is_empty())
             .map(|p| {
                 (
                     p.handle.trim().to_string(),
-                    PackageRef {
+                    ScreenRepoRef {
                         repo: p.repo.clone(),
                         pin: p.pin.clone(),
                         token: p.token.clone(),
@@ -222,8 +222,8 @@ mod tests {
             admin_token: None,
             log_level: Some("info".to_string()),
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         assert_eq!(
             log_filter(&r).as_deref(),
@@ -237,8 +237,8 @@ mod tests {
             admin_token: None,
             log_level: Some("verbose".to_string()),
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         assert_eq!(log_filter(&unknown), None);
         assert_eq!(log_filter(&ReadResult::Missing), None);
@@ -250,8 +250,8 @@ mod tests {
             admin_token: Some("secret".to_string()),
             log_level: None,
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         let mut config = embedded_config();
         config.admin.token = None;
@@ -268,8 +268,8 @@ mod tests {
             admin_token: Some("   ".to_string()),
             log_level: None,
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         let mut config = embedded_config();
         config.admin.token = Some("stale".to_string());
@@ -283,8 +283,8 @@ mod tests {
             admin_token: None,
             log_level: Some("info".to_string()),
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         let mut config = embedded_config();
         config.admin.token = Some("stale".to_string());
@@ -315,8 +315,8 @@ mod tests {
             admin_token: None,
             log_level: Some("verbose".to_string()),
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         assert_eq!(invalid_log_level(&unknown).as_deref(), Some("verbose"));
 
@@ -324,8 +324,8 @@ mod tests {
             admin_token: None,
             log_level: Some("info".to_string()),
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         assert_eq!(invalid_log_level(&valid), None);
 
@@ -333,8 +333,8 @@ mod tests {
             admin_token: None,
             log_level: Some("  ".to_string()),
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         assert_eq!(invalid_log_level(&blank), None);
 
@@ -342,8 +342,8 @@ mod tests {
             admin_token: None,
             log_level: None,
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         assert_eq!(invalid_log_level(&absent), None);
         assert_eq!(invalid_log_level(&ReadResult::Missing), None);
@@ -358,8 +358,8 @@ mod tests {
             r#"{
                 "admin_token":"secret",
                 "auth_mode":"ed25519",
-                "package_refresh_interval":900,
-                "packages":[
+                "screen_repo_refresh_interval":900,
+                "screen_repos":[
                     {"handle":"disttest","repo":"https://example.com/x.git","pin":"main","token":"gh_x"},
                     {"handle":"nopin","repo":"https://example.com/y.git"}
                 ]
@@ -369,12 +369,12 @@ mod tests {
         match read_options(&path) {
             ReadResult::Parsed(opts) => {
                 assert_eq!(opts.auth_mode.as_deref(), Some("ed25519"));
-                assert_eq!(opts.package_refresh_interval, Some(900));
-                assert_eq!(opts.packages.len(), 2);
-                assert_eq!(opts.packages[0].handle, "disttest");
-                assert_eq!(opts.packages[0].pin.as_deref(), Some("main"));
-                assert_eq!(opts.packages[1].pin, None);
-                assert_eq!(opts.packages[1].token, None);
+                assert_eq!(opts.screen_repo_refresh_interval, Some(900));
+                assert_eq!(opts.screen_repos.len(), 2);
+                assert_eq!(opts.screen_repos[0].handle, "disttest");
+                assert_eq!(opts.screen_repos[0].pin.as_deref(), Some("main"));
+                assert_eq!(opts.screen_repos[1].pin, None);
+                assert_eq!(opts.screen_repos[1].token, None);
             }
             other => panic!("expected Parsed, got {other:?}"),
         }
@@ -386,8 +386,8 @@ mod tests {
             admin_token: Some("t".to_string()),
             log_level: None,
             auth_mode: Some("ed25519".to_string()),
-            package_refresh_interval: Some(600),
-            packages: vec![AddonPackage {
+            screen_repo_refresh_interval: Some(600),
+            screen_repos: vec![AddonScreenRepo {
                 handle: "disttest".to_string(),
                 repo: Some("https://example.com/x.git".to_string()),
                 pin: Some("main".to_string()),
@@ -397,8 +397,11 @@ mod tests {
         let mut config = embedded_config();
         apply_to_config(&r, &mut config);
         assert_eq!(config.auth_mode, "ed25519");
-        assert_eq!(config.package_refresh_interval, 600);
-        let pkg = config.packages.get("disttest").expect("package present");
+        assert_eq!(config.screen_repo_refresh_interval, 600);
+        let pkg = config
+            .screen_repos
+            .get("disttest")
+            .expect("screen repo present");
         assert_eq!(pkg.repo.as_deref(), Some("https://example.com/x.git"));
         assert_eq!(pkg.pin.as_deref(), Some("main"));
         assert_eq!(pkg.token.as_deref(), Some("gh_x"));
@@ -407,21 +410,21 @@ mod tests {
     #[test]
     fn apply_preserves_absent_settings_but_clears_packages() {
         // A parsed options file that omits the new keys must not clobber config
-        // defaults (only admin_token and packages are authoritative-on-absence
+        // defaults (only admin_token and screen repos are authoritative-on-absence
         // / authoritative-replace; auth_mode and interval preserve-on-absent).
         let r = ReadResult::Parsed(AddonOptions {
             admin_token: None,
             log_level: None,
             auth_mode: None,
-            package_refresh_interval: None,
-            packages: vec![],
+            screen_repo_refresh_interval: None,
+            screen_repos: vec![],
         });
         let mut config = embedded_config();
         config.auth_mode = "api_key".to_string();
-        config.package_refresh_interval = 42;
-        config.packages.insert(
+        config.screen_repo_refresh_interval = 42;
+        config.screen_repos.insert(
             "stale".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some("https://example.com/stale.git".to_string()),
                 pin: None,
                 token: None,
@@ -433,12 +436,12 @@ mod tests {
             "absent auth_mode keeps config value"
         );
         assert_eq!(
-            config.package_refresh_interval, 42,
+            config.screen_repo_refresh_interval, 42,
             "absent interval keeps config value"
         );
         assert!(
-            config.packages.is_empty(),
-            "empty packages list in Parsed options must clear a pre-existing registry"
+            config.screen_repos.is_empty(),
+            "empty screen repos list in Parsed options must clear a pre-existing registry"
         );
     }
 }

--- a/src/api/admin/mod.rs
+++ b/src/api/admin/mod.rs
@@ -51,12 +51,18 @@ pub fn admin_router() -> Router<AppState> {
         .route("/pending", get(read::pending))
         .route("/config", get(read::get_config))
         .route("/screens", get(read::screens))
-        .route("/packages", get(read::packages).post(write::add_package))
         .route(
-            "/packages/:handle",
-            patch(write::patch_package).delete(write::delete_package),
+            "/screen-repos",
+            get(read::screen_repos).post(write::add_screen_repo),
         )
-        .route("/packages/:handle/update", post(write::update_package))
-        .route("/packages/update", post(write::update_all_packages))
+        .route(
+            "/screen-repos/:handle",
+            patch(write::patch_screen_repo).delete(write::delete_screen_repo),
+        )
+        .route(
+            "/screen-repos/:handle/update",
+            post(write::update_screen_repo),
+        )
+        .route("/screen-repos/update", post(write::update_all_screen_repos))
         .route("/settings", patch(write::patch_settings))
 }

--- a/src/api/admin/read.rs
+++ b/src/api/admin/read.rs
@@ -9,7 +9,7 @@ use crate::models::config::{AppConfig, RESERVED_DEFAULT_KEY};
 use crate::models::param_schema::ParamField;
 use crate::server::AppState;
 use crate::services::git_fetch::PinKind;
-use crate::services::package_status::{PackageState, PackageStatus};
+use crate::services::screen_repo_status::{ScreenRepoState, ScreenRepoStatus};
 use crate::services::DeviceRegistry;
 
 use super::require_admin;
@@ -69,13 +69,13 @@ pub async fn get_config(
         {
             admin.remove(serde_yaml::Value::from("token"));
         }
-        // Strip package tokens — `PackageRef.token` is documented as
+        // Strip screen repo tokens — `ScreenRepoRef.token` is documented as
         // "Secret token; redacted in read APIs".
-        if let Some(packages) = map
-            .get_mut(serde_yaml::Value::from("packages"))
+        if let Some(screen_repos) = map
+            .get_mut(serde_yaml::Value::from("screen_repos"))
             .and_then(|p| p.as_mapping_mut())
         {
-            for (_, pkg) in packages.iter_mut() {
+            for (_, pkg) in screen_repos.iter_mut() {
                 if let Some(pkg_map) = pkg.as_mapping_mut() {
                     pkg_map.remove(serde_yaml::Value::from("token"));
                 }
@@ -200,7 +200,7 @@ pub struct ScreenInfo {
 }
 
 #[derive(Serialize)]
-pub struct PackageScreens {
+pub struct ScreenRepoScreens {
     pub handle: String,
     pub name: String,
     pub description: String,
@@ -219,18 +219,18 @@ pub struct PanelInfo {
 
 #[derive(Serialize)]
 pub struct ScreensResponse {
-    pub packages: Vec<PackageScreens>,
+    pub screen_repos: Vec<ScreenRepoScreens>,
     pub panels: Vec<PanelInfo>,
     pub dither_algorithms: Vec<String>,
 }
 
-/// One entry in the package registry listing (`GET /packages`).
+/// One entry in the screen repo registry listing (`GET /screen-repos`).
 #[derive(Serialize)]
-pub struct PackageInfo {
+pub struct ScreenRepoInfo {
     pub handle: String,
     pub repo: Option<String>,
     pub pin: Option<String>,
-    /// `true` for the embedded builtin or any package without a remote repo.
+    /// `true` for the embedded builtin or any screen repo without a remote repo.
     pub builtin: bool,
     /// Whether an auth token is configured — the token itself is never serialized.
     pub token_set: bool,
@@ -239,9 +239,9 @@ pub struct PackageInfo {
     /// handles report `error` — they are not currently serving.
     pub status: String,
     /// How `pin` was resolved (`sha`/`tag`/`branch`), or `embedded` for the
-    /// builtin package. `None` if never successfully fetched.
+    /// builtin screen repo. `None` if never successfully fetched.
     pub pin_kind: Option<PinKind>,
-    /// The commit sha the package is currently pinned/fetched at.
+    /// The commit sha the screen repo is currently pinned/fetched at.
     pub resolved_sha: Option<String>,
     /// RFC3339 timestamp of the last successful fetch.
     pub last_fetched: Option<String>,
@@ -270,17 +270,17 @@ pub async fn screens(
     require_admin(&state, &headers)?;
     let config = state.config.load();
 
-    // Group every resolved screen by its package handle. The package-level
-    // metadata (name/description/author/license) comes from that package's
+    // Group every resolved screen by its screen repo handle. The screen-repo-level
+    // metadata (name/description/author/license) comes from that screen repo's
     // manifest, read off the first screen encountered for the handle.
     let engine = engine_version();
-    let mut by_handle: std::collections::BTreeMap<String, PackageScreens> =
+    let mut by_handle: std::collections::BTreeMap<String, ScreenRepoScreens> =
         std::collections::BTreeMap::new();
 
-    for screen in state.package_manager.loader().list_all() {
+    for screen in state.screen_repo_manager.loader().list_all() {
         let entry = by_handle.entry(screen.handle.clone()).or_insert_with(|| {
             let m = screen.source.manifest();
-            PackageScreens {
+            ScreenRepoScreens {
                 handle: screen.handle.clone(),
                 name: m.name.clone(),
                 description: m.description.clone(),
@@ -299,8 +299,8 @@ pub async fn screens(
         });
     }
 
-    // Deterministic order: screens within each package sorted by ref.
-    let packages: Vec<PackageScreens> = by_handle
+    // Deterministic order: screens within each screen repo sorted by ref.
+    let screen_repos: Vec<ScreenRepoScreens> = by_handle
         .into_values()
         .map(|mut p| {
             p.screens.sort_by(|a, b| a.r#ref.cmp(&b.r#ref));
@@ -320,16 +320,16 @@ pub async fn screens(
         .collect();
 
     Ok(Json(ScreensResponse {
-        packages,
+        screen_repos,
         panels,
         dither_algorithms: DITHER_ALGORITHMS.iter().map(|s| s.to_string()).collect(),
     }))
 }
 
-/// Build the `PackageInfo` for a single handle from the live config and its
-/// fetch status (from `PackageManager::status_snapshot()`).
+/// Build the `ScreenRepoInfo` for a single handle from the live config and its
+/// fetch status (from `ScreenRepoManager::status_snapshot()`).
 ///
-/// Shared by `packages()` (the read listing) and the package write handlers
+/// Shared by `screen_repos()` (the read listing) and the screen repo write handlers
 /// (`add`/`patch`/`update`), so both surfaces stay in sync.
 ///
 /// Status mapping:
@@ -342,15 +342,15 @@ pub async fn screens(
 ///   registration, before the first refresh runs): `status: "error"`, all
 ///   other fields `None`. It is not currently serving, so `"error"` is the
 ///   honest default.
-pub(crate) fn build_package_info(
+pub(crate) fn build_screen_repo_info(
     config: &AppConfig,
-    status: Option<&PackageStatus>,
+    status: Option<&ScreenRepoStatus>,
     screen_count: usize,
     handle: String,
-) -> PackageInfo {
-    let pkg = config.packages.get(&handle);
+) -> ScreenRepoInfo {
+    let pkg = config.screen_repos.get(&handle);
     let repo = pkg.and_then(|p| p.repo.clone());
-    let builtin = handle == crate::services::package_loader::BUILTIN_HANDLE || repo.is_none();
+    let builtin = handle == crate::services::screen_repo_loader::BUILTIN_HANDLE || repo.is_none();
 
     let (status_str, pin_kind, resolved_sha, last_fetched, error) = if builtin {
         (
@@ -363,12 +363,12 @@ pub(crate) fn build_package_info(
     } else {
         match status {
             Some(s) => {
-                let state = s.state.unwrap_or(PackageState::Error);
+                let state = s.state.unwrap_or(ScreenRepoState::Error);
                 let status_str = match state {
-                    PackageState::Ready => "ready",
-                    PackageState::Fetching => "fetching",
-                    PackageState::Error => "error",
-                    PackageState::Offline => "offline",
+                    ScreenRepoState::Ready => "ready",
+                    ScreenRepoState::Fetching => "fetching",
+                    ScreenRepoState::Error => "error",
+                    ScreenRepoState::Offline => "offline",
                 }
                 .to_string();
                 (
@@ -383,7 +383,7 @@ pub(crate) fn build_package_info(
         }
     };
 
-    PackageInfo {
+    ScreenRepoInfo {
         repo,
         pin: pkg.and_then(|p| p.pin.clone()),
         builtin,
@@ -401,16 +401,16 @@ pub(crate) fn build_package_info(
 #[cfg(test)]
 mod build_package_info_tests {
     use super::*;
-    use crate::models::config::PackageRef;
+    use crate::models::config::ScreenRepoRef;
 
     #[test]
     fn builtin_handle_is_always_ready_and_embedded() {
         let config = AppConfig::default();
-        let info = build_package_info(
+        let info = build_screen_repo_info(
             &config,
             None,
             3,
-            crate::services::package_loader::BUILTIN_HANDLE.to_string(),
+            crate::services::screen_repo_loader::BUILTIN_HANDLE.to_string(),
         );
         assert!(info.builtin);
         assert_eq!(info.status, "ready");
@@ -423,22 +423,22 @@ mod build_package_info_tests {
     #[test]
     fn non_builtin_with_error_status_reports_it() {
         let mut config = AppConfig::default();
-        config.packages.insert(
+        config.screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some("github.com/x/y".to_string()),
                 pin: Some("main".to_string()),
                 token: None,
             },
         );
-        let status = PackageStatus {
-            state: Some(PackageState::Error),
+        let status = ScreenRepoStatus {
+            state: Some(ScreenRepoState::Error),
             resolved_sha: Some("deadbeef".to_string()),
             last_fetched: None,
             error: Some("network unreachable".to_string()),
             pin_kind: Some(PinKind::Branch),
         };
-        let info = build_package_info(&config, Some(&status), 0, "weather".to_string());
+        let info = build_screen_repo_info(&config, Some(&status), 0, "weather".to_string());
         assert!(!info.builtin);
         assert_eq!(info.status, "error");
         assert_eq!(info.pin_kind, Some(PinKind::Branch));
@@ -449,15 +449,15 @@ mod build_package_info_tests {
     #[test]
     fn non_builtin_never_fetched_defaults_to_error() {
         let mut config = AppConfig::default();
-        config.packages.insert(
+        config.screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some("github.com/x/y".to_string()),
                 pin: Some("main".to_string()),
                 token: None,
             },
         );
-        let info = build_package_info(&config, None, 0, "weather".to_string());
+        let info = build_screen_repo_info(&config, None, 0, "weather".to_string());
         assert!(!info.builtin);
         assert_eq!(info.status, "error");
         assert_eq!(info.pin_kind, None);
@@ -466,13 +466,13 @@ mod build_package_info_tests {
         assert_eq!(info.error, None);
     }
 
-    /// A `PackageRef` for a non-builtin handle, so `build_package_info`
+    /// A `ScreenRepoRef` for a non-builtin handle, so `build_screen_repo_info`
     /// exercises the status-mapping branch rather than the builtin shortcut.
     fn config_with_weather() -> AppConfig {
         let mut config = AppConfig::default();
-        config.packages.insert(
+        config.screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some("github.com/x/y".to_string()),
                 pin: Some("main".to_string()),
                 token: None,
@@ -487,14 +487,14 @@ mod build_package_info_tests {
         // entry exists but never reached a terminal state. Most likely to
         // regress silently, so pin it down.
         let config = config_with_weather();
-        let status = PackageStatus {
+        let status = ScreenRepoStatus {
             state: None,
             resolved_sha: Some("abc123".to_string()),
             last_fetched: None,
             error: None,
             pin_kind: Some(PinKind::Tag),
         };
-        let info = build_package_info(&config, Some(&status), 0, "weather".to_string());
+        let info = build_screen_repo_info(&config, Some(&status), 0, "weather".to_string());
         assert_eq!(info.status, "error");
         // Other fields still copy through from the entry.
         assert_eq!(info.pin_kind, Some(PinKind::Tag));
@@ -505,15 +505,15 @@ mod build_package_info_tests {
     fn state_serializes_to_snake_case_status_string() {
         let config = config_with_weather();
         for (state, expected) in [
-            (PackageState::Ready, "ready"),
-            (PackageState::Fetching, "fetching"),
-            (PackageState::Offline, "offline"),
+            (ScreenRepoState::Ready, "ready"),
+            (ScreenRepoState::Fetching, "fetching"),
+            (ScreenRepoState::Offline, "offline"),
         ] {
-            let status = PackageStatus {
+            let status = ScreenRepoStatus {
                 state: Some(state),
                 ..Default::default()
             };
-            let info = build_package_info(&config, Some(&status), 0, "weather".to_string());
+            let info = build_screen_repo_info(&config, Some(&status), 0, "weather".to_string());
             assert_eq!(info.status, expected, "state {state:?}");
         }
     }
@@ -526,12 +526,12 @@ mod build_package_info_tests {
             .unwrap()
             .with_timezone(&Utc);
         let config = config_with_weather();
-        let status = PackageStatus {
-            state: Some(PackageState::Ready),
+        let status = ScreenRepoStatus {
+            state: Some(ScreenRepoState::Ready),
             last_fetched: Some(dt),
             ..Default::default()
         };
-        let info = build_package_info(&config, Some(&status), 0, "weather".to_string());
+        let info = build_screen_repo_info(&config, Some(&status), 0, "weather".to_string());
 
         let rendered = info.last_fetched.expect("last_fetched present");
         // Equals the canonical RFC3339 rendering...
@@ -544,35 +544,35 @@ mod build_package_info_tests {
     }
 }
 
-/// List the registered screen packages. `byonk-builtin` is always present (it is
-/// registered by the package loader even without a `packages:` config entry); any
-/// additional entries come from `config.packages`. The package `token` is never
+/// List the registered screen repos. `byonk-builtin` is always present (it is
+/// registered by the screen repo loader even without a `screen_repos:` config entry); any
+/// additional entries come from `config.screen_repos`. The screen repo `token` is never
 /// serialized — only whether one is set (`token_set`).
-pub async fn packages(
+pub async fn screen_repos(
     State(state): State<AppState>,
     headers: HeaderMap,
-) -> Result<Json<Vec<PackageInfo>>, ApiError> {
+) -> Result<Json<Vec<ScreenRepoInfo>>, ApiError> {
     require_admin(&state, &headers)?;
     let config = state.config.load();
 
-    // Screen counts per handle, from the source of truth (the package loader).
-    let loader = state.package_manager.loader();
+    // Screen counts per handle, from the source of truth (the screen repo loader).
+    let loader = state.screen_repo_manager.loader();
     let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     for screen in loader.list_all() {
         *counts.entry(screen.handle).or_insert(0) += 1;
     }
 
-    // Union of loader-registered handles and configured package handles, so the
-    // always-registered builtin appears and config-only packages are not dropped.
+    // Union of loader-registered handles and configured screen repo handles, so the
+    // always-registered builtin appears and config-only screen repos are not dropped.
     let mut handles: std::collections::BTreeSet<String> = loader.handles().into_iter().collect();
-    handles.extend(config.packages.keys().cloned());
+    handles.extend(config.screen_repos.keys().cloned());
 
-    let statuses = state.package_manager.status_snapshot();
+    let statuses = state.screen_repo_manager.status_snapshot();
     let out = handles
         .into_iter()
         .map(|handle| {
             let count = counts.get(&handle).copied().unwrap_or(0);
-            build_package_info(&config, statuses.get(&handle), count, handle)
+            build_screen_repo_info(&config, statuses.get(&handle), count, handle)
         })
         .collect();
 

--- a/src/api/admin/write.rs
+++ b/src/api/admin/write.rs
@@ -13,9 +13,9 @@ use crate::models::config::RESERVED_DEFAULT_KEY;
 use crate::models::param_schema::validate_params;
 use crate::server::{reload_config, AppState};
 use crate::services::config_writer;
-use crate::services::package_loader::BUILTIN_HANDLE;
+use crate::services::screen_repo_loader::BUILTIN_HANDLE;
 
-use super::read::{build_package_info, PackageInfo};
+use super::read::{build_screen_repo_info, ScreenRepoInfo};
 use super::require_admin;
 
 #[derive(Deserialize)]
@@ -41,7 +41,7 @@ fn require_file_config(state: &AppState) -> Result<std::path::PathBuf, ApiError>
 
 /// Guard: global-config registry/settings writes are read-only when byonk runs
 /// as an HA add-on. The add-on Options form (`/data/options.json`) is the sole
-/// editor for global config; per-device writes and package content-refresh are
+/// editor for global config; per-device writes and screen repo content-refresh are
 /// unaffected.
 fn require_writable_global(state: &AppState) -> Result<(), ApiError> {
     if state.addon_mode {
@@ -55,7 +55,7 @@ fn require_writable_global(state: &AppState) -> Result<(), ApiError> {
 /// In add-on mode, the genuinely-global settings are read-only (edited via the
 /// add-on Options form). The operational `registration_enabled` toggle stays live.
 fn require_writable_settings(state: &AppState, body: &SettingsWrite) -> Result<(), ApiError> {
-    let touches_global = body.auth_mode.is_some() || body.package_refresh_interval.is_some();
+    let touches_global = body.auth_mode.is_some() || body.screen_repo_refresh_interval.is_some();
     if state.addon_mode && touches_global {
         return Err(ApiError::Conflict(
             "global config is read-only in add-on mode; edit it in the byonk add-on Configuration tab".into(),
@@ -64,16 +64,16 @@ fn require_writable_settings(state: &AppState, body: &SettingsWrite) -> Result<(
     Ok(())
 }
 
-/// Validate the screen ref resolves to a package screen and that the provided
+/// Validate the screen ref resolves to a screen repo screen and that the provided
 /// params pass its `meta.yaml` schema. A device `screen` is always a qualified
-/// `handle/path` package ref — there is no bare-name / flat-file resolution.
+/// `handle/path` screen repo ref — there is no bare-name / flat-file resolution.
 fn validate_screen_and_params(
     state: &AppState,
     screen: &str,
     params: &HashMap<String, serde_yaml::Value>,
 ) -> Result<(), ApiError> {
     let resolved = state
-        .package_manager
+        .screen_repo_manager
         .loader()
         .resolve(screen)
         .ok_or_else(|| ApiError::BadRequest(format!("unknown screen `{screen}`")))?;
@@ -275,7 +275,7 @@ pub async fn delete_device(
 pub struct SettingsWrite {
     pub(crate) registration_enabled: Option<bool>,
     pub(crate) auth_mode: Option<String>,
-    pub(crate) package_refresh_interval: Option<u64>,
+    pub(crate) screen_repo_refresh_interval: Option<u64>,
 }
 
 pub async fn patch_settings(
@@ -310,8 +310,8 @@ pub async fn patch_settings(
         yaml = config_writer::set_scalar(&yaml, &["auth_mode"], mode.as_str().into())
             .map_err(|e| ApiError::Internal(e.to_string()))?;
     }
-    if let Some(secs) = body.package_refresh_interval {
-        yaml = config_writer::set_scalar(&yaml, &["package_refresh_interval"], secs.into())
+    if let Some(secs) = body.screen_repo_refresh_interval {
+        yaml = config_writer::set_scalar(&yaml, &["screen_repo_refresh_interval"], secs.into())
             .map_err(|e| ApiError::Internal(e.to_string()))?;
     }
 
@@ -321,7 +321,7 @@ pub async fn patch_settings(
 }
 
 #[derive(Deserialize)]
-pub struct PackageWrite {
+pub struct ScreenRepoWrite {
     pub handle: Option<String>,
     pub repo: Option<String>,
     pub pin: Option<String>,
@@ -330,9 +330,9 @@ pub struct PackageWrite {
 
 /// Number of screens currently resolved under `handle` (0 before the first
 /// successful fetch, since nothing is registered in the loader yet).
-fn package_screen_count(state: &AppState, handle: &str) -> usize {
+fn screen_repo_screen_count(state: &AppState, handle: &str) -> usize {
     state
-        .package_manager
+        .screen_repo_manager
         .loader()
         .list_all()
         .into_iter()
@@ -340,9 +340,9 @@ fn package_screen_count(state: &AppState, handle: &str) -> usize {
         .count()
 }
 
-/// Build a `serde_yaml::Mapping` package block from the given fields, omitting
+/// Build a `serde_yaml::Mapping` screen repo block from the given fields, omitting
 /// any that are `None` (so e.g. an absent `token` is never written as `null`).
-fn package_block(
+fn screen_repo_block(
     repo: Option<&str>,
     pin: Option<&str>,
     token: Option<&str>,
@@ -360,11 +360,11 @@ fn package_block(
     m
 }
 
-pub async fn add_package(
+pub async fn add_screen_repo(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(body): Json<PackageWrite>,
-) -> Result<Json<PackageInfo>, ApiError> {
+    Json(body): Json<ScreenRepoWrite>,
+) -> Result<Json<ScreenRepoInfo>, ApiError> {
     require_writable_global(&state)?;
     require_admin(&state, &headers)?;
     let path = require_file_config(&state)?;
@@ -377,16 +377,16 @@ pub async fn add_package(
 
     if handle == BUILTIN_HANDLE {
         return Err(ApiError::Conflict(format!(
-            "`{handle}` is the reserved builtin package handle"
+            "`{handle}` is the reserved builtin screen repo handle"
         )));
     }
-    if state.config.load().packages.contains_key(&handle) {
+    if state.config.load().screen_repos.contains_key(&handle) {
         return Err(ApiError::Conflict(format!(
-            "package `{handle}` already exists"
+            "screen repo `{handle}` already exists"
         )));
     }
 
-    let block = package_block(
+    let block = screen_repo_block(
         body.repo.as_deref(),
         body.pin.as_deref(),
         body.token.as_deref(),
@@ -395,29 +395,29 @@ pub async fn add_package(
         .asset_loader
         .read_config_string()
         .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let new_yaml = config_writer::upsert_package(&yaml, &handle, &block)
+    let new_yaml = config_writer::upsert_screen_repo(&yaml, &handle, &block)
         .map_err(|e| ApiError::Internal(e.to_string()))?;
     persist(&state, &path, new_yaml)?;
 
     // Fetch asynchronously; the response reflects whatever status exists at
-    // this instant (likely no entry yet). The client polls GET /packages for
+    // this instant (likely no entry yet). The client polls GET /screen-repos for
     // the settled result rather than this handler awaiting the fetch.
-    let mgr = state.package_manager.clone();
+    let mgr = state.screen_repo_manager.clone();
     let h = handle.clone();
     tokio::task::spawn_blocking(move || mgr.refresh_one(&h));
 
-    let count = package_screen_count(&state, &handle);
-    let statuses = state.package_manager.status_snapshot();
-    let info = build_package_info(&state.config.load(), statuses.get(&handle), count, handle);
+    let count = screen_repo_screen_count(&state, &handle);
+    let statuses = state.screen_repo_manager.status_snapshot();
+    let info = build_screen_repo_info(&state.config.load(), statuses.get(&handle), count, handle);
     Ok(Json(info))
 }
 
-pub async fn patch_package(
+pub async fn patch_screen_repo(
     State(state): State<AppState>,
     Path(handle): Path<String>,
     headers: HeaderMap,
-    Json(body): Json<PackageWrite>,
-) -> Result<Json<PackageInfo>, ApiError> {
+    Json(body): Json<ScreenRepoWrite>,
+) -> Result<Json<ScreenRepoInfo>, ApiError> {
     require_writable_global(&state)?;
     require_admin(&state, &headers)?;
     let path = require_file_config(&state)?;
@@ -425,14 +425,14 @@ pub async fn patch_package(
 
     if handle == BUILTIN_HANDLE {
         return Err(ApiError::Conflict(format!(
-            "`{handle}` is the reserved builtin package handle"
+            "`{handle}` is the reserved builtin screen repo handle"
         )));
     }
 
     let existing = state
         .config
         .load()
-        .packages
+        .screen_repos
         .get(&handle)
         .cloned()
         .ok_or(ApiError::NotFound)?;
@@ -445,28 +445,28 @@ pub async fn patch_package(
     let repo_or_pin_changed = (body.repo.is_some() && body.repo != existing.repo)
         || (body.pin.is_some() && body.pin != existing.pin);
 
-    let block = package_block(repo.as_deref(), pin.as_deref(), token.as_deref());
+    let block = screen_repo_block(repo.as_deref(), pin.as_deref(), token.as_deref());
     let yaml = state
         .asset_loader
         .read_config_string()
         .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let new_yaml = config_writer::upsert_package(&yaml, &handle, &block)
+    let new_yaml = config_writer::upsert_screen_repo(&yaml, &handle, &block)
         .map_err(|e| ApiError::Internal(e.to_string()))?;
     persist(&state, &path, new_yaml)?;
 
     if repo_or_pin_changed {
-        let mgr = state.package_manager.clone();
+        let mgr = state.screen_repo_manager.clone();
         let h = handle.clone();
         tokio::task::spawn_blocking(move || mgr.refresh_one(&h));
     }
 
-    let count = package_screen_count(&state, &handle);
-    let statuses = state.package_manager.status_snapshot();
-    let info = build_package_info(&state.config.load(), statuses.get(&handle), count, handle);
+    let count = screen_repo_screen_count(&state, &handle);
+    let statuses = state.screen_repo_manager.status_snapshot();
+    let info = build_screen_repo_info(&state.config.load(), statuses.get(&handle), count, handle);
     Ok(Json(info))
 }
 
-pub async fn delete_package(
+pub async fn delete_screen_repo(
     State(state): State<AppState>,
     Path(handle): Path<String>,
     headers: HeaderMap,
@@ -478,11 +478,11 @@ pub async fn delete_package(
 
     if handle == BUILTIN_HANDLE {
         return Err(ApiError::Conflict(format!(
-            "`{handle}` is the reserved builtin package handle"
+            "`{handle}` is the reserved builtin screen repo handle"
         )));
     }
 
-    // Reject if any device's screen dangles into this package's namespace.
+    // Reject if any device's screen dangles into this screen repo's namespace.
     let prefix = format!("{handle}/");
     let config = state.config.load();
     if let Some((device_key, _)) = config
@@ -492,7 +492,7 @@ pub async fn delete_package(
         .map(|(k, d)| (k.clone(), d.screen.clone()))
     {
         return Err(ApiError::Conflict(format!(
-            "package `{handle}` is referenced by device `{device_key}`"
+            "screen repo `{handle}` is referenced by device `{device_key}`"
         )));
     }
     drop(config);
@@ -501,7 +501,7 @@ pub async fn delete_package(
         .asset_loader
         .read_config_string()
         .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let new_yaml = match config_writer::remove_package(&yaml, &handle) {
+    let new_yaml = match config_writer::remove_screen_repo(&yaml, &handle) {
         Ok(y) => y,
         Err(config_writer::ConfigWriteError::NotFound(_)) => return Err(ApiError::NotFound),
         Err(e) => return Err(ApiError::Internal(e.to_string())),
@@ -510,43 +510,43 @@ pub async fn delete_package(
 
     // Forget the deleted handle's fetch status so a later re-registration of
     // the same handle doesn't briefly surface the stale resolved_sha/Ready
-    // state left over from the deleted package.
-    state.package_manager.forget_status(&handle);
+    // state left over from the deleted screen repo.
+    state.screen_repo_manager.forget_status(&handle);
     // Rebuild the hot-swapped loader so the deleted handle's screens stop
     // resolving immediately (in-memory only; not blocking).
-    state.package_manager.rebuild_loader();
+    state.screen_repo_manager.rebuild_loader();
 
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
-pub async fn update_package(
+pub async fn update_screen_repo(
     State(state): State<AppState>,
     Path(handle): Path<String>,
     headers: HeaderMap,
-) -> Result<Json<PackageInfo>, ApiError> {
+) -> Result<Json<ScreenRepoInfo>, ApiError> {
     require_admin(&state, &headers)?;
 
-    if handle != BUILTIN_HANDLE && !state.config.load().packages.contains_key(&handle) {
+    if handle != BUILTIN_HANDLE && !state.config.load().screen_repos.contains_key(&handle) {
         return Err(ApiError::NotFound);
     }
 
-    let mgr = state.package_manager.clone();
+    let mgr = state.screen_repo_manager.clone();
     let h = handle.clone();
     tokio::task::spawn_blocking(move || mgr.refresh_one(&h));
 
-    let count = package_screen_count(&state, &handle);
-    let statuses = state.package_manager.status_snapshot();
-    let info = build_package_info(&state.config.load(), statuses.get(&handle), count, handle);
+    let count = screen_repo_screen_count(&state, &handle);
+    let statuses = state.screen_repo_manager.status_snapshot();
+    let info = build_screen_repo_info(&state.config.load(), statuses.get(&handle), count, handle);
     Ok(Json(info))
 }
 
-pub async fn update_all_packages(
+pub async fn update_all_screen_repos(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     require_admin(&state, &headers)?;
 
-    let mgr = state.package_manager.clone();
+    let mgr = state.screen_repo_manager.clone();
     tokio::task::spawn_blocking(move || mgr.refresh_all(true));
 
     Ok(Json(serde_json::json!({ "ok": true })))
@@ -587,7 +587,7 @@ mod tests {
         SettingsWrite {
             registration_enabled: Some(true),
             auth_mode: None,
-            package_refresh_interval: None,
+            screen_repo_refresh_interval: None,
         }
     }
 
@@ -618,7 +618,7 @@ mod tests {
         let body = SettingsWrite {
             registration_enabled: Some(false),
             auth_mode: Some("ed25519".to_string()),
-            package_refresh_interval: Some(300),
+            screen_repo_refresh_interval: Some(300),
         };
         assert!(require_writable_settings(&state, &body).is_ok());
     }

--- a/src/api/dev.rs
+++ b/src/api/dev.rs
@@ -22,7 +22,7 @@ use tokio_stream::StreamExt;
 use crate::assets::AssetLoader;
 use crate::models::{AppConfig, DisplaySpec};
 use crate::server::DevOverrides;
-use crate::services::package_manager::PackageManager;
+use crate::services::screen_repo_manager::ScreenRepoManager;
 use crate::services::{ContentCache, ContentPipeline, DeviceContext, FileWatcher, RenderService};
 
 /// Dev mode application state
@@ -34,7 +34,7 @@ pub struct DevState {
     pub renderer: Arc<RenderService>,
     pub file_watcher: Arc<FileWatcher>,
     pub asset_loader: Arc<AssetLoader>,
-    pub package_manager: Arc<PackageManager>,
+    pub screen_repo_manager: Arc<ScreenRepoManager>,
     pub dev_overrides: DevOverrides,
 }
 
@@ -180,11 +180,11 @@ pub async fn handle_dev_js() -> impl IntoResponse {
 /// Config-defined screens are included first, then any filesystem screens not in config
 /// are auto-discovered. This allows new screens to appear without restarting the server.
 pub async fn handle_screens(State(state): State<DevState>) -> Json<ScreensResponse> {
-    // Every screen comes from the package loader (the source of truth). The
+    // Every screen comes from the screen repo loader (the source of truth). The
     // `name` is the qualified `handle/path` ref the dev UI feeds back into
     // `?screen=<ref>`; script/template are informational only.
     let mut screens: Vec<ScreenInfo> = state
-        .package_manager
+        .screen_repo_manager
         .loader()
         .list_all()
         .into_iter()
@@ -358,7 +358,7 @@ pub async fn handle_render(
             .or_else(|| state.config.get_device_config_for_code(mac))
         {
             Some(dc) => {
-                // The device's `screen` is a `handle/path` package ref.
+                // The device's `screen` is a `handle/path` screen repo ref.
                 // Convert device params to JSON
                 let params: HashMap<String, serde_json::Value> = yaml_params_to_json(&dc.params);
                 (
@@ -385,7 +385,7 @@ pub async fn handle_render(
             }
         }
     } else if let Some(ref screen_name) = query.screen {
-        // `screen_name` is a `handle/path` package ref; validity is checked when
+        // `screen_name` is a `handle/path` screen repo ref; validity is checked when
         // the pipeline resolves it below.
         (
             screen_name.clone(),

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -552,7 +552,7 @@ mod tests {
         let screens = loader.list_screens();
         assert!(!screens.is_empty());
 
-        // Should include the migrated hello screen's package files
+        // Should include the migrated hello screen's screen repo files
         assert!(screens.iter().any(|s| s == "example/hello/script.lua"));
         assert!(screens.iter().any(|s| s == "example/hello/screen.svg"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,10 +199,10 @@ fn run_render_command(
     let renderer = Arc::new(RenderService::new(&asset_loader)?);
     let shared: byonk::server::SharedConfig =
         std::sync::Arc::new(arc_swap::ArcSwap::from(config.clone()));
-    let package_manager =
-        byonk::server::build_package_manager(asset_loader.clone(), shared.clone());
+    let screen_repo_manager =
+        byonk::server::build_screen_repo_manager(asset_loader.clone(), shared.clone());
     let content_pipeline = Arc::new(
-        ContentPipeline::new(shared, asset_loader, renderer.clone(), package_manager)
+        ContentPipeline::new(shared, asset_loader, renderer.clone(), screen_repo_manager)
             .expect("Failed to initialize content pipeline"),
     );
 
@@ -685,44 +685,44 @@ async fn run_server() -> anyhow::Result<()> {
     // admin writes to read-only (the add-on Options form is the sole editor).
     state.addon_mode = matches!(addon, byonk::addon_options::ReadResult::Parsed(_));
 
-    // Startup package fetch: bring every configured package up to date once at
-    // boot, independent of the periodic interval. Without this, packages are
+    // Startup screen repo fetch: bring every configured screen repo up to date once at
+    // boot, independent of the periodic interval. Without this, screen repos are
     // not fetched on startup and — because the periodic loop below never
-    // refreshes when `package_refresh_interval == 0` (manual mode) — a restart
-    // (add-on update, HA reboot, options change, re-auth) would leave package
-    // screens missing until the user manually pressed "Update packages".
+    // refreshes when `screen_repo_refresh_interval == 0` (manual mode) — a restart
+    // (add-on update, HA reboot, options change, re-auth) would leave screen repo
+    // screens missing until the user manually pressed "Update screen repos".
     // `refresh_all(false)` reuses the on-disk cache for immutable pins, so this
     // is cheap when nothing changed. Spawned so it never delays the listener.
     {
-        let mgr = state.package_manager.clone();
+        let mgr = state.screen_repo_manager.clone();
         tokio::spawn(async move {
             if let Err(e) = tokio::task::spawn_blocking(move || mgr.refresh_all(false)).await {
-                tracing::warn!(error = %e, "startup package refresh task panicked");
+                tracing::warn!(error = %e, "startup screen repo refresh task panicked");
             }
         });
     }
 
-    // Periodic package refresh: re-fetches mutable (tag/branch) package pins
+    // Periodic screen repo refresh: re-fetches mutable (tag/branch) screen repo pins
     // on a config-driven interval. Spawned unconditionally (not gated on the
     // interval being >0 at startup) so that enabling it later via a settings
     // PATCH takes effect without a restart — the loop re-reads the interval
     // from the live config each iteration.
     {
-        let mgr = state.package_manager.clone();
+        let mgr = state.screen_repo_manager.clone();
         let cfg = state.config.clone();
         tokio::spawn(async move {
             loop {
-                let secs = cfg.load().package_refresh_interval;
+                let secs = cfg.load().screen_repo_refresh_interval;
                 if secs == 0 {
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
                     continue;
                 }
                 tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-                tracing::debug!("Periodic package refresh tick");
+                tracing::debug!("Periodic screen repo refresh tick");
                 let m = mgr.clone();
                 // Blocking git work off the async executor.
                 if let Err(e) = tokio::task::spawn_blocking(move || m.refresh_all(false)).await {
-                    tracing::warn!(error = %e, "periodic package refresh task panicked");
+                    tracing::warn!(error = %e, "periodic screen repo refresh task panicked");
                 }
             }
         });
@@ -828,7 +828,7 @@ async fn run_dev_server() -> anyhow::Result<()> {
         renderer: state.renderer.clone(),
         file_watcher,
         asset_loader,
-        package_manager: state.package_manager.clone(),
+        screen_repo_manager: state.screen_repo_manager.clone(),
         dev_overrides,
     };
 

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -151,11 +151,11 @@ pub fn normalize_algorithm_name(name: &str) -> String {
     }
 }
 
-/// Reference to a named screen package.
+/// Reference to a named screen screen repo.
 ///
-/// `repo == None` means the embedded byonk-builtin package.
+/// `repo == None` means the embedded byonk-builtin screen repo.
 #[derive(Debug, Deserialize, Clone, Default)]
-pub struct PackageRef {
+pub struct ScreenRepoRef {
     #[serde(default)]
     pub repo: Option<String>,
     #[serde(default)]
@@ -190,14 +190,14 @@ pub struct AppConfig {
     #[serde(default)]
     pub admin: AdminConfig,
 
-    /// Screen package registry
+    /// Screen screen repo registry
     #[serde(default)]
-    pub packages: HashMap<String, PackageRef>,
+    pub screen_repos: HashMap<String, ScreenRepoRef>,
 
-    /// Interval (seconds) at which mutable (tag/branch) package pins are
+    /// Interval (seconds) at which mutable (tag/branch) screen repo pins are
     /// re-fetched by a background task. `0` disables periodic refresh.
     #[serde(default)]
-    pub package_refresh_interval: u64,
+    pub screen_repo_refresh_interval: u64,
 }
 
 /// Panel profile with official and measured display colors
@@ -317,7 +317,7 @@ impl AppConfig {
     /// Check if a device is registered (by MAC or by registration code)
     ///
     /// This only checks whether a device config entry exists. Screen resolution
-    /// happens separately via the package loader (`handle/path` refs), so a
+    /// happens separately via the screen repo loader (`handle/path` refs), so a
     /// registered device does not require any embedded screen definition.
     pub fn is_device_registered(&self, mac: &str, code: Option<&str>) -> bool {
         // Check by MAC first
@@ -395,8 +395,8 @@ impl Default for AppConfig {
             registration: RegistrationConfig::default(),
             auth_mode: default_auth_mode(),
             admin: AdminConfig::default(),
-            packages: HashMap::new(),
-            package_refresh_interval: 0,
+            screen_repos: HashMap::new(),
+            screen_repo_refresh_interval: 0,
         }
     }
 }
@@ -420,13 +420,13 @@ mod tests {
         let config = AppConfig::default();
 
         assert!(config.devices.is_empty());
-        assert!(config.packages.is_empty());
+        assert!(config.screen_repos.is_empty());
     }
 
     #[test]
     fn test_package_refresh_interval_defaults_zero() {
         let c: AppConfig = serde_yaml::from_str("auth_mode: api_key\n").unwrap();
-        assert_eq!(c.package_refresh_interval, 0);
+        assert_eq!(c.screen_repo_refresh_interval, 0);
     }
 
     #[test]
@@ -691,11 +691,11 @@ colors: "#000000,#FFFFFF"
 
     #[test]
     fn test_packages_registry_parses() {
-        let yaml = "packages:\n  byonk-builtin: {}\n  weather:\n    repo: github.com/acme/screens\n    pin: v1.4.0\n";
+        let yaml = "screen_repos:\n  byonk-builtin: {}\n  weather:\n    repo: github.com/acme/screens\n    pin: v1.4.0\n";
         let cfg: AppConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(cfg.packages.contains_key("byonk-builtin"));
-        assert_eq!(cfg.packages["weather"].pin.as_deref(), Some("v1.4.0"));
-        assert!(cfg.packages["byonk-builtin"].repo.is_none());
+        assert!(cfg.screen_repos.contains_key("byonk-builtin"));
+        assert_eq!(cfg.screen_repos["weather"].pin.as_deref(), Some("v1.4.0"));
+        assert!(cfg.screen_repos["byonk-builtin"].repo.is_none());
     }
 
     #[test]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,9 +2,9 @@ pub mod compat;
 pub mod config;
 pub mod device;
 pub mod display_spec;
-pub mod package_manifest;
 pub mod param_schema;
 pub mod screen_meta;
+pub mod screen_repo_manifest;
 
 pub use config::{
     normalize_algorithm_name, AdminConfig, AppConfig, DeviceConfig, DitherTuningValues,

--- a/src/models/screen_repo_manifest.rs
+++ b/src/models/screen_repo_manifest.rs
@@ -1,9 +1,9 @@
-//! `byonk-screens.yaml` — the mandatory package manifest at a package root.
+//! `byonk-screens.yaml` — the mandatory screen repo manifest at a screen repo root.
 
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct PackageManifest {
+pub struct ScreenRepoManifest {
     pub name: String,
     pub description: String,
     pub author: String,
@@ -12,8 +12,8 @@ pub struct PackageManifest {
     pub root: Option<String>,
 }
 
-impl PackageManifest {
-    pub fn from_yaml(src: &str) -> Result<PackageManifest, String> {
+impl ScreenRepoManifest {
+    pub fn from_yaml(src: &str) -> Result<ScreenRepoManifest, String> {
         serde_yaml::from_str(src).map_err(|e| format!("invalid byonk-screens.yaml: {e}"))
     }
 }
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn test_parse_manifest() {
         let src = "name: acme\ndescription: d\nauthor: a\nlicense: MIT\nroot: contrib/trmnl\n";
-        let m = PackageManifest::from_yaml(src).unwrap();
+        let m = ScreenRepoManifest::from_yaml(src).unwrap();
         assert_eq!(m.name, "acme");
         assert_eq!(m.root.as_deref(), Some("contrib/trmnl"));
     }
@@ -33,12 +33,12 @@ mod tests {
     #[test]
     fn test_root_optional() {
         let src = "name: a\ndescription: d\nauthor: x\nlicense: MIT\n";
-        assert_eq!(PackageManifest::from_yaml(src).unwrap().root, None);
+        assert_eq!(ScreenRepoManifest::from_yaml(src).unwrap().root, None);
     }
 
     #[test]
     fn test_missing_required_field_errors() {
         let src = "name: a\ndescription: d\n"; // no author/license
-        assert!(PackageManifest::from_yaml(src).is_err());
+        assert!(ScreenRepoManifest::from_yaml(src).is_err());
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,9 +21,9 @@ use tracing::{Level, Span};
 use crate::api;
 use crate::assets::AssetLoader;
 use crate::error::ApiError;
-use crate::models::{config::PackageRef, AppConfig, DitherTuningValues};
-use crate::services::package_cache::PackageCache;
-use crate::services::package_manager::PackageManager;
+use crate::models::{config::ScreenRepoRef, AppConfig, DitherTuningValues};
+use crate::services::screen_repo_cache::ScreenRepoCache;
+use crate::services::screen_repo_manager::ScreenRepoManager;
 use crate::services::{ContentCache, ContentPipeline, InMemoryRegistry, RenderService};
 
 /// Runtime overrides set by the dev GUI and consumed by production handlers.
@@ -76,7 +76,7 @@ pub struct AppState {
     pub content_pipeline: Arc<ContentPipeline>,
     pub content_cache: Arc<ContentCache>,
     pub dev_overrides: DevOverrides,
-    pub package_manager: Arc<PackageManager>,
+    pub screen_repo_manager: Arc<ScreenRepoManager>,
     /// True when byonk started as an HA Supervisor add-on (i.e. `/data/options.json`
     /// was present). In add-on mode, global-config admin writes are read-only.
     pub addon_mode: bool,
@@ -96,16 +96,16 @@ pub fn create_app_state_with_config(
     create_app_state_with_overrides(asset_loader, Arc::new(config), DevOverrides::default())
 }
 
-/// Build the set of on-disk packages from `PACKAGES_DIR`.
+/// Build the set of on-disk screen repos from `SCREEN_REPOS_DIR`.
 ///
-/// Only handles that appear in `registry` (i.e. `config.packages`) AND whose
-/// directory `dir/<handle>` exists on disk are included. Non-builtin packages
-/// are placed manually under `PACKAGES_DIR` in this phase; git fetching is a
+/// Only handles that appear in `registry` (i.e. `config.screen_repos`) AND whose
+/// directory `dir/<handle>` exists on disk are included. Non-builtin screen repos
+/// are placed manually under `SCREEN_REPOS_DIR` in this phase; git fetching is a
 /// later plan. `byonk-builtin` needs no disk entry — it registers embedded
-/// inside `PackageLoader`.
+/// inside `ScreenRepoLoader`.
 fn collect_disk_packages(
     dir: &std::path::Path,
-    registry: &HashMap<String, PackageRef>,
+    registry: &HashMap<String, ScreenRepoRef>,
 ) -> HashMap<String, std::path::PathBuf> {
     registry
         .keys()
@@ -120,31 +120,31 @@ fn collect_disk_packages(
         .collect()
 }
 
-/// Build the [`PackageManager`] from the embedded builtin package, any
-/// on-disk packages under `PACKAGES_DIR` declared in `config.packages`, and
-/// any previously fetched checkouts under the cache root (`PACKAGES_CACHE_DIR`
+/// Build the [`ScreenRepoManager`] from the embedded builtin screen repo, any
+/// on-disk screen repos under `SCREEN_REPOS_DIR` declared in `config.screen_repos`, and
+/// any previously fetched checkouts under the cache root (`SCREEN_REPOS_CACHE_DIR`
 /// env, falling back to a temp dir). Rebuilds the loader once before
 /// returning so the manager is immediately usable.
-pub fn build_package_manager(
+pub fn build_screen_repo_manager(
     asset_loader: Arc<AssetLoader>,
     config: SharedConfig,
-) -> Arc<PackageManager> {
-    let cache_root = std::env::var("PACKAGES_CACHE_DIR")
+) -> Arc<ScreenRepoManager> {
+    let cache_root = std::env::var("SCREEN_REPOS_CACHE_DIR")
         .ok()
         .filter(|s| !s.is_empty())
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| std::env::temp_dir().join("byonk-packages"));
 
-    let extra_disk = std::env::var("PACKAGES_DIR")
+    let extra_disk = std::env::var("SCREEN_REPOS_DIR")
         .ok()
         .filter(|s| !s.is_empty())
-        .map(|dir| collect_disk_packages(std::path::Path::new(&dir), &config.load().packages))
+        .map(|dir| collect_disk_packages(std::path::Path::new(&dir), &config.load().screen_repos))
         .unwrap_or_default();
 
-    let manager = PackageManager::new(
+    let manager = ScreenRepoManager::new(
         asset_loader,
         config,
-        PackageCache::new(cache_root),
+        ScreenRepoCache::new(cache_root),
         extra_disk,
     );
     manager.rebuild_loader();
@@ -164,7 +164,8 @@ pub fn create_app_state_with_overrides(
 
     let shared_config: SharedConfig = Arc::new(ArcSwap::from(config.clone()));
 
-    let package_manager = build_package_manager(asset_loader.clone(), shared_config.clone());
+    let screen_repo_manager =
+        build_screen_repo_manager(asset_loader.clone(), shared_config.clone());
 
     let registry = Arc::new(InMemoryRegistry::new());
     let renderer = Arc::new(RenderService::new(&asset_loader)?);
@@ -173,7 +174,7 @@ pub fn create_app_state_with_overrides(
             shared_config.clone(),
             asset_loader.clone(),
             renderer.clone(),
-            package_manager.clone(),
+            screen_repo_manager.clone(),
         )
         .map_err(|e| anyhow::anyhow!("Failed to create content pipeline: {e}"))?,
     );
@@ -189,7 +190,7 @@ pub fn create_app_state_with_overrides(
         content_pipeline,
         content_cache,
         dev_overrides,
-        package_manager,
+        screen_repo_manager,
         addon_mode: false,
     })
 }
@@ -198,7 +199,7 @@ pub fn create_app_state_with_overrides(
 pub fn reload_config(state: &AppState) -> anyhow::Result<()> {
     let fresh = AppConfig::load_from_assets(&state.asset_loader)?;
     state.config.store(Arc::new(fresh));
-    state.package_manager.rebuild_loader();
+    state.screen_repo_manager.rebuild_loader();
     Ok(())
 }
 
@@ -289,7 +290,7 @@ mod reload_tests {
         let cfg = AppConfig::default();
         let state = create_app_state_with_config(loader, cfg).unwrap();
         assert!(state
-            .package_manager
+            .screen_repo_manager
             .loader()
             .resolve("byonk-builtin/default")
             .is_some());

--- a/src/services/config_writer.rs
+++ b/src/services/config_writer.rs
@@ -2,9 +2,9 @@
 //!
 //! Strategy (avoids yamlpatch's weak spots on sequences/flow lists):
 //! - global scalar settings → in-place scalar replace
-//! - device / package add/edit/remove → remove the entry's subtree + append a
+//! - device / screen repo add/edit/remove → remove the entry's subtree + append a
 //!   freshly block-serialized subtree (entries are machine-managed, so no user
-//!   comments live inside them). Both `devices:` and `packages:` share the
+//!   comments live inside them). Both `devices:` and `screen_repos:` share the
 //!   same section-generic helpers.
 
 use yamlpatch::{apply_yaml_patches, Op, Patch};
@@ -144,7 +144,7 @@ fn block_range(yaml: &str, section: &str, key: &str) -> Result<(usize, usize), C
 
 /// Remove `<section>.<key>` entirely. Returns [`ConfigWriteError::NotFound`] if
 /// the entry does not exist. `label` is the singular noun used in the
-/// [`ConfigWriteError::NotFound`] message (e.g. `"device"`, `"package"`).
+/// [`ConfigWriteError::NotFound`] message (e.g. `"device"`, `"screen repo"`).
 fn remove_from_section(
     yaml: &str,
     section: &str,
@@ -166,7 +166,7 @@ fn remove_from_section(
 }
 
 /// Add a new entry or replace an existing one with `block` under `section`
-/// (e.g. `devices` or `packages`). `label` is the singular noun used in the
+/// (e.g. `devices` or `screen repos`). `label` is the singular noun used in the
 /// [`ConfigWriteError::NotFound`] message.
 ///
 /// Editing is implemented as remove-then-add so it is robust against odd
@@ -324,19 +324,19 @@ pub fn upsert_device(
     upsert_in_section(yaml, "devices", "device", key, block)
 }
 
-/// Remove `packages.<handle>` entirely. Returns [`ConfigWriteError::NotFound`]
-/// if the package does not exist.
-pub fn remove_package(yaml: &str, handle: &str) -> Result<String, ConfigWriteError> {
-    remove_from_section(yaml, "packages", "package", handle)
+/// Remove `screen_repos.<handle>` entirely. Returns [`ConfigWriteError::NotFound`]
+/// if the screen repo does not exist.
+pub fn remove_screen_repo(yaml: &str, handle: &str) -> Result<String, ConfigWriteError> {
+    remove_from_section(yaml, "screen_repos", "screen repo", handle)
 }
 
-/// Add a new package or replace an existing one with `block`.
-pub fn upsert_package(
+/// Add a new screen repo or replace an existing one with `block`.
+pub fn upsert_screen_repo(
     yaml: &str,
     handle: &str,
     block: &serde_yaml::Mapping,
 ) -> Result<String, ConfigWriteError> {
-    upsert_in_section(yaml, "packages", "package", handle, block)
+    upsert_in_section(yaml, "screen_repos", "screen repo", handle, block)
 }
 
 #[cfg(test)]
@@ -479,10 +479,10 @@ devices: {}
         let mut block = serde_yaml::Mapping::new();
         block.insert("repo".into(), "github.com/acme/x".into());
         block.insert("pin".into(), "v1.0.0".into());
-        let out = upsert_package(yaml, "weather", &block).unwrap();
+        let out = upsert_screen_repo(yaml, "weather", &block).unwrap();
         let v: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         assert_eq!(
-            v["packages"]["weather"]["repo"],
+            v["screen_repos"]["weather"]["repo"],
             serde_yaml::Value::from("github.com/acme/x")
         );
 
@@ -490,21 +490,21 @@ devices: {}
         let mut b2 = serde_yaml::Mapping::new();
         b2.insert("repo".into(), "github.com/acme/x".into());
         b2.insert("pin".into(), "v2.0.0".into());
-        let out2 = upsert_package(&out, "weather", &b2).unwrap();
+        let out2 = upsert_screen_repo(&out, "weather", &b2).unwrap();
         let v2: serde_yaml::Value = serde_yaml::from_str(&out2).unwrap();
         assert_eq!(
-            v2["packages"]["weather"]["pin"],
+            v2["screen_repos"]["weather"]["pin"],
             serde_yaml::Value::from("v2.0.0")
         );
     }
 
     #[test]
     fn test_remove_package() {
-        let yaml = "packages:\n  weather:\n    repo: github.com/acme/x\n    pin: v1\n";
-        let out = remove_package(yaml, "weather").unwrap();
+        let yaml = "screen_repos:\n  weather:\n    repo: github.com/acme/x\n    pin: v1\n";
+        let out = remove_screen_repo(yaml, "weather").unwrap();
         let v: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
         assert!(v
-            .get("packages")
+            .get("screen_repos")
             .map(|p| p.get("weather").is_none())
             .unwrap_or(true));
     }
@@ -512,7 +512,7 @@ devices: {}
     #[test]
     fn test_remove_missing_package_is_notfound() {
         assert!(matches!(
-            remove_package("packages: {}\n", "nope"),
+            remove_screen_repo("screen_repos: {}\n", "nope"),
             Err(ConfigWriteError::NotFound(_))
         ));
     }

--- a/src/services/content_pipeline.rs
+++ b/src/services/content_pipeline.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use crate::assets::AssetLoader;
 use crate::error::RenderError;
 use crate::models::DisplaySpec;
-use crate::services::package_loader::{join_rel, PackageSource, ResolvedScreen};
-use crate::services::package_manager::PackageManager;
+use crate::services::screen_repo_loader::{join_rel, ResolvedScreen, ScreenRepoSource};
+use crate::services::screen_repo_manager::ScreenRepoManager;
 use crate::services::{FontFaceInfo, LuaRuntime, RenderService, TemplateService};
 
 /// Resolve the effective refresh rate.
@@ -34,9 +34,9 @@ pub struct ScriptResult {
     pub skip_update: bool,
     /// Screen name (a `handle/path` ref), for logging
     pub screen_name: String,
-    /// The screen's package source, for reading `screen.svg` + sibling parts
-    pub source: Arc<dyn PackageSource>,
-    /// The screen's package-relative directory
+    /// The screen's screen repo source, for reading `screen.svg` + sibling parts
+    pub source: Arc<dyn ScreenRepoSource>,
+    /// The screen's screen-repo-relative directory
     pub screen_dir: String,
     /// Config params
     pub params: HashMap<String, serde_yaml::Value>,
@@ -115,7 +115,7 @@ pub struct ContentPipeline {
     lua_runtime: LuaRuntime,
     template_service: TemplateService,
     renderer: Arc<RenderService>,
-    package_manager: Arc<PackageManager>,
+    screen_repo_manager: Arc<ScreenRepoManager>,
 }
 
 impl ContentPipeline {
@@ -123,7 +123,7 @@ impl ContentPipeline {
         config: crate::server::SharedConfig,
         asset_loader: Arc<AssetLoader>,
         renderer: Arc<RenderService>,
-        package_manager: Arc<PackageManager>,
+        screen_repo_manager: Arc<ScreenRepoManager>,
     ) -> Result<Self, ContentError> {
         // Build font info from the renderer's fontdb
         let mut font_families: HashMap<String, Vec<FontFaceInfo>> = HashMap::new();
@@ -152,7 +152,7 @@ impl ContentPipeline {
             lua_runtime,
             template_service,
             renderer,
-            package_manager,
+            screen_repo_manager,
         })
     }
 
@@ -172,8 +172,12 @@ impl ContentPipeline {
             .or_else(|| config.get_device_config(device_mac));
 
         if let Some(device_config) = device_config {
-            // Found device config — resolve the device's screen ref via packages.
-            if let Some(resolved) = self.package_manager.loader().resolve(&device_config.screen) {
+            // Found device config — resolve the device's screen ref via screen repos.
+            if let Some(resolved) = self
+                .screen_repo_manager
+                .loader()
+                .resolve(&device_config.screen)
+            {
                 if let Some(ctx) = device_ctx.as_mut() {
                     ctx.refresh_override = device_config.refresh;
                 }
@@ -192,7 +196,7 @@ impl ContentPipeline {
             .default_device_screen()
             .unwrap_or("byonk-builtin/default");
         let resolved = self
-            .package_manager
+            .screen_repo_manager
             .loader()
             .resolve(default_ref)
             .ok_or_else(|| ContentError::ScreenNotFound(device_mac.to_string()))?;
@@ -212,7 +216,7 @@ impl ContentPipeline {
         device_ctx: Option<DeviceContext>,
     ) -> Result<ScriptResult, ContentError> {
         let resolved = self
-            .package_manager
+            .screen_repo_manager
             .loader()
             .resolve(screen_ref)
             .ok_or_else(|| ContentError::ScreenNotFound(screen_ref.to_string()))?;
@@ -234,7 +238,7 @@ impl ContentPipeline {
             ContentError::ScreenNotFound(format!("{screen_name} (missing script.lua)"))
         })?;
 
-        // Run the Lua script, resolving require() against the screen's package.
+        // Run the Lua script, resolving require() against the screen's screen repo.
         let lua_result = self.lua_runtime.run_script(
             &script_src,
             &resolved.source,
@@ -344,13 +348,13 @@ impl ContentPipeline {
 
         let template_data = serde_json::Value::Object(template_context);
 
-        // Read the screen's `screen.svg` from its package.
+        // Read the screen's `screen.svg` from its screen repo.
         let template_rel = join_rel(&result.screen_dir, "screen.svg");
         let template_src = result.source.read_string(&template_rel).ok_or_else(|| {
             ContentError::Template(super::TemplateError::NotFound(template_rel.clone()))
         })?;
 
-        // Render the template to SVG (scoped to the screen's package + byonk-base).
+        // Render the template to SVG (scoped to the screen's screen repo + byonk-base).
         let svg_content = self.template_service.render(
             &template_src,
             &result.source,
@@ -613,7 +617,7 @@ impl ContentPipeline {
             .collect();
 
         let resolved = self
-            .package_manager
+            .screen_repo_manager
             .loader()
             .resolve(screen_ref)
             .ok_or_else(|| format!("Screen '{screen_ref}' not found"))?;
@@ -653,7 +657,7 @@ mod refresh_tests {
 mod pipeline_tests {
     use super::*;
     use crate::assets::AssetLoader;
-    use crate::services::package_cache::PackageCache;
+    use crate::services::screen_repo_cache::ScreenRepoCache;
     use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
@@ -681,10 +685,10 @@ mod pipeline_tests {
             std::process::id(),
             rand::random::<u64>()
         ));
-        let pm = PackageManager::new(
+        let pm = ScreenRepoManager::new(
             loader.clone(),
             shared.clone(),
-            PackageCache::new(cache_root),
+            ScreenRepoCache::new(cache_root),
             disk,
         );
         pm.rebuild_loader();
@@ -759,7 +763,7 @@ mod pipeline_tests {
         assert_eq!(result.screen_name, "acme/weather/forecast");
         assert_eq!(result.screen_dir, "weather/forecast");
 
-        // And the template renders through the package source.
+        // And the template renders through the screen repo source.
         let svg = pipeline.render_svg_from_script(&result, None).unwrap();
         assert!(svg.contains("<t>hi</t>"), "{svg}");
 

--- a/src/services/git_fetch.rs
+++ b/src/services/git_fetch.rs
@@ -1,12 +1,12 @@
-//! Low-level git primitive for screen-package distribution.
+//! Low-level git primitive for screen repo distribution.
 //!
-//! [`fetch`] clones/fetches a package repo at a *pin* (a full sha, tag, or
+//! [`fetch`] clones/fetches a screen repo repo at a *pin* (a full sha, tag, or
 //! branch name) and materializes the pinned tree into a plain directory —
 //! not a git working tree. We clone bare into scratch space, resolve `pin`
 //! against the fetched refs/objects, then export the resolved tree's blobs
 //! directly into `dest`. That keeps `dest` a clean content directory with no
-//! `.git` folder mixed in, which matters because later code (`PackageSource`
-//! disk-walking in `package_loader.rs`) walks `dest` for package files and
+//! `.git` folder mixed in, which matters because later code (`ScreenRepoSource`
+//! disk-walking in `screen_repo_loader.rs`) walks `dest` for screen repo files and
 //! shouldn't have to know about, or skip over, git internals.
 //!
 //! This interface is deliberately engine-agnostic (no `gix` types appear in
@@ -29,9 +29,9 @@ pub enum PinKind {
     /// by our bare clone/fetch (`refs/remotes/origin/<pin>`), not
     /// `refs/heads/<pin>` on the remote directly.
     Branch,
-    /// The embedded builtin package. This is an API-layer marker only — the
+    /// The embedded builtin screen repo. This is an API-layer marker only — the
     /// git resolver above never produces it; `read.rs` uses it to describe
-    /// `byonk-builtin` in `GET /packages` responses.
+    /// `byonk-builtin` in `GET /screen-repos` responses.
     Embedded,
 }
 
@@ -61,7 +61,7 @@ pub enum FetchError {
     InvalidRepo(String),
 }
 
-/// Transport schemes we accept verbatim for a package `repo`.
+/// Transport schemes we accept verbatim for a screen repo `repo`.
 const REPO_SCHEMES: &[&str] = &["https://", "http://", "git://", "ssh://", "file://"];
 
 /// Validate that `repo` carries an explicit transport, so it is never
@@ -78,7 +78,7 @@ fn validate_repo(repo: &str) -> Result<(), FetchError> {
         return Ok(());
     }
     Err(FetchError::InvalidRepo(redact_userinfo(format!(
-        "invalid package repo `{repo}`: add an explicit scheme \
+        "invalid screen repo repo `{repo}`: add an explicit scheme \
          (https://, git://, ssh:// or file://). A remote like \
          `github.com/owner/repo` must be written `https://github.com/owner/repo`; \
          a local repository must be `file:///path/to/repo`."
@@ -98,8 +98,8 @@ fn git_err(msg: impl Into<String>) -> FetchError {
 
 /// Build a [`FetchError::PinNotFound`], redacting any userinfo embedded in
 /// `repo` first — same rationale as [`git_err`]: a user who hand-embeds
-/// `https://user:pass@host` in a package's `repo` config must never have
-/// that credential echoed back into `status.error` / `GET /packages`.
+/// `https://user:pass@host` in a screen repo's `repo` config must never have
+/// that credential echoed back into `status.error` / `GET /screen-repos`.
 fn pin_not_found(pin: &str, repo: &str) -> FetchError {
     FetchError::PinNotFound(pin.to_string(), redact_userinfo(repo.to_string()))
 }
@@ -176,7 +176,7 @@ pub fn fetch(
 /// `Dockerfile.release`) and has no `/tmp` directory, so `std::env::temp_dir()`
 /// resolves to a `/tmp/…` path whose parent does not exist — gix then fails the
 /// bare clone with `Could not open data at '/tmp/byonk-git-fetch-…'` and every
-/// package fetch errors. `dest` is the caller's package-cache checkout dir
+/// screen repo fetch errors. `dest` is the caller's screen-repo-cache checkout dir
 /// (under `/data`, just created via `create_dir_all`), so its parent is
 /// guaranteed to exist and be writable; cloning beside it also makes the final
 /// export a same-filesystem operation. Fall back to the system temp dir only
@@ -268,7 +268,7 @@ fn resolve_pin(repo: &gix::Repository, pin: &str) -> Option<(gix::ObjectId, PinK
 /// ("tree") entries, not blobs only; without filtering those out, writing a
 /// directory entry as a file collides with `create_dir_all` for any deeper
 /// blob under it. Symlinks are written as regular files containing the link
-/// target text (best-effort; screen packages are not expected to contain
+/// target text (best-effort; screen repos are not expected to contain
 /// symlinks).
 fn export_tree(
     repo: &gix::Repository,
@@ -390,7 +390,7 @@ mod tests {
     fn test_scratch_is_sibling_of_dest_not_system_temp() {
         // Regression: the release image is `FROM scratch` and has no /tmp, so
         // the intermediate bare clone must live beside `dest` (on the writable
-        // package-cache filesystem under /data), never in std::env::temp_dir()
+        // screen-repo-cache filesystem under /data), never in std::env::temp_dir()
         // — otherwise gix fails with "Could not open data at '/tmp/…'".
         let dest = Path::new("/data/packages/repohash/scratch-checkout");
         let scratch = scratch_for(dest);
@@ -472,7 +472,7 @@ mod tests {
     struct FixtureRepo {
         /// On-disk path (for fs cleanup / mutation in tests).
         dir: PathBuf,
-        /// `file://` URL of `dir` (a package `repo:` must carry a scheme).
+        /// `file://` URL of `dir` (a screen repo `repo:` must carry a scheme).
         url: String,
         branch: String,
         tag: String,
@@ -558,7 +558,7 @@ mod tests {
     }
 
     /// Regression test: a real tree with a nested directory (as every screen
-    /// package has, e.g. `weather/forecast/meta.yaml`) must export cleanly.
+    /// screen repo has, e.g. `weather/forecast/meta.yaml`) must export cleanly.
     /// `breadthfirst().files()` records *every* tree entry, including
     /// intermediate directories, not just blobs — `export_tree` must skip
     /// those or `create_dir_all` collides with a directory entry written as

--- a/src/services/git_fetch.rs
+++ b/src/services/git_fetch.rs
@@ -162,21 +162,36 @@ pub fn fetch(
     std::fs::create_dir_all(dest)
         .map_err(|e| git_err(format!("creating {}: {e}", dest.display())))?;
 
-    let scratch = scratch_dir();
+    let scratch = scratch_for(dest);
     let result = fetch_into(repo, pin, token, dest, &scratch);
     // Always clean up scratch, regardless of outcome.
     let _ = std::fs::remove_dir_all(&scratch);
     result
 }
 
-fn scratch_dir() -> PathBuf {
+/// Directory for the intermediate bare clone. It MUST live on the same
+/// filesystem as `dest` (a sibling of it), NOT in `std::env::temp_dir()`.
+///
+/// The published container image is built `FROM scratch` (see
+/// `Dockerfile.release`) and has no `/tmp` directory, so `std::env::temp_dir()`
+/// resolves to a `/tmp/…` path whose parent does not exist — gix then fails the
+/// bare clone with `Could not open data at '/tmp/byonk-git-fetch-…'` and every
+/// package fetch errors. `dest` is the caller's package-cache checkout dir
+/// (under `/data`, just created via `create_dir_all`), so its parent is
+/// guaranteed to exist and be writable; cloning beside it also makes the final
+/// export a same-filesystem operation. Fall back to the system temp dir only
+/// when `dest` has no parent (not reachable for real cache paths).
+fn scratch_for(dest: &Path) -> PathBuf {
     let unique = format!(
         "byonk-git-fetch-{}-{}-{}",
         std::process::id(),
         chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default(),
         rand::random::<u64>()
     );
-    std::env::temp_dir().join(unique)
+    match dest.parent() {
+        Some(parent) => parent.join(unique),
+        None => std::env::temp_dir().join(unique),
+    }
 }
 
 fn fetch_into(
@@ -369,6 +384,29 @@ mod tests {
     #[test]
     fn test_auth_url_local_path_unchanged() {
         assert_eq!(auth_url("/local/path", Some("tok")), "/local/path");
+    }
+
+    #[test]
+    fn test_scratch_is_sibling_of_dest_not_system_temp() {
+        // Regression: the release image is `FROM scratch` and has no /tmp, so
+        // the intermediate bare clone must live beside `dest` (on the writable
+        // package-cache filesystem under /data), never in std::env::temp_dir()
+        // — otherwise gix fails with "Could not open data at '/tmp/…'".
+        let dest = Path::new("/data/packages/repohash/scratch-checkout");
+        let scratch = scratch_for(dest);
+        assert_eq!(
+            scratch.parent(),
+            Some(Path::new("/data/packages/repohash")),
+            "scratch must be a sibling of dest"
+        );
+        assert!(
+            !scratch.starts_with(std::env::temp_dir()),
+            "scratch must not live in the system temp dir (release image has no /tmp)"
+        );
+        assert!(scratch
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("byonk-git-fetch-")));
     }
 
     #[test]

--- a/src/services/lua_runtime.rs
+++ b/src/services/lua_runtime.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use super::DeviceContext;
 use crate::assets::AssetLoader;
-use crate::services::package_loader::PackageSource;
+use crate::services::screen_repo_loader::ScreenRepoSource;
 
 /// Result from running a Lua script
 #[derive(Debug)]
@@ -56,14 +56,14 @@ pub struct FontFaceInfo {
     pub bitmap_strikes: Vec<u16>,
 }
 
-/// A [`PackageSource`] backed by the flat screens directory of an `AssetLoader`.
+/// A [`ScreenRepoSource`] backed by the flat screens directory of an `AssetLoader`.
 /// Used by [`LuaRuntime::run_script_from_asset`] for tests/dev where scripts live
-/// directly under `SCREENS_DIR` rather than inside a package.
+/// directly under `SCREENS_DIR` rather than inside a screen repo.
 struct AssetScreensSource {
     loader: Arc<AssetLoader>,
 }
 
-impl PackageSource for AssetScreensSource {
+impl ScreenRepoSource for AssetScreensSource {
     fn read(&self, rel: &str) -> Option<Vec<u8>> {
         self.loader
             .read_screen(std::path::Path::new(rel))
@@ -79,7 +79,7 @@ impl PackageSource for AssetScreensSource {
         Vec::new()
     }
 
-    fn manifest(&self) -> &crate::models::package_manifest::PackageManifest {
+    fn manifest(&self) -> &crate::models::screen_repo_manifest::ScreenRepoManifest {
         unreachable!("AssetScreensSource::manifest() is not used")
     }
 }
@@ -112,15 +112,15 @@ impl LuaRuntime {
     /// Run a Lua script with the given parameters.
     ///
     /// `script_src` is the already-read `script.lua` contents. `source` is the
-    /// screen's package source, used to resolve `require()` for package-relative
+    /// screen's screen repo source, used to resolve `require()` for screen-repo-relative
     /// modules and `read_asset()` for sibling files. `screen_name` (a `handle/path`
-    /// ref) is used for logging. `screen_dir` is the screen's package-relative
+    /// ref) is used for logging. `screen_dir` is the screen's screen-repo-relative
     /// directory, against which `read_asset(path)` reads through `source`.
     #[allow(clippy::too_many_arguments)]
     pub fn run_script(
         &self,
         script_src: &str,
-        source: &Arc<dyn PackageSource>,
+        source: &Arc<dyn ScreenRepoSource>,
         screen_name: &str,
         screen_dir: &str,
         params: &HashMap<String, serde_yaml::Value>,
@@ -140,7 +140,7 @@ impl LuaRuntime {
             timestamp_override,
         )?;
 
-        // Install the sandboxed `require()` scoped to this package + byonk-base.
+        // Install the sandboxed `require()` scoped to this screen repo + byonk-base.
         self.install_require(&lua, source)?;
 
         // Execute the script
@@ -193,7 +193,7 @@ impl LuaRuntime {
     }
 
     /// Test/dev convenience: read a screen script from the `AssetLoader` by path
-    /// and run it with a screens-dir-backed package source (no package manifest
+    /// and run it with a screens-dir-backed screen repo source (no screen repo manifest
     /// required). `require()` resolves sibling files under the screens dir.
     pub fn run_script_from_asset(
         &self,
@@ -206,7 +206,7 @@ impl LuaRuntime {
             .asset_loader
             .read_screen_string(script_path)
             .map_err(|e| ScriptError::NotFound(e.to_string()))?;
-        let source: Arc<dyn PackageSource> = Arc::new(AssetScreensSource {
+        let source: Arc<dyn ScreenRepoSource> = Arc::new(AssetScreensSource {
             loader: self.asset_loader.clone(),
         });
         let screen_name = script_path
@@ -231,12 +231,12 @@ impl LuaRuntime {
     }
 
     /// Install a sandboxed `require(name)` global that can only reach two places:
-    /// the screen's own package (package-relative modules like `require("lib/x")`)
+    /// the screen's own screen repo (screen-repo-relative modules like `require("lib/x")`)
     /// and the embedded `byonk-base` std library (`require("byonk-base-v1/std")`).
     ///
     /// A `package.loaded`-style cache in the Lua registry ensures each module is
     /// evaluated at most once per run and returns the same value on repeat calls.
-    fn install_require(&self, lua: &Lua, source: &Arc<dyn PackageSource>) -> LuaResult<()> {
+    fn install_require(&self, lua: &Lua, source: &Arc<dyn ScreenRepoSource>) -> LuaResult<()> {
         // Module cache (package.loaded-style), keyed by the require name.
         let cache = lua.create_table()?;
         lua.set_named_registry_value("__require_cache", cache)?;
@@ -261,7 +261,7 @@ impl LuaRuntime {
                 };
                 require_assets.read_base_string(&rel)
             } else {
-                // package-relative: lib/util -> read_string("lib/util.lua")
+                // screen-repo-relative: lib/util -> read_string("lib/util.lua")
                 let rel = if name.ends_with(".lua") {
                     name.clone()
                 } else {
@@ -291,7 +291,7 @@ impl LuaRuntime {
         params: &HashMap<String, serde_yaml::Value>,
         device_ctx: Option<&DeviceContext>,
         _screen_name: &str,
-        source: &Arc<dyn PackageSource>,
+        source: &Arc<dyn ScreenRepoSource>,
         screen_dir: &str,
         timestamp_override: Option<i64>,
     ) -> LuaResult<()> {
@@ -507,13 +507,13 @@ impl LuaRuntime {
         globals.set("url_decode", url_decode)?;
 
         // read_asset(path) -> string (binary data)
-        // Reads a file sibling to the screen's `script.lua`, package-relative to
-        // `screen_dir`, through the screen's package source. The source applies the
+        // Reads a file sibling to the screen's `script.lua`, screen-repo-relative to
+        // `screen_dir`, through the screen's screen repo source. The source applies the
         // `is_safe_rel` sandbox guard, so `..` traversal is rejected.
         let asset_source = source.clone();
         let asset_dir = screen_dir.to_string();
         let read_asset = lua.create_function(move |lua, path: String| {
-            let rel = crate::services::package_loader::join_rel(&asset_dir, &path);
+            let rel = crate::services::screen_repo_loader::join_rel(&asset_dir, &path);
             match asset_source.read(&rel) {
                 Some(data) => {
                     // Return as Lua string (which can contain binary data)
@@ -1322,12 +1322,12 @@ fn lua_to_json_inner(value: Value) -> LuaResult<serde_json::Value> {
 #[cfg(test)]
 mod require_tests {
     use super::*;
-    use crate::services::package_loader::PackageSource;
+    use crate::services::screen_repo_loader::ScreenRepoSource;
     use std::sync::Arc;
 
-    /// Minimal in-memory package source for exercising `require()`.
+    /// Minimal in-memory screen repo source for exercising `require()`.
     struct MockSource;
-    impl PackageSource for MockSource {
+    impl ScreenRepoSource for MockSource {
         fn read(&self, rel: &str) -> Option<Vec<u8>> {
             match rel {
                 "lib/util.lua" => Some(b"return { greet = function() return 'hi' end }".to_vec()),
@@ -1340,7 +1340,7 @@ mod require_tests {
         fn svg_files(&self) -> Vec<String> {
             vec![]
         }
-        fn manifest(&self) -> &crate::models::package_manifest::PackageManifest {
+        fn manifest(&self) -> &crate::models::screen_repo_manifest::ScreenRepoManifest {
             unreachable!("manifest() not used by require()")
         }
     }
@@ -1348,7 +1348,7 @@ mod require_tests {
     #[test]
     fn test_require_resolves_package_relative_module() {
         let rt = LuaRuntime::new(Arc::new(crate::assets::AssetLoader::new(None, None, None)));
-        let src: Arc<dyn PackageSource> = Arc::new(MockSource);
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(MockSource);
         let script = "local u = require('lib/util'); return { data = { m = u.greet() } }";
         let res = rt
             .run_script(script, &src, "t", "", &Default::default(), None, None)
@@ -1360,7 +1360,7 @@ mod require_tests {
     fn test_require_caches_module() {
         // A module with a side-effecting counter must only evaluate once.
         struct CounterSource;
-        impl PackageSource for CounterSource {
+        impl ScreenRepoSource for CounterSource {
             fn read(&self, rel: &str) -> Option<Vec<u8>> {
                 match rel {
                     "lib/c.lua" => Some(b"COUNT = (COUNT or 0) + 1; return COUNT".to_vec()),
@@ -1373,12 +1373,12 @@ mod require_tests {
             fn svg_files(&self) -> Vec<String> {
                 vec![]
             }
-            fn manifest(&self) -> &crate::models::package_manifest::PackageManifest {
+            fn manifest(&self) -> &crate::models::screen_repo_manifest::ScreenRepoManifest {
                 unreachable!()
             }
         }
         let rt = LuaRuntime::new(Arc::new(crate::assets::AssetLoader::new(None, None, None)));
-        let src: Arc<dyn PackageSource> = Arc::new(CounterSource);
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(CounterSource);
         let script =
             "local a = require('lib/c'); local b = require('lib/c'); return { data = { a = a, b = b } }";
         let res = rt
@@ -1391,7 +1391,7 @@ mod require_tests {
     #[test]
     fn test_require_missing_module_errors() {
         let rt = LuaRuntime::new(Arc::new(crate::assets::AssetLoader::new(None, None, None)));
-        let src: Arc<dyn PackageSource> = Arc::new(MockSource);
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(MockSource);
         let script = "local x = require('nope/missing'); return { data = {} }";
         let err = rt
             .run_script(script, &src, "t", "", &Default::default(), None, None)
@@ -1404,10 +1404,10 @@ mod require_tests {
 
     #[test]
     fn test_require_traversal_is_blocked() {
-        // A malicious `require("../escape")` must not read host files; the package
+        // A malicious `require("../escape")` must not read host files; the screen repo
         // source rejects the `..` path, so `require` reports "module not found".
         let rt = LuaRuntime::new(Arc::new(crate::assets::AssetLoader::new(None, None, None)));
-        let src: Arc<dyn PackageSource> = Arc::new(MockSource);
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(MockSource);
         let script = "local x = require('../escape'); return { data = {} }";
         let err = rt
             .run_script(script, &src, "t", "", &Default::default(), None, None)
@@ -1420,9 +1420,9 @@ mod require_tests {
 
     #[test]
     fn test_read_asset_reads_sibling_via_source() {
-        // read_asset resolves package-relative to screen_dir through the source.
+        // read_asset resolves screen-repo-relative to screen_dir through the source.
         struct AssetSource;
-        impl PackageSource for AssetSource {
+        impl ScreenRepoSource for AssetSource {
             fn read(&self, rel: &str) -> Option<Vec<u8>> {
                 match rel {
                     "s/data.txt" => Some(b"hello-asset".to_vec()),
@@ -1435,12 +1435,12 @@ mod require_tests {
             fn svg_files(&self) -> Vec<String> {
                 vec![]
             }
-            fn manifest(&self) -> &crate::models::package_manifest::PackageManifest {
+            fn manifest(&self) -> &crate::models::screen_repo_manifest::ScreenRepoManifest {
                 unreachable!()
             }
         }
         let rt = LuaRuntime::new(Arc::new(crate::assets::AssetLoader::new(None, None, None)));
-        let src: Arc<dyn PackageSource> = Arc::new(AssetSource);
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(AssetSource);
         let script = "return { data = { c = read_asset('data.txt') } }";
         let res = rt
             .run_script(script, &src, "acme/s", "s", &Default::default(), None, None)
@@ -1451,7 +1451,7 @@ mod require_tests {
     #[test]
     fn test_read_asset_traversal_is_blocked() {
         let rt = LuaRuntime::new(Arc::new(crate::assets::AssetLoader::new(None, None, None)));
-        let src: Arc<dyn PackageSource> = Arc::new(MockSource);
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(MockSource);
         let script = "return { data = { c = read_asset('../../etc/passwd') } }";
         let err = rt
             .run_script(script, &src, "t", "s", &Default::default(), None, None)

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,11 +6,11 @@ pub mod file_watcher;
 pub mod git_fetch;
 pub mod http_cache;
 pub mod lua_runtime;
-pub mod package_cache;
-pub mod package_loader;
-pub mod package_manager;
-pub mod package_status;
 pub mod renderer;
+pub mod screen_repo_cache;
+pub mod screen_repo_loader;
+pub mod screen_repo_manager;
+pub mod screen_repo_status;
 pub mod template_service;
 
 pub use config_writer::{remove_device, set_scalar, upsert_device, ConfigWriteError};

--- a/src/services/package_manager.rs
+++ b/src/services/package_manager.rs
@@ -183,6 +183,11 @@ impl PackageManager {
                     });
                     return;
                 }
+                tracing::info!(
+                    handle = %handle,
+                    sha = %fetched.resolved_sha,
+                    "package refreshed"
+                );
                 self.update_status(handle, |st| {
                     st.state = Some(PackageState::Ready);
                     st.resolved_sha = Some(fetched.resolved_sha.clone());
@@ -194,8 +199,13 @@ impl PackageManager {
             }
             Err(e) => {
                 cleanup_scratch(&scratch);
+                // `e`/`message` is already userinfo-redacted by git_fetch; the
+                // handle is operator-chosen. Log it so a failing package fetch
+                // is visible in the add-on log, not only in the per-package
+                // status surfaced by `GET /packages`.
                 let message = e.to_string();
                 let state = self.state_after_post_fetch_failure(handle, &repo);
+                tracing::warn!(handle = %handle, state = ?state, "package fetch failed: {message}");
                 self.update_status(handle, |st| {
                     st.state = Some(state);
                     st.error = Some(message);

--- a/src/services/screen_repo_cache.rs
+++ b/src/services/screen_repo_cache.rs
@@ -1,7 +1,7 @@
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 
-pub struct PackageCache {
+pub struct ScreenRepoCache {
     root: PathBuf,
 }
 
@@ -11,7 +11,7 @@ fn repo_key(repo: &str) -> String {
     hex::encode(&h.finalize()[..8]) // 16 hex chars — enough to avoid collisions
 }
 
-impl PackageCache {
+impl ScreenRepoCache {
     pub fn new(root: PathBuf) -> Self {
         Self { root }
     }
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn test_checkout_dir_is_stable_and_scoped() {
-        let c = PackageCache::new(std::path::PathBuf::from("/tmp/byonk-cache"));
+        let c = ScreenRepoCache::new(std::path::PathBuf::from("/tmp/byonk-cache"));
         let a = c.checkout_dir("github.com/acme/x", "deadbeef");
         let b = c.checkout_dir("github.com/acme/x", "deadbeef");
         let d = c.checkout_dir("github.com/acme/y", "deadbeef");
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_has_false_when_absent() {
-        let c = PackageCache::new(std::env::temp_dir().join("byonk-cache-none"));
+        let c = ScreenRepoCache::new(std::env::temp_dir().join("byonk-cache-none"));
         assert!(!c.has("github.com/acme/x", "deadbeef"));
     }
 }

--- a/src/services/screen_repo_loader.rs
+++ b/src/services/screen_repo_loader.rs
@@ -1,9 +1,9 @@
-//! Screen-package registry: resolve a `handle/path` reference to a `ResolvedScreen`.
+//! Screen-screen repo registry: resolve a `handle/path` reference to a `ResolvedScreen`.
 //!
-//! A *package* is a collection of screens plus shared library/part files, described
+//! A *screen repo* is a collection of screens plus shared library/part files, described
 //! by a `byonk-screens.yaml` manifest at its root. Each screen lives in a directory
-//! that contains a `meta.yaml`. This module abstracts *where* a package's bytes come
-//! from (`PackageSource`) so screens can be served identically whether they are
+//! that contains a `meta.yaml`. This module abstracts *where* a screen repo's bytes come
+//! from (`ScreenRepoSource`) so screens can be served identically whether they are
 //! embedded in the binary (`byonk-builtin`) or dropped on disk.
 
 use std::collections::HashMap;
@@ -11,52 +11,52 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::assets::AssetLoader;
-use crate::models::package_manifest::PackageManifest;
 use crate::models::screen_meta::ScreenMeta;
+use crate::models::screen_repo_manifest::ScreenRepoManifest;
 
-/// The handle under which the built-in (embedded + `SCREENS_DIR`) package is registered.
+/// The handle under which the built-in (embedded + `SCREENS_DIR`) screen repo is registered.
 pub const BUILTIN_HANDLE: &str = "byonk-builtin";
 
-/// Reads any file within a package by package-root-relative (manifest-`root`-relative)
+/// Reads any file within a screen repo by screen-repo-root-relative (manifest-`root`-relative)
 /// path, using forward slashes. Implementations must be cheap to share across threads.
-pub trait PackageSource: Send + Sync {
-    /// Read a package file's raw bytes, or `None` if it does not exist.
+pub trait ScreenRepoSource: Send + Sync {
+    /// Read a screen repo file's raw bytes, or `None` if it does not exist.
     fn read(&self, rel: &str) -> Option<Vec<u8>>;
 
-    /// Read a package file as a UTF-8 string, or `None` if missing / not valid UTF-8.
+    /// Read a screen repo file as a UTF-8 string, or `None` if missing / not valid UTF-8.
     fn read_string(&self, rel: &str) -> Option<String> {
         self.read(rel).and_then(|b| String::from_utf8(b).ok())
     }
 
-    /// All screen directories in this package (dirs containing a `meta.yaml`),
-    /// relative to the manifest `root` (or the package root if no `root`).
+    /// All screen directories in this screen repo (dirs containing a `meta.yaml`),
+    /// relative to the manifest `root` (or the screen repo root if no `root`).
     fn screen_paths(&self) -> Vec<String>;
 
-    /// Package-relative paths of every `.svg` file in the package. Used to scope
-    /// Tera template registration to one package (screens + shared parts).
+    /// ScreenRepo-relative paths of every `.svg` file in the screen repo. Used to scope
+    /// Tera template registration to one screen repo (screens + shared parts).
     fn svg_files(&self) -> Vec<String>;
 
-    /// The parsed package manifest.
-    fn manifest(&self) -> &PackageManifest;
+    /// The parsed screen repo manifest.
+    fn manifest(&self) -> &ScreenRepoManifest;
 }
 
-/// A fully resolved screen: its parsed metadata plus a handle back to its package
+/// A fully resolved screen: its parsed metadata plus a handle back to its screen repo
 /// so siblings (`lib/*.lua` for `require`, `parts/*.svg` for includes) can be read.
 pub struct ResolvedScreen {
-    /// Package handle, e.g. `"byonk-builtin"` or `"acme"`.
+    /// ScreenRepo handle, e.g. `"byonk-builtin"` or `"acme"`.
     pub handle: String,
-    /// Screen path within the package, e.g. `"useful/gphoto"`.
+    /// Screen path within the screen repo, e.g. `"useful/gphoto"`.
     pub path: String,
     /// Parsed `meta.yaml`.
     pub meta: ScreenMeta,
-    /// The screen's package source, for reading sibling files.
-    pub source: Arc<dyn PackageSource>,
+    /// The screen's screen repo source, for reading sibling files.
+    pub source: Arc<dyn ScreenRepoSource>,
     /// Manifest-root-relative directory of the screen (same as `path`).
     pub screen_dir: String,
 }
 
-/// Join a manifest-`root` (or screen-dir) prefix with a package-relative path,
-/// using forward slashes. Shared by every read path (packages, includes,
+/// Join a manifest-`root` (or screen-dir) prefix with a screen-repo-relative path,
+/// using forward slashes. Shared by every read path (screen repos, includes,
 /// image-refs, `read_asset`).
 pub fn join_rel(prefix: &str, rel: &str) -> String {
     if prefix.is_empty() || prefix == "." {
@@ -66,12 +66,12 @@ pub fn join_rel(prefix: &str, rel: &str) -> String {
     }
 }
 
-/// True if `rel` is a safe package-relative path that stays inside the package.
+/// True if `rel` is a safe screen-repo-relative path that stays inside the screen repo.
 ///
 /// Rejects paths that are empty, absolute (`/…`), Windows drive/UNC-style
 /// (`C:\…`, leading `\`), or that contain any `..` path component (split on both
 /// `/` and `\`). This is the sandbox guard applied before every filesystem read
-/// so a screen can never escape its package via `require("../../etc/passwd")` or
+/// so a screen can never escape its screen repo via `require("../../etc/passwd")` or
 /// an SVG `href="../../secret"`.
 pub fn is_safe_rel(rel: &str) -> bool {
     if rel.is_empty() {
@@ -100,27 +100,27 @@ fn split_ref(screen_ref: &str) -> Option<(&str, &str)> {
     }
 }
 
-/// A package that lives in an on-disk directory. Files are read with `fs::read`;
+/// A screen repo that lives in an on-disk directory. Files are read with `fs::read`;
 /// screens are discovered by walking the manifest root for `meta.yaml` files.
-pub struct DiskPackageSource {
-    manifest: PackageManifest,
+pub struct DiskScreenRepoSource {
+    manifest: ScreenRepoManifest,
     /// Directory the manifest-relative paths resolve against (`root.join(manifest.root)`).
     manifest_root: PathBuf,
 }
 
-impl DiskPackageSource {
-    /// Load a disk package rooted at `root`. Returns `Err` (skip) if the
+impl DiskScreenRepoSource {
+    /// Load a disk screen repo rooted at `root`. Returns `Err` (skip) if the
     /// `byonk-screens.yaml` manifest is missing or invalid.
-    pub fn load(root: &Path) -> Result<DiskPackageSource, String> {
+    pub fn load(root: &Path) -> Result<DiskScreenRepoSource, String> {
         let manifest_path = root.join("byonk-screens.yaml");
         let src = std::fs::read_to_string(&manifest_path)
             .map_err(|e| format!("cannot read {}: {e}", manifest_path.display()))?;
-        let manifest = PackageManifest::from_yaml(&src)?;
+        let manifest = ScreenRepoManifest::from_yaml(&src)?;
         let manifest_root = match manifest.root.as_deref() {
             Some(r) if !r.is_empty() && r != "." => root.join(r),
             _ => root.to_path_buf(),
         };
-        Ok(DiskPackageSource {
+        Ok(DiskScreenRepoSource {
             manifest,
             manifest_root,
         })
@@ -166,7 +166,7 @@ impl DiskPackageSource {
     }
 }
 
-impl PackageSource for DiskPackageSource {
+impl ScreenRepoSource for DiskScreenRepoSource {
     fn read(&self, rel: &str) -> Option<Vec<u8>> {
         if !is_safe_rel(rel) {
             return None;
@@ -188,28 +188,28 @@ impl PackageSource for DiskPackageSource {
         out
     }
 
-    fn manifest(&self) -> &PackageManifest {
+    fn manifest(&self) -> &ScreenRepoManifest {
         &self.manifest
     }
 }
 
-/// The built-in package, backed by the embedded `screens/` tree (optionally
+/// The built-in screen repo, backed by the embedded `screens/` tree (optionally
 /// overlaid by `SCREENS_DIR`) via `AssetLoader`.
 pub struct EmbeddedBuiltinSource {
     loader: Arc<AssetLoader>,
-    manifest: PackageManifest,
+    manifest: ScreenRepoManifest,
     /// Manifest-`root` prefix within the screens tree (empty when no `root`).
     root_prefix: String,
 }
 
 impl EmbeddedBuiltinSource {
-    /// Load the built-in package. Returns `Err` (skip) if `byonk-screens.yaml`
+    /// Load the built-in screen repo. Returns `Err` (skip) if `byonk-screens.yaml`
     /// is missing or invalid.
     pub fn load(loader: Arc<AssetLoader>) -> Result<EmbeddedBuiltinSource, String> {
         let src = loader
             .read_screen_string(Path::new("byonk-screens.yaml"))
             .map_err(|e| format!("cannot read embedded byonk-screens.yaml: {e}"))?;
-        let manifest = PackageManifest::from_yaml(&src)?;
+        let manifest = ScreenRepoManifest::from_yaml(&src)?;
         let root_prefix = match manifest.root.as_deref() {
             Some(r) if !r.is_empty() && r != "." => r.trim_end_matches('/').to_string(),
             _ => String::new(),
@@ -222,7 +222,7 @@ impl EmbeddedBuiltinSource {
     }
 }
 
-impl PackageSource for EmbeddedBuiltinSource {
+impl ScreenRepoSource for EmbeddedBuiltinSource {
     fn read(&self, rel: &str) -> Option<Vec<u8>> {
         if !is_safe_rel(rel) {
             return None;
@@ -285,45 +285,45 @@ impl PackageSource for EmbeddedBuiltinSource {
         out
     }
 
-    fn manifest(&self) -> &PackageManifest {
+    fn manifest(&self) -> &ScreenRepoManifest {
         &self.manifest
     }
 }
 
-/// Resolves screen references against a registry of packages keyed by handle.
-pub struct PackageLoader {
-    registry: HashMap<String, Arc<dyn PackageSource>>,
+/// Resolves screen references against a registry of screen repos keyed by handle.
+pub struct ScreenRepoLoader {
+    registry: HashMap<String, Arc<dyn ScreenRepoSource>>,
 }
 
-impl PackageLoader {
+impl ScreenRepoLoader {
     /// Build a loader. The `byonk-builtin` handle is always registered (backed by
     /// the embedded tree + `SCREENS_DIR` overlay). Each `disk_packages` entry maps
-    /// a handle to a package root directory. Packages whose manifest is
+    /// a handle to a screen repo root directory. ScreenRepos whose manifest is
     /// missing/invalid are skipped with a warning.
     pub fn new(asset_loader: Arc<AssetLoader>, disk_packages: HashMap<String, PathBuf>) -> Self {
-        let mut registry: HashMap<String, Arc<dyn PackageSource>> = HashMap::new();
+        let mut registry: HashMap<String, Arc<dyn ScreenRepoSource>> = HashMap::new();
 
         match EmbeddedBuiltinSource::load(asset_loader) {
             Ok(src) => {
                 registry.insert(BUILTIN_HANDLE.to_string(), Arc::new(src));
             }
             Err(e) => {
-                tracing::warn!(error = %e, "skipping byonk-builtin package: unreadable manifest");
+                tracing::warn!(error = %e, "skipping byonk-builtin screen repo: unreadable manifest");
             }
         }
 
         for (handle, root) in disk_packages {
-            match DiskPackageSource::load(&root) {
+            match DiskScreenRepoSource::load(&root) {
                 Ok(src) => {
                     registry.insert(handle, Arc::new(src));
                 }
                 Err(e) => {
-                    tracing::warn!(handle = %handle, root = %root.display(), error = %e, "skipping disk package: invalid manifest");
+                    tracing::warn!(handle = %handle, root = %root.display(), error = %e, "skipping disk screen repo: invalid manifest");
                 }
             }
         }
 
-        PackageLoader { registry }
+        ScreenRepoLoader { registry }
     }
 
     /// Resolve `"handle/path"` to a screen. `None` if the handle is unknown, the
@@ -346,7 +346,7 @@ impl PackageLoader {
         })
     }
 
-    /// Resolve every screen in every registered package.
+    /// Resolve every screen in every registered screen repo.
     pub fn list_all(&self) -> Vec<ResolvedScreen> {
         let mut out = Vec::new();
         for (handle, source) in &self.registry {
@@ -359,7 +359,7 @@ impl PackageLoader {
         out
     }
 
-    /// All registered package handles.
+    /// All registered screen repo handles.
     pub fn handles(&self) -> Vec<String> {
         let mut h: Vec<String> = self.registry.keys().cloned().collect();
         h.sort();
@@ -404,7 +404,7 @@ mod tests {
         let loader = std::sync::Arc::new(crate::assets::AssetLoader::new(None, None, None));
         let mut disk = HashMap::new();
         disk.insert("acme".to_string(), tmp.clone());
-        let pl = PackageLoader::new(loader, disk);
+        let pl = ScreenRepoLoader::new(loader, disk);
 
         let r = pl.resolve("acme/weather/forecast").expect("resolve");
         assert_eq!(r.handle, "acme");
@@ -449,11 +449,11 @@ mod tests {
             "name: t\ndescription: d\nauthor: a\nlicense: MIT\n",
         );
         write(&tmp, "lib/util.lua", "return {}\n");
-        // A secret file OUTSIDE the package root (sibling of tmp).
+        // A secret file OUTSIDE the screen repo root (sibling of tmp).
         let secret = tmp.parent().unwrap().join("byonk_secret_marker.txt");
         fs::write(&secret, "TOP SECRET").unwrap();
 
-        let src = DiskPackageSource::load(&tmp).expect("load");
+        let src = DiskScreenRepoSource::load(&tmp).expect("load");
         // Legitimate read works.
         assert_eq!(
             src.read_string("lib/util.lua").as_deref(),
@@ -472,7 +472,7 @@ mod tests {
     #[test]
     fn test_builtin_always_registered() {
         let loader = std::sync::Arc::new(crate::assets::AssetLoader::new(None, None, None));
-        let pl = PackageLoader::new(loader, HashMap::new());
+        let pl = ScreenRepoLoader::new(loader, HashMap::new());
         assert!(pl.handles().contains(&"byonk-builtin".to_string()));
     }
 }

--- a/src/services/screen_repo_manager.rs
+++ b/src/services/screen_repo_manager.rs
@@ -1,18 +1,18 @@
-//! Orchestrates screen-package fetch/cache/refresh and serves a
-//! hot-swappable [`PackageLoader`] snapshot.
+//! Orchestrates screen repo fetch/cache/refresh and serves a
+//! hot-swappable [`ScreenRepoLoader`] snapshot.
 //!
-//! `PackageManager` is the single owner of "what package handles resolve to
-//! what bytes right now": it holds the [`PackageCache`] (fetched checkouts on
-//! disk), a per-handle [`PackageStatus`] store (fetch/error/offline state for
-//! `GET /packages`), and an [`ArcSwap`]-backed [`PackageLoader`] snapshot that
-//! call sites resolve screens against. Fetching a package never blocks
-//! readers: `refresh_one`/`refresh_all` build a brand new `PackageLoader` and
+//! `ScreenRepoManager` is the single owner of "what screen repo handles resolve to
+//! what bytes right now": it holds the [`ScreenRepoCache`] (fetched checkouts on
+//! disk), a per-handle [`ScreenRepoStatus`] store (fetch/error/offline state for
+//! `GET /screen-repos`), and an [`ArcSwap`]-backed [`ScreenRepoLoader`] snapshot that
+//! call sites resolve screens against. Fetching a screen repo never blocks
+//! readers: `refresh_one`/`refresh_all` build a brand new `ScreenRepoLoader` and
 //! atomically swap it in; in-flight `resolve()` calls against the old
 //! snapshot keep working against the old (still-valid) checkout until they
 //! naturally pick up the new one on their next call.
 //!
 //! This fixes Plan-1 follow-up #6: previously the loader was built once at
-//! startup and never rebuilt when `config.packages` changed.
+//! startup and never rebuilt when `config.screen_repos` changed.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -22,39 +22,39 @@ use arc_swap::ArcSwap;
 use chrono::Utc;
 
 use crate::assets::AssetLoader;
-use crate::models::config::PackageRef;
+use crate::models::config::ScreenRepoRef;
 use crate::server::SharedConfig;
 use crate::services::git_fetch;
-use crate::services::package_cache::PackageCache;
-use crate::services::package_loader::{PackageLoader, BUILTIN_HANDLE};
-use crate::services::package_status::{PackageState, PackageStatus};
+use crate::services::screen_repo_cache::ScreenRepoCache;
+use crate::services::screen_repo_loader::{ScreenRepoLoader, BUILTIN_HANDLE};
+use crate::services::screen_repo_status::{ScreenRepoState, ScreenRepoStatus};
 
-/// Owns package fetch orchestration + the live, hot-swappable [`PackageLoader`].
-pub struct PackageManager {
+/// Owns screen repo fetch orchestration + the live, hot-swappable [`ScreenRepoLoader`].
+pub struct ScreenRepoManager {
     asset_loader: Arc<AssetLoader>,
-    /// Reads `config.packages` fresh on every refresh (config can change
+    /// Reads `config.screen_repos` fresh on every refresh (config can change
     /// underneath us via the admin API).
     config: SharedConfig,
-    cache: PackageCache,
-    /// Per-handle fetch state, surfaced via `status_snapshot` for `GET /packages`.
-    status: Mutex<HashMap<String, PackageStatus>>,
+    cache: ScreenRepoCache,
+    /// Per-handle fetch state, surfaced via `status_snapshot` for `GET /screen-repos`.
+    status: Mutex<HashMap<String, ScreenRepoStatus>>,
     /// The live snapshot readers resolve screens against.
-    loader: ArcSwap<PackageLoader>,
-    /// `PACKAGES_DIR`-style dev packages that are always disk-backed, never fetched.
+    loader: ArcSwap<ScreenRepoLoader>,
+    /// `SCREEN_REPOS_DIR`-style dev screen repos that are always disk-backed, never fetched.
     extra_disk: HashMap<String, PathBuf>,
 }
 
-impl PackageManager {
+impl ScreenRepoManager {
     /// Build a manager and its initial loader snapshot (embedded builtin +
     /// `extra_disk` only — cache checkouts are added once `rebuild_loader`
     /// runs after a successful fetch).
     pub fn new(
         asset_loader: Arc<AssetLoader>,
         config: SharedConfig,
-        cache: PackageCache,
+        cache: ScreenRepoCache,
         extra_disk: HashMap<String, PathBuf>,
     ) -> Arc<Self> {
-        let initial = PackageLoader::new(asset_loader.clone(), extra_disk.clone());
+        let initial = ScreenRepoLoader::new(asset_loader.clone(), extra_disk.clone());
         Arc::new(Self {
             asset_loader,
             config,
@@ -66,11 +66,11 @@ impl PackageManager {
     }
 
     /// Current loader snapshot (cheap; call once per resolve, not once per file read).
-    pub fn loader(&self) -> Arc<PackageLoader> {
+    pub fn loader(&self) -> Arc<ScreenRepoLoader> {
         self.loader.load_full()
     }
 
-    /// Rebuild the loader from the embedded builtin (added by `PackageLoader::new`
+    /// Rebuild the loader from the embedded builtin (added by `ScreenRepoLoader::new`
     /// itself) + `extra_disk` + every registered handle whose status has a
     /// `resolved_sha` that's actually present in the cache, then swap it in.
     pub fn rebuild_loader(&self) {
@@ -78,7 +78,7 @@ impl PackageManager {
 
         let config = self.config.load();
         let status = self.lock_status();
-        for (handle, pkg_ref) in config.packages.iter() {
+        for (handle, pkg_ref) in config.screen_repos.iter() {
             if handle == BUILTIN_HANDLE {
                 continue;
             }
@@ -97,7 +97,7 @@ impl PackageManager {
         }
         drop(status);
 
-        let fresh = PackageLoader::new(self.asset_loader.clone(), disk_map);
+        let fresh = ScreenRepoLoader::new(self.asset_loader.clone(), disk_map);
         self.loader.store(Arc::new(fresh));
     }
 
@@ -109,7 +109,7 @@ impl PackageManager {
         if handle == BUILTIN_HANDLE {
             return;
         }
-        let pkg_ref: PackageRef = match self.config.load().packages.get(handle) {
+        let pkg_ref: ScreenRepoRef = match self.config.load().screen_repos.get(handle) {
             Some(p) => p.clone(),
             None => return,
         };
@@ -120,14 +120,14 @@ impl PackageManager {
         let token = pkg_ref.token.clone();
 
         self.update_status(handle, |st| {
-            st.state = Some(PackageState::Fetching);
+            st.state = Some(ScreenRepoState::Fetching);
         });
 
         // Immutable pin whose tree we already have on disk: reuse without a
         // network round-trip. A sha's content can never change underneath us.
         if git_fetch::looks_like_sha(&pin) && self.cache.has(&repo, &pin) {
             self.update_status(handle, |st| {
-                st.state = Some(PackageState::Ready);
+                st.state = Some(ScreenRepoState::Ready);
                 st.resolved_sha = Some(pin.clone());
                 st.pin_kind = Some(git_fetch::PinKind::Sha);
                 st.error = None;
@@ -160,7 +160,7 @@ impl PackageManager {
                     // same-handle refresh can't race the move.
                     cleanup_scratch(&scratch);
                     self.update_status(handle, |st| {
-                        st.state = Some(PackageState::Ready);
+                        st.state = Some(ScreenRepoState::Ready);
                         st.resolved_sha = Some(fetched.resolved_sha.clone());
                         st.pin_kind = Some(fetched.pin_kind);
                         st.last_fetched = Some(Utc::now());
@@ -186,10 +186,10 @@ impl PackageManager {
                 tracing::info!(
                     handle = %handle,
                     sha = %fetched.resolved_sha,
-                    "package refreshed"
+                    "screen repo refreshed"
                 );
                 self.update_status(handle, |st| {
-                    st.state = Some(PackageState::Ready);
+                    st.state = Some(ScreenRepoState::Ready);
                     st.resolved_sha = Some(fetched.resolved_sha.clone());
                     st.pin_kind = Some(fetched.pin_kind);
                     st.last_fetched = Some(Utc::now());
@@ -200,12 +200,12 @@ impl PackageManager {
             Err(e) => {
                 cleanup_scratch(&scratch);
                 // `e`/`message` is already userinfo-redacted by git_fetch; the
-                // handle is operator-chosen. Log it so a failing package fetch
-                // is visible in the add-on log, not only in the per-package
-                // status surfaced by `GET /packages`.
+                // handle is operator-chosen. Log it so a failing screen repo fetch
+                // is visible in the add-on log, not only in the per-screen repo
+                // status surfaced by `GET /screen-repos`.
                 let message = e.to_string();
                 let state = self.state_after_post_fetch_failure(handle, &repo);
-                tracing::warn!(handle = %handle, state = ?state, "package fetch failed: {message}");
+                tracing::warn!(handle = %handle, state = ?state, "screen repo fetch failed: {message}");
                 self.update_status(handle, |st| {
                     st.state = Some(state);
                     st.error = Some(message);
@@ -214,7 +214,7 @@ impl PackageManager {
         }
     }
 
-    /// Fetch every registered non-builtin package that needs it, then
+    /// Fetch every registered non-builtin screen repo that needs it, then
     /// rebuild+swap the loader once. Skipping is keyed on **pin shape**, not
     /// run-time state: a sha pin is immutable, so an already-cached sha is
     /// left alone (`!force`); a tag/branch pin is mutable and must always get
@@ -227,7 +227,7 @@ impl PackageManager {
         let handles: Vec<String> = self
             .config
             .load()
-            .packages
+            .screen_repos
             .iter()
             .filter(|(handle, pkg_ref)| handle.as_str() != BUILTIN_HANDLE && pkg_ref.repo.is_some())
             .map(|(handle, _)| handle.clone())
@@ -242,25 +242,25 @@ impl PackageManager {
         self.rebuild_loader();
     }
 
-    /// Snapshot of per-handle status for `GET /packages`.
-    pub fn status_snapshot(&self) -> HashMap<String, PackageStatus> {
+    /// Snapshot of per-handle status for `GET /screen-repos`.
+    pub fn status_snapshot(&self) -> HashMap<String, ScreenRepoStatus> {
         self.lock_status().clone()
     }
 
-    /// Remove `handle`'s fetch status entry, e.g. after `delete_package` so a
+    /// Remove `handle`'s fetch status entry, e.g. after `delete_screen_repo` so a
     /// later re-registration of the same handle doesn't briefly surface the
-    /// stale `resolved_sha`/`Ready` state from the deleted package.
+    /// stale `resolved_sha`/`Ready` state from the deleted screen repo.
     pub fn forget_status(&self, handle: &str) {
         self.lock_status().remove(handle);
     }
 
     /// True only when `handle`'s configured pin is a sha (immutable) *and*
     /// that sha is already cached on disk. A tag/branch pin always returns
-    /// false, regardless of run-time `PackageStatus`, so `refresh_all(false)`
+    /// false, regardless of run-time `ScreenRepoStatus`, so `refresh_all(false)`
     /// can't skip it forever once it's first fetched.
     fn pin_is_immutable_and_cached(&self, handle: &str) -> bool {
         let config = self.config.load();
-        let Some(pkg_ref) = config.packages.get(handle) else {
+        let Some(pkg_ref) = config.screen_repos.get(handle) else {
             return false;
         };
         let Some(repo) = pkg_ref.repo.as_deref() else {
@@ -276,7 +276,7 @@ impl PackageManager {
     /// successful fetch failing to install): `Offline` when a prior checkout
     /// is still cached (keep serving it), `Error` when there's nothing to
     /// fall back to.
-    fn state_after_post_fetch_failure(&self, handle: &str, repo: &str) -> PackageState {
+    fn state_after_post_fetch_failure(&self, handle: &str, repo: &str) -> ScreenRepoState {
         let prior_sha = self
             .lock_status()
             .get(handle)
@@ -285,19 +285,19 @@ impl PackageManager {
             .as_deref()
             .is_some_and(|sha| self.cache.has(repo, sha));
         if still_cached {
-            PackageState::Offline
+            ScreenRepoState::Offline
         } else {
-            PackageState::Error
+            ScreenRepoState::Error
         }
     }
 
-    fn lock_status(&self) -> std::sync::MutexGuard<'_, HashMap<String, PackageStatus>> {
+    fn lock_status(&self) -> std::sync::MutexGuard<'_, HashMap<String, ScreenRepoStatus>> {
         self.status
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    fn update_status(&self, handle: &str, f: impl FnOnce(&mut PackageStatus)) {
+    fn update_status(&self, handle: &str, f: impl FnOnce(&mut ScreenRepoStatus)) {
         let mut guard = self.lock_status();
         let entry = guard.entry(handle.to_string()).or_default();
         f(entry);
@@ -372,9 +372,9 @@ mod tests {
         ))
     }
 
-    fn shared_config(packages: HashMap<String, PackageRef>) -> SharedConfig {
+    fn shared_config(screen_repos: HashMap<String, ScreenRepoRef>) -> SharedConfig {
         let mut config = AppConfig::default();
-        config.packages = packages;
+        config.screen_repos = screen_repos;
         Arc::new(ArcSwap::from_pointee(config))
     }
 
@@ -382,9 +382,9 @@ mod tests {
         Arc::new(AssetLoader::new(None, None, None))
     }
 
-    /// Build a fixture package dir with one screen (`weather/forecast`) plus
-    /// a root `byonk-screens.yaml`, mirroring the Plan-1 `PackageLoader`
-    /// fixture pattern (see `package_loader.rs` tests).
+    /// Build a fixture screen repo dir with one screen (`weather/forecast`) plus
+    /// a root `byonk-screens.yaml`, mirroring the Plan-1 `ScreenRepoLoader`
+    /// fixture pattern (see `screen_repo_loader.rs` tests).
     fn make_disk_package(name_prefix: &str) -> PathBuf {
         let tmp = tempdir_path(name_prefix);
         write(
@@ -410,20 +410,20 @@ mod tests {
     fn test_manager_serves_extra_disk_package_and_reports_builtin() {
         let tmp = make_disk_package("pkgmgr_disk");
 
-        let mut packages = HashMap::new();
-        packages.insert("acme".to_string(), PackageRef::default());
-        let config = shared_config(packages);
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert("acme".to_string(), ScreenRepoRef::default());
+        let config = shared_config(screen_repos);
 
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache"));
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache"));
         let mut extra_disk = HashMap::new();
         extra_disk.insert("acme".to_string(), tmp.clone());
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, extra_disk);
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, extra_disk);
         mgr.rebuild_loader();
 
         assert!(mgr.loader().resolve("acme/weather/forecast").is_some());
         assert!(mgr.loader().handles().iter().any(|h| h == "byonk-builtin"));
-        // A disk-only package (no `repo`) never gets fetch state.
+        // A disk-only screen repo (no `repo`) never gets fetch state.
         assert!(mgr
             .status_snapshot()
             .get("acme")
@@ -434,13 +434,13 @@ mod tests {
     }
 
     /// A source fixture git repo built on disk with the system `git` binary
-    /// (a valid screen package committed on its default branch), used as a
+    /// (a valid screen screen repo committed on its default branch), used as a
     /// hermetic `refresh_one`/`refresh_all` source via a plain filesystem
     /// path — no network involved.
     struct FixtureRepo {
         /// On-disk path (for fs cleanup / upstream mutation in tests).
         dir: PathBuf,
-        /// `file://` URL of `dir` (a package `repo:` must carry a scheme).
+        /// `file://` URL of `dir` (a screen repo `repo:` must carry a scheme).
         url: String,
         branch: String,
         head_sha: String,
@@ -521,24 +521,24 @@ mod tests {
     #[test]
     fn test_refresh_one_fetches_and_serves_from_local_repo() {
         let src = make_fixture_repo();
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some(src.url.clone()),
                 pin: Some(src.branch.clone()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_fetch"));
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_fetch"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_one("weather");
 
         let status = mgr.status_snapshot();
         let st = status.get("weather").expect("status recorded");
-        assert_eq!(st.state, Some(PackageState::Ready));
+        assert_eq!(st.state, Some(ScreenRepoState::Ready));
         assert_eq!(st.resolved_sha.as_deref(), Some(src.head_sha.as_str()));
         assert!(st.last_fetched.is_some());
 
@@ -558,20 +558,20 @@ mod tests {
         // `refresh_one` (branch unchanged, same resolved sha) leaves it
         // untouched.
         let src = make_fixture_repo();
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some(src.url.clone()),
                 pin: Some(src.branch.clone()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
+        let config = shared_config(screen_repos);
         let cache_root = tempdir_path("pkgmgr_cache_no_teardown");
-        let cache = PackageCache::new(cache_root.clone());
+        let cache = ScreenRepoCache::new(cache_root.clone());
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_one("weather");
         let sha = mgr
             .status_snapshot()
@@ -580,7 +580,7 @@ mod tests {
             .expect("resolved after first refresh_one");
         assert_eq!(sha, src.head_sha);
 
-        let probe_cache = PackageCache::new(cache_root);
+        let probe_cache = ScreenRepoCache::new(cache_root);
         let dest = probe_cache.checkout_dir(&src.url, &sha);
         let sentinel = dest.join("_sentinel");
         fs::write(&sentinel, b"x").unwrap();
@@ -590,7 +590,7 @@ mod tests {
         mgr.refresh_one("weather");
         let status = mgr.status_snapshot();
         let st = status.get("weather").unwrap();
-        assert_eq!(st.state, Some(PackageState::Ready));
+        assert_eq!(st.state, Some(ScreenRepoState::Ready));
         assert_eq!(st.resolved_sha.as_deref(), Some(src.head_sha.as_str()));
         assert!(
             sentinel.exists(),
@@ -602,24 +602,24 @@ mod tests {
 
     #[test]
     fn test_refresh_one_error_when_repo_missing_and_never_cached() {
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "ghost".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some("file:///no/such/repo/on/disk".to_string()),
                 pin: Some("main".to_string()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_err"));
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_err"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_one("ghost");
 
         let status = mgr.status_snapshot();
         let st = status.get("ghost").expect("status recorded");
-        assert_eq!(st.state, Some(PackageState::Error));
+        assert_eq!(st.state, Some(ScreenRepoState::Error));
         assert!(st.error.is_some());
         assert!(st.resolved_sha.is_none());
     }
@@ -627,23 +627,23 @@ mod tests {
     #[test]
     fn test_refresh_one_goes_offline_when_fetch_fails_but_prior_checkout_cached() {
         let src = make_fixture_repo();
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some(src.url.clone()),
                 pin: Some(src.branch.clone()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_offline"));
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_offline"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_one("weather");
         assert_eq!(
             mgr.status_snapshot().get("weather").unwrap().state,
-            Some(PackageState::Ready)
+            Some(ScreenRepoState::Ready)
         );
 
         // Repo host goes away (deleted/unreachable) — same `repo` string
@@ -655,7 +655,7 @@ mod tests {
         mgr.refresh_one("weather");
         let status = mgr.status_snapshot();
         let st = status.get("weather").unwrap();
-        assert_eq!(st.state, Some(PackageState::Offline));
+        assert_eq!(st.state, Some(ScreenRepoState::Offline));
         // Old resolved sha is preserved so the loader keeps serving it.
         assert_eq!(st.resolved_sha.as_deref(), Some(src.head_sha.as_str()));
         assert!(mgr.loader().resolve("weather/weather/forecast").is_some());
@@ -665,13 +665,13 @@ mod tests {
 
     #[test]
     fn test_refresh_one_noop_for_builtin_and_disk_only_handles() {
-        let mut packages = HashMap::new();
-        packages.insert(BUILTIN_HANDLE.to_string(), PackageRef::default());
-        packages.insert("acme".to_string(), PackageRef::default()); // no repo
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_noop"));
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(BUILTIN_HANDLE.to_string(), ScreenRepoRef::default());
+        screen_repos.insert("acme".to_string(), ScreenRepoRef::default()); // no repo
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_noop"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_one(BUILTIN_HANDLE);
         mgr.refresh_one("acme");
         mgr.refresh_one("unknown-handle");
@@ -682,23 +682,23 @@ mod tests {
     #[test]
     fn test_refresh_all_skips_already_ready_unless_forced() {
         let src = make_fixture_repo();
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some(src.url.clone()),
                 pin: Some(src.branch.clone()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_refresh_all"));
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_refresh_all"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_all(false);
         assert_eq!(
             mgr.status_snapshot().get("weather").unwrap().state,
-            Some(PackageState::Ready)
+            Some(ScreenRepoState::Ready)
         );
 
         // Re-running is idempotent either way: a branch pin is re-fetched
@@ -710,7 +710,7 @@ mod tests {
         mgr.refresh_all(true);
         assert_eq!(
             mgr.status_snapshot().get("weather").unwrap().state,
-            Some(PackageState::Ready)
+            Some(ScreenRepoState::Ready)
         );
 
         let _ = fs::remove_dir_all(&src.dir);
@@ -722,19 +722,19 @@ mod tests {
         // so it picks up upstream moves — it must never be skipped just
         // because the handle is already `Ready` with a cached checkout.
         let src = make_fixture_repo();
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some(src.url.clone()),
                 pin: Some(src.branch.clone()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_refresh_all_branch"));
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_refresh_all_branch"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_all(false);
         let first_sha = mgr
             .status_snapshot()
@@ -770,7 +770,7 @@ mod tests {
         mgr.refresh_all(false);
         let status = mgr.status_snapshot();
         let st = status.get("weather").unwrap();
-        assert_eq!(st.state, Some(PackageState::Ready));
+        assert_eq!(st.state, Some(ScreenRepoState::Ready));
         assert_eq!(
             st.resolved_sha.as_deref(),
             Some(second_sha.as_str()),
@@ -785,23 +785,23 @@ mod tests {
         // A sha pin is immutable: once cached, `refresh_all(false)` must
         // leave it alone, even if upstream becomes unreachable.
         let src = make_fixture_repo();
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some(src.url.clone()),
                 pin: Some(src.head_sha.clone()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_refresh_all_sha"));
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_refresh_all_sha"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_all(false);
         assert_eq!(
             mgr.status_snapshot().get("weather").unwrap().state,
-            Some(PackageState::Ready)
+            Some(ScreenRepoState::Ready)
         );
         assert_eq!(
             mgr.status_snapshot()
@@ -819,7 +819,7 @@ mod tests {
         mgr.refresh_all(false);
         let status = mgr.status_snapshot();
         let st = status.get("weather").unwrap();
-        assert_eq!(st.state, Some(PackageState::Ready));
+        assert_eq!(st.state, Some(ScreenRepoState::Ready));
         assert!(st.error.is_none());
         assert_eq!(st.resolved_sha.as_deref(), Some(src.head_sha.as_str()));
     }
@@ -832,20 +832,20 @@ mod tests {
         // rule the sibling `git_fetch::fetch` `Err` branch already applies —
         // not unconditionally `Error`.
         let src = make_fixture_repo();
-        let mut packages = HashMap::new();
-        packages.insert(
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert(
             "weather".to_string(),
-            PackageRef {
+            ScreenRepoRef {
                 repo: Some(src.url.clone()),
                 pin: Some(src.branch.clone()),
                 token: None,
             },
         );
-        let config = shared_config(packages);
+        let config = shared_config(screen_repos);
         let cache_root = tempdir_path("pkgmgr_cache_install_fail");
-        let cache = PackageCache::new(cache_root.clone());
+        let cache = ScreenRepoCache::new(cache_root.clone());
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.refresh_one("weather");
         let sha1 = mgr
             .status_snapshot()
@@ -878,7 +878,7 @@ mod tests {
         .trim()
         .to_string();
 
-        let probe_cache = PackageCache::new(cache_root);
+        let probe_cache = ScreenRepoCache::new(cache_root);
         let dest = probe_cache.checkout_dir(&src.url, &sha2);
         fs::create_dir_all(dest.parent().unwrap()).unwrap();
         fs::write(&dest, b"not a directory, so move_dir's install fails").unwrap();
@@ -888,7 +888,7 @@ mod tests {
         let st = status.get("weather").unwrap();
         assert_eq!(
             st.state,
-            Some(PackageState::Offline),
+            Some(ScreenRepoState::Offline),
             "install failure with a prior cached checkout must report Offline, not Error"
         );
         assert!(st.error.is_some());
@@ -903,14 +903,14 @@ mod tests {
 
     #[test]
     fn test_forget_status_clears_entry() {
-        let mut packages = HashMap::new();
-        packages.insert("acme".to_string(), PackageRef::default());
-        let config = shared_config(packages);
-        let cache = PackageCache::new(tempdir_path("pkgmgr_cache_forget"));
+        let mut screen_repos = HashMap::new();
+        screen_repos.insert("acme".to_string(), ScreenRepoRef::default());
+        let config = shared_config(screen_repos);
+        let cache = ScreenRepoCache::new(tempdir_path("pkgmgr_cache_forget"));
 
-        let mgr = PackageManager::new(asset_loader(), config, cache, HashMap::new());
+        let mgr = ScreenRepoManager::new(asset_loader(), config, cache, HashMap::new());
         mgr.update_status("acme", |st| {
-            st.state = Some(PackageState::Ready);
+            st.state = Some(ScreenRepoState::Ready);
             st.resolved_sha = Some("deadbeef".to_string());
         });
         assert!(mgr.status_snapshot().contains_key("acme"));

--- a/src/services/screen_repo_status.rs
+++ b/src/services/screen_repo_status.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum PackageState {
+pub enum ScreenRepoState {
     Ready,
     Fetching,
     Error,
@@ -8,8 +8,8 @@ pub enum PackageState {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct PackageStatus {
-    pub state: Option<PackageState>,
+pub struct ScreenRepoStatus {
+    pub state: Option<ScreenRepoState>,
     pub resolved_sha: Option<String>,
     pub last_fetched: Option<chrono::DateTime<chrono::Utc>>,
     pub error: Option<String>,
@@ -23,18 +23,18 @@ mod tests {
     #[test]
     fn test_state_serializes_snake_case() {
         assert_eq!(
-            serde_json::to_string(&PackageState::Offline).unwrap(),
+            serde_json::to_string(&ScreenRepoState::Offline).unwrap(),
             "\"offline\""
         );
         assert_eq!(
-            serde_json::to_string(&PackageState::Fetching).unwrap(),
+            serde_json::to_string(&ScreenRepoState::Fetching).unwrap(),
             "\"fetching\""
         );
     }
 
     #[test]
     fn test_default_status_is_empty() {
-        let s = PackageStatus::default();
+        let s = ScreenRepoStatus::default();
         assert!(s.state.is_none() && s.resolved_sha.is_none() && s.error.is_none());
     }
 }

--- a/src/services/template_service.rs
+++ b/src/services/template_service.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, OnceLock};
 use tera::{Context, Tera};
 
 use crate::assets::AssetLoader;
-use crate::services::package_loader::{join_rel, PackageSource};
+use crate::services::screen_repo_loader::{join_rel, ScreenRepoSource};
 
 /// Compiled regex for matching image href attributes in SVG.
 /// Uses OnceLock to compile once and reuse across all render calls.
@@ -96,21 +96,21 @@ impl TemplateService {
         );
     }
 
-    /// Render a screen template with the given data, scoped to one package.
+    /// Render a screen template with the given data, scoped to one screen repo.
     ///
     /// Templates are always loaded fresh (to support live editing). Every base
-    /// asset is registered under `byonk-base-<v>/…` and every package `.svg` under
-    /// its package-relative name, so `{% include %}`/`{% extends %}` can only reach
-    /// the screen's own package plus the embedded `byonk-base` library.
+    /// asset is registered under `byonk-base-<v>/…` and every screen repo `.svg` under
+    /// its screen-repo-relative name, so `{% include %}`/`{% extends %}` can only reach
+    /// the screen's own screen repo plus the embedded `byonk-base` library.
     ///
     /// * `template_src` — the resolved `screen.svg` contents.
-    /// * `source` — the screen's package source (for sibling includes/parts).
-    /// * `screen_path` — the screen's package-relative directory (for image refs
+    /// * `source` — the screen's screen repo source (for sibling includes/parts).
+    /// * `screen_path` — the screen's screen-repo-relative directory (for image refs
     ///   and the main template name).
     pub fn render(
         &self,
         template_src: &str,
-        source: &Arc<dyn PackageSource>,
+        source: &Arc<dyn ScreenRepoSource>,
         screen_path: &str,
         data: &serde_json::Value,
     ) -> Result<String, TemplateError> {
@@ -127,11 +127,11 @@ impl TemplateService {
             }
         }
 
-        // Register every package `.svg` under its package-relative name.
+        // Register every screen repo `.svg` under its screen-repo-relative name.
         for p in source.svg_files() {
             if let Some(content) = source.read_string(&p) {
                 if let Err(e) = tera.add_raw_template(&p, &content) {
-                    tracing::trace!(template = %p, error = %e, "Skipped package template");
+                    tracing::trace!(template = %p, error = %e, "Skipped screen repo template");
                 }
             }
         }
@@ -146,7 +146,7 @@ impl TemplateService {
         let context = Context::from_serialize(data)?;
         let svg = tera.render(&main_name, &context)?;
 
-        // Resolve relative image references to data URIs (package-relative to the
+        // Resolve relative image references to data URIs (screen-repo-relative to the
         // screen directory).
         let svg = self.resolve_image_refs(&svg, source, screen_path)?;
 
@@ -157,11 +157,11 @@ impl TemplateService {
     ///
     /// Scans for `<image ... href="..."/>` elements and replaces relative paths
     /// with base64-encoded data URIs. Paths like `logo.png` are resolved to the
-    /// package file at `<screen_dir>/logo.png`.
+    /// screen repo file at `<screen_dir>/logo.png`.
     fn resolve_image_refs(
         &self,
         svg: &str,
-        source: &Arc<dyn PackageSource>,
+        source: &Arc<dyn ScreenRepoSource>,
         screen_dir: &str,
     ) -> Result<String, TemplateError> {
         use base64::Engine;
@@ -188,10 +188,10 @@ impl TemplateService {
                 continue;
             }
 
-            // Build the package-relative asset path: <screen_dir>/<href>
+            // Build the screen-repo-relative asset path: <screen_dir>/<href>
             let asset_rel = join_rel(screen_dir, href);
 
-            // Try to read the asset from the package
+            // Try to read the asset from the screen repo
             match source.read(&asset_rel) {
                 Some(data) => {
                     // Determine MIME type from extension
@@ -352,7 +352,7 @@ mod tests {
         assert!(base.iter().any(|s| s == "v1/status_bar.svg"));
     }
 
-    /// In-memory package source for render tests.
+    /// In-memory screen repo source for render tests.
     struct TestSource {
         files: std::collections::HashMap<String, Vec<u8>>,
     }
@@ -366,7 +366,7 @@ mod tests {
             }
         }
     }
-    impl PackageSource for TestSource {
+    impl ScreenRepoSource for TestSource {
         fn read(&self, rel: &str) -> Option<Vec<u8>> {
             self.files.get(rel).cloned()
         }
@@ -383,7 +383,7 @@ mod tests {
             v.sort();
             v
         }
-        fn manifest(&self) -> &crate::models::package_manifest::PackageManifest {
+        fn manifest(&self) -> &crate::models::screen_repo_manifest::ScreenRepoManifest {
             unreachable!("manifest() not used by render()")
         }
     }
@@ -394,9 +394,9 @@ mod tests {
 
     #[test]
     fn test_render_uses_byonk_base_include() {
-        // screen.svg includes a base asset AND a package-relative part, and
+        // screen.svg includes a base asset AND a screen-repo-relative part, and
         // interpolates a data value.
-        let src: Arc<dyn PackageSource> = Arc::new(TestSource::new(&[(
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(TestSource::new(&[(
             "weather/parts/x.svg",
             "<rect id=\"part\"/>",
         )]));
@@ -404,10 +404,10 @@ mod tests {
         let data = serde_json::json!({ "data": { "n": 42 }, "layout": { "grey_count": 4 } });
         let out = svc().render(template, &src, "weather", &data).unwrap();
 
-        // The package part and the interpolated value both appear.
+        // The screen repo part and the interpolated value both appear.
         assert!(
             out.contains("<rect id=\"part\"/>"),
-            "missing package part: {out}"
+            "missing screen repo part: {out}"
         );
         assert!(out.contains("<t>42</t>"), "missing interpolation: {out}");
         // The base include resolved to some content from v1/hinting.svg (non-empty
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_render_package_extends() {
-        let src: Arc<dyn PackageSource> = Arc::new(TestSource::new(&[(
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(TestSource::new(&[(
             "weather/base.svg",
             "<svg><g>{% block content %}{% endblock %}</g></svg>",
         )]));
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_render_missing_include_fails() {
-        let src: Arc<dyn PackageSource> = Arc::new(TestSource::new(&[]));
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(TestSource::new(&[]));
         let template = r#"<svg>{% include "weather/nope.svg" %}</svg>"#;
         let data = serde_json::json!({});
         assert!(svc().render(template, &src, "weather", &data).is_err());
@@ -437,11 +437,11 @@ mod tests {
 
     #[test]
     fn test_render_resolves_image_ref_from_package() {
-        // A 1x1 PNG in the package, referenced relatively from the screen dir.
+        // A 1x1 PNG in the screen repo, referenced relatively from the screen dir.
         let png = b"\x89PNG\r\n\x1a\n";
         let mut files = std::collections::HashMap::new();
         files.insert("weather/logo.png".to_string(), png.to_vec());
-        let src: Arc<dyn PackageSource> = Arc::new(TestSource { files });
+        let src: Arc<dyn ScreenRepoSource> = Arc::new(TestSource { files });
         let template = r#"<svg><image href="logo.png"/></svg>"#;
         let data = serde_json::json!({});
         let out = svc().render(template, &src, "weather", &data).unwrap();

--- a/tests/addon_manifest_test.rs
+++ b/tests/addon_manifest_test.rs
@@ -84,13 +84,13 @@ fn addon_config_matches_design() {
     // Remote screen-package cache lives in the add-on's persistent /data so it
     // survives restarts/rebuilds (unset would fall back to an ephemeral temp dir).
     assert_eq!(
-        cfg["environment"]["PACKAGES_CACHE_DIR"].as_str(),
+        cfg["environment"]["SCREEN_REPOS_CACHE_DIR"].as_str(),
         Some("/data/packages")
     );
 
     // schema exposes EXACTLY the add-on-owned options: admin_token + log_level
     // (Phase 2) plus the genuinely-global settings and the package registry
-    // (Plan A — add-on-owned global config: auth_mode, package_refresh_interval,
+    // (Plan A — add-on-owned global config: auth_mode, screen_repo_refresh_interval,
     // packages). The operational registration_enabled toggle and per-device
     // config are NOT here — they stay live via the admin API / HA integration.
     let schema_keys: std::collections::BTreeSet<&str> = cfg["schema"]
@@ -103,14 +103,14 @@ fn addon_config_matches_design() {
         "admin_token",
         "log_level",
         "auth_mode",
-        "package_refresh_interval",
-        "packages",
+        "screen_repo_refresh_interval",
+        "screen_repos",
     ]
     .into_iter()
     .collect();
     assert_eq!(
         schema_keys, expected,
         "add-on schema must expose exactly admin_token, log_level, auth_mode, \
-         package_refresh_interval, and packages"
+         screen_repo_refresh_interval, and packages"
     );
 }

--- a/tests/admin_read_test.rs
+++ b/tests/admin_read_test.rs
@@ -76,18 +76,18 @@ async fn test_config_requires_auth() {
 }
 
 /// Security: package tokens must NOT appear in GET /api/admin/config.
-/// `PackageRef.token` is documented "Secret token; redacted in read APIs".
+/// `ScreenRepoRef.token` is documented "Secret token; redacted in read APIs".
 #[tokio::test]
 async fn test_config_redacts_package_token() {
     let dir = tempfile::tempdir().unwrap();
-    let yaml = "admin:\n  token: secret\npackages:\n  mypkg:\n    repo: https://github.com/example/screens\n    pin: v1.0.0\n    token: pkg-secret-abc\n";
+    let yaml = "admin:\n  token: secret\nscreen_repos:\n  mypkg:\n    repo: https://github.com/example/screens\n    pin: v1.0.0\n    token: pkg-secret-abc\n";
     let (app, _) = TestApp::new_with_config_yaml(yaml, dir.path());
     let resp = app.get_with_headers("/api/admin/config", &[AUTH]).await;
     assert_eq!(resp.status, StatusCode::OK);
     let json: serde_json::Value = resp.json();
 
     // The package entry should be present with repo and pin intact.
-    let pkg = &json["packages"]["mypkg"];
+    let pkg = &json["screen_repos"]["mypkg"];
     assert_eq!(
         pkg["repo"].as_str(),
         Some("https://github.com/example/screens"),

--- a/tests/admin_screen_repos_test.rs
+++ b/tests/admin_screen_repos_test.rs
@@ -12,7 +12,7 @@ async fn test_add_package_persists_and_lists_with_token_redacted() {
 
     let resp = app
         .post_json(
-            "/api/admin/packages",
+            "/api/admin/screen-repos",
             &[AUTH],
             r#"{"handle":"weather","repo":"github.com/x/y","pin":"v1","token":"secret-token"}"#,
         )
@@ -20,7 +20,9 @@ async fn test_add_package_persists_and_lists_with_token_redacted() {
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
 
     // GET /packages shows the new handle with token_set true.
-    let listed = app.get_with_headers("/api/admin/packages", &[AUTH]).await;
+    let listed = app
+        .get_with_headers("/api/admin/screen-repos", &[AUTH])
+        .await;
     assert_eq!(listed.status, StatusCode::OK);
     let json: serde_json::Value = listed.json();
     let row = json
@@ -48,10 +50,14 @@ async fn test_add_package_duplicate_handle_conflicts() {
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
 
     let body = r#"{"handle":"weather","repo":"github.com/x/y","pin":"v1"}"#;
-    let first = app.post_json("/api/admin/packages", &[AUTH], body).await;
+    let first = app
+        .post_json("/api/admin/screen-repos", &[AUTH], body)
+        .await;
     assert_eq!(first.status, StatusCode::OK);
 
-    let second = app.post_json("/api/admin/packages", &[AUTH], body).await;
+    let second = app
+        .post_json("/api/admin/screen-repos", &[AUTH], body)
+        .await;
     assert_eq!(second.status, StatusCode::CONFLICT);
 }
 
@@ -62,7 +68,7 @@ async fn test_add_package_builtin_handle_conflicts() {
 
     let resp = app
         .post_json(
-            "/api/admin/packages",
+            "/api/admin/screen-repos",
             &[AUTH],
             r#"{"handle":"byonk-builtin","repo":"github.com/x/y"}"#,
         )
@@ -76,7 +82,7 @@ async fn test_delete_builtin_package_conflicts() {
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
 
     let resp = app
-        .delete("/api/admin/packages/byonk-builtin", &[AUTH])
+        .delete("/api/admin/screen-repos/byonk-builtin", &[AUTH])
         .await;
     assert!(resp.status.is_client_error(), "status: {}", resp.status);
 }
@@ -88,14 +94,16 @@ async fn test_delete_unreferenced_package_succeeds() {
 
     let resp = app
         .post_json(
-            "/api/admin/packages",
+            "/api/admin/screen-repos",
             &[AUTH],
             r#"{"handle":"weather","repo":"github.com/x/y","pin":"v1"}"#,
         )
         .await;
     assert_eq!(resp.status, StatusCode::OK);
 
-    let listed = app.get_with_headers("/api/admin/packages", &[AUTH]).await;
+    let listed = app
+        .get_with_headers("/api/admin/screen-repos", &[AUTH])
+        .await;
     let json: serde_json::Value = listed.json();
     assert!(json
         .as_array()
@@ -104,10 +112,12 @@ async fn test_delete_unreferenced_package_succeeds() {
         .any(|p| p["handle"] == "weather"));
 
     // No device references `weather/...`: delete succeeds.
-    let del = app.delete("/api/admin/packages/weather", &[AUTH]).await;
+    let del = app.delete("/api/admin/screen-repos/weather", &[AUTH]).await;
     assert_eq!(del.status, StatusCode::OK, "body: {}", del.text());
 
-    let listed = app.get_with_headers("/api/admin/packages", &[AUTH]).await;
+    let listed = app
+        .get_with_headers("/api/admin/screen-repos", &[AUTH])
+        .await;
     let json: serde_json::Value = listed.json();
     assert!(!json
         .as_array()
@@ -124,7 +134,7 @@ async fn test_delete_package_referenced_by_device_is_conflict() {
     // Register the package.
     let resp = app
         .post_json(
-            "/api/admin/packages",
+            "/api/admin/screen-repos",
             &[AUTH],
             r#"{"handle":"weather","repo":"github.com/x/y","pin":"v1"}"#,
         )
@@ -159,12 +169,12 @@ async fn test_delete_package_referenced_by_device_is_conflict() {
         .patch_json(
             "/api/admin/settings",
             &[AUTH],
-            r#"{"package_refresh_interval":1}"#,
+            r#"{"screen_repo_refresh_interval":1}"#,
         )
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
 
-    let del = app.delete("/api/admin/packages/weather", &[AUTH]).await;
+    let del = app.delete("/api/admin/screen-repos/weather", &[AUTH]).await;
     assert_eq!(del.status, StatusCode::CONFLICT, "body: {}", del.text());
     assert!(
         del.text().contains("AA:BB:CC:DD:EE:FF"),
@@ -181,7 +191,7 @@ async fn test_delete_package_referenced_by_default_device_is_conflict() {
     // Register the package.
     let resp = app
         .post_json(
-            "/api/admin/packages",
+            "/api/admin/screen-repos",
             &[AUTH],
             r#"{"handle":"weather","repo":"github.com/x/y","pin":"v1"}"#,
         )
@@ -212,12 +222,12 @@ async fn test_delete_package_referenced_by_default_device_is_conflict() {
         .patch_json(
             "/api/admin/settings",
             &[AUTH],
-            r#"{"package_refresh_interval":1}"#,
+            r#"{"screen_repo_refresh_interval":1}"#,
         )
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
 
-    let del = app.delete("/api/admin/packages/weather", &[AUTH]).await;
+    let del = app.delete("/api/admin/screen-repos/weather", &[AUTH]).await;
     assert_eq!(del.status, StatusCode::CONFLICT, "body: {}", del.text());
     assert!(
         del.text().contains("DEFAULT"),
@@ -230,7 +240,7 @@ async fn test_delete_package_referenced_by_default_device_is_conflict() {
 async fn test_delete_missing_package_is_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
-    let resp = app.delete("/api/admin/packages/nope", &[AUTH]).await;
+    let resp = app.delete("/api/admin/screen-repos/nope", &[AUTH]).await;
     assert_eq!(resp.status, StatusCode::NOT_FOUND);
 }
 
@@ -240,18 +250,24 @@ async fn test_patch_package_preserves_token_and_updates_pin() {
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
 
     app.post_json(
-        "/api/admin/packages",
+        "/api/admin/screen-repos",
         &[AUTH],
         r#"{"handle":"weather","repo":"github.com/x/y","pin":"v1","token":"secret-token"}"#,
     )
     .await;
 
     let patch = app
-        .patch_json("/api/admin/packages/weather", &[AUTH], r#"{"pin":"v2"}"#)
+        .patch_json(
+            "/api/admin/screen-repos/weather",
+            &[AUTH],
+            r#"{"pin":"v2"}"#,
+        )
         .await;
     assert_eq!(patch.status, StatusCode::OK, "body: {}", patch.text());
 
-    let listed = app.get_with_headers("/api/admin/packages", &[AUTH]).await;
+    let listed = app
+        .get_with_headers("/api/admin/screen-repos", &[AUTH])
+        .await;
     let json: serde_json::Value = listed.json();
     let row = json
         .as_array()
@@ -272,7 +288,7 @@ async fn test_patch_package_builtin_conflicts() {
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
     let resp = app
         .patch_json(
-            "/api/admin/packages/byonk-builtin",
+            "/api/admin/screen-repos/byonk-builtin",
             &[AUTH],
             r#"{"pin":"v2"}"#,
         )
@@ -285,7 +301,7 @@ async fn test_patch_missing_package_is_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
     let resp = app
-        .patch_json("/api/admin/packages/nope", &[AUTH], r#"{"pin":"v2"}"#)
+        .patch_json("/api/admin/screen-repos/nope", &[AUTH], r#"{"pin":"v2"}"#)
         .await;
     assert_eq!(resp.status, StatusCode::NOT_FOUND);
 }
@@ -295,7 +311,7 @@ async fn test_update_missing_package_is_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
     let resp = app
-        .post_json("/api/admin/packages/nope/update", &[AUTH], "")
+        .post_json("/api/admin/screen-repos/nope/update", &[AUTH], "")
         .await;
     assert_eq!(resp.status, StatusCode::NOT_FOUND);
 }
@@ -306,19 +322,19 @@ async fn test_update_package_and_update_all_return_ok() {
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
 
     app.post_json(
-        "/api/admin/packages",
+        "/api/admin/screen-repos",
         &[AUTH],
         r#"{"handle":"weather","repo":"github.com/x/y","pin":"v1"}"#,
     )
     .await;
 
     let resp = app
-        .post_json("/api/admin/packages/weather/update", &[AUTH], "")
+        .post_json("/api/admin/screen-repos/weather/update", &[AUTH], "")
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
 
     let resp = app
-        .post_json("/api/admin/packages/update", &[AUTH], "")
+        .post_json("/api/admin/screen-repos/update", &[AUTH], "")
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
 }
@@ -328,7 +344,9 @@ async fn test_packages_list_reports_real_status_for_builtin() {
     let dir = tempfile::tempdir().unwrap();
     let (app, _path) = TestApp::new_admin_with_file("secret", dir.path());
 
-    let listed = app.get_with_headers("/api/admin/packages", &[AUTH]).await;
+    let listed = app
+        .get_with_headers("/api/admin/screen-repos", &[AUTH])
+        .await;
     assert_eq!(listed.status, StatusCode::OK);
     let text = listed.text();
     assert!(

--- a/tests/admin_screens_test.rs
+++ b/tests/admin_screens_test.rs
@@ -7,7 +7,7 @@ const AUTH: (&str, &str) = ("Authorization", "Bearer secret");
 
 /// Find a screen by its `handle/path` ref across all package groups.
 fn find_screen<'a>(json: &'a serde_json::Value, r#ref: &str) -> Option<&'a serde_json::Value> {
-    json["packages"]
+    json["screen_repos"]
         .as_array()?
         .iter()
         .flat_map(|p| p["screens"].as_array().into_iter().flatten())
@@ -21,7 +21,7 @@ async fn test_screens_grouped_includes_builtin_with_titles() {
     assert_eq!(resp.status, StatusCode::OK);
     let json: serde_json::Value = resp.json();
 
-    let packages = json["packages"].as_array().expect("packages array");
+    let packages = json["screen_repos"].as_array().expect("packages array");
     let builtin = packages
         .iter()
         .find(|p| p["handle"] == "byonk-builtin")
@@ -105,7 +105,9 @@ async fn test_swiss_departure_board_has_station_param() {
 #[tokio::test]
 async fn test_packages_lists_builtin_with_redaction() {
     let app = TestApp::new_admin("secret");
-    let resp = app.get_with_headers("/api/admin/packages", &[AUTH]).await;
+    let resp = app
+        .get_with_headers("/api/admin/screen-repos", &[AUTH])
+        .await;
     assert_eq!(resp.status, StatusCode::OK);
     let json: serde_json::Value = resp.json();
 
@@ -136,6 +138,6 @@ async fn test_packages_lists_builtin_with_redaction() {
 #[tokio::test]
 async fn test_packages_unauthorized() {
     let app = TestApp::new_admin("secret");
-    let resp = app.get("/api/admin/packages").await;
+    let resp = app.get("/api/admin/screen-repos").await;
     assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
 }

--- a/tests/admin_write_test.rs
+++ b/tests/admin_write_test.rs
@@ -409,7 +409,7 @@ async fn test_patch_with_screen_change_replaces_params() {
 }
 
 #[tokio::test]
-async fn test_patch_settings_package_refresh_interval_persists() {
+async fn test_patch_settings_screen_repo_refresh_interval_persists() {
     let dir = tempfile::tempdir().unwrap();
     let (app, path) = TestApp::new_admin_with_file("secret", dir.path());
 
@@ -417,15 +417,15 @@ async fn test_patch_settings_package_refresh_interval_persists() {
         .patch_json(
             "/api/admin/settings",
             &[AUTH],
-            r#"{"package_refresh_interval":3600}"#,
+            r#"{"screen_repo_refresh_interval":3600}"#,
         )
         .await;
     assert_eq!(resp.status, StatusCode::OK);
 
     let on_disk = std::fs::read_to_string(&path).unwrap();
     assert!(
-        on_disk.contains("package_refresh_interval: 3600"),
-        "expected 'package_refresh_interval: 3600' in:\n{on_disk}"
+        on_disk.contains("screen_repo_refresh_interval: 3600"),
+        "expected 'screen_repo_refresh_interval: 3600' in:\n{on_disk}"
     );
 }
 

--- a/tests/builtin_package.rs
+++ b/tests/builtin_package.rs
@@ -2,12 +2,12 @@
 //! migrated built-in screens through the package loader.
 
 use byonk::assets::AssetLoader;
-use byonk::services::package_loader::PackageLoader;
+use byonk::services::screen_repo_loader::ScreenRepoLoader;
 
 #[test]
 fn test_builtin_default_resolves() {
     let loader = std::sync::Arc::new(AssetLoader::new(None, None, None));
-    let pl = PackageLoader::new(loader, Default::default());
+    let pl = ScreenRepoLoader::new(loader, Default::default());
     let r = pl
         .resolve("byonk-builtin/default")
         .expect("default screen resolves");
@@ -17,7 +17,7 @@ fn test_builtin_default_resolves() {
 #[test]
 fn test_builtin_list_all_includes_migrated_screens() {
     let loader = std::sync::Arc::new(AssetLoader::new(None, None, None));
-    let pl = PackageLoader::new(loader, Default::default());
+    let pl = ScreenRepoLoader::new(loader, Default::default());
 
     let refs: Vec<String> = pl
         .list_all()

--- a/tests/screen_schemas_test.rs
+++ b/tests/screen_schemas_test.rs
@@ -2,11 +2,11 @@
 //! known screens expose their documented params through the package loader.
 
 use byonk::assets::AssetLoader;
-use byonk::services::package_loader::PackageLoader;
+use byonk::services::screen_repo_loader::ScreenRepoLoader;
 use std::sync::Arc;
 
-fn loader() -> PackageLoader {
-    PackageLoader::new(
+fn loader() -> ScreenRepoLoader {
+    ScreenRepoLoader::new(
         Arc::new(AssetLoader::new(None, None, None)),
         Default::default(),
     )

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -16,7 +16,7 @@ from custom_components.byonk.const import (
 pytest_plugins = ["pytest_homeassistant_custom_component"]
 
 DEFAULT_SCREENS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [{"ref": "byonk-builtin/useful/swiss-departure-board",
                                 "title": "Swiss Departure Board", "description": "",
@@ -68,11 +68,11 @@ def byonk():
         update_device=AsyncMock(),
         delete_device=AsyncMock(),
         update_settings=AsyncMock(),
-        packages=[],
-        add_package=AsyncMock(return_value={"handle": "x"}),
-        update_package=AsyncMock(return_value={"handle": "x"}),
-        delete_package=AsyncMock(return_value={"ok": True}),
-        update_packages=AsyncMock(return_value={"ok": True}),
+        screen_repos=[],
+        add_screen_repo=AsyncMock(return_value={"handle": "x"}),
+        update_screen_repo=AsyncMock(return_value={"handle": "x"}),
+        delete_screen_repo=AsyncMock(return_value={"ok": True}),
+        update_screen_repos=AsyncMock(return_value={"ok": True}),
     )
     with (
         patch("custom_components.byonk.async_read_token", new=AsyncMock(return_value="tok")),
@@ -86,11 +86,11 @@ def byonk():
             async_update_device=state.update_device,
             async_delete_device=state.delete_device,
             async_update_settings=state.update_settings,
-            async_get_packages=AsyncMock(side_effect=lambda *a, **k: list(state.packages)),
-            async_add_package=state.add_package,
-            async_update_package=state.update_package,
-            async_delete_package=state.delete_package,
-            async_update_packages=state.update_packages,
+            async_get_screen_repos=AsyncMock(side_effect=lambda *a, **k: list(state.screen_repos)),
+            async_add_screen_repo=state.add_screen_repo,
+            async_update_screen_repo=state.update_screen_repo,
+            async_delete_screen_repo=state.delete_screen_repo,
+            async_update_screen_repos=state.update_screen_repos,
         ),
     ):
         yield state

--- a/tests_ha/test_api.py
+++ b/tests_ha/test_api.py
@@ -58,19 +58,19 @@ async def test_409_raises_readonly(mock_aioresponse):
             await client.async_update_settings({"registration_enabled": True})
 
 
-async def test_get_packages(mock_aioresponse):
+async def test_get_screen_repos(mock_aioresponse):
     mock_aioresponse.get(
-        f"{BASE}/api/admin/packages",
+        f"{BASE}/api/admin/screen-repos",
         payload=[{"handle": "weather", "builtin": False, "status": "ready"}],
     )
     async with aiohttp.ClientSession() as session:
         client = ByonkClient(session, BASE, "secret")
-        result = await client.async_get_packages()
+        result = await client.async_get_screen_repos()
     assert result[0]["handle"] == "weather"
 
 
-async def test_update_all_packages_posts(mock_aioresponse):
-    mock_aioresponse.post(f"{BASE}/api/admin/packages/update", payload={"ok": True})
+async def test_update_all_screen_repos_posts(mock_aioresponse):
+    mock_aioresponse.post(f"{BASE}/api/admin/screen-repos/update", payload={"ok": True})
     async with aiohttp.ClientSession() as session:
         client = ByonkClient(session, BASE, "secret")
-        assert await client.async_update_packages() == {"ok": True}
+        assert await client.async_update_screen_repos() == {"ok": True}

--- a/tests_ha/test_default_device.py
+++ b/tests_ha/test_default_device.py
@@ -30,7 +30,7 @@ DEFAULT_DEV = {
 }
 
 SCREENS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [
                       {"ref": DEFAULT_SCREEN, "title": "Default", "description": "",
@@ -102,7 +102,7 @@ async def test_default_device_exempt_from_orphan_prune(hass, byonk):
         panels=[],
         dither=[],
         config={},
-        packages=[],
+        screen_repos=[],
     )
     # REMOVE_STRIKES is 2; call twice to make sure a real orphan would have been
     # pruned by now, but DEFAULT never is.

--- a/tests_ha/test_device_flow.py
+++ b/tests_ha/test_device_flow.py
@@ -5,14 +5,14 @@ from tests_ha.conftest import make_hub_entry
 
 TRANSIT_REF = "byonk-builtin/useful/swiss-departure-board"
 SCREENS_NO_PARAMS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [{"ref": TRANSIT_REF, "title": "Swiss Departure Board", "description": "",
                                 "params": [], "byonk": "0.15", "compat_warning": None}]}],
     "panels": [{"name": "trmnl_og"}], "dither_algorithms": ["atkinson"],
 }
 SCREENS_PARAMS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [{"ref": TRANSIT_REF, "title": "Swiss Departure Board", "description": "",
                                 "params": [{"name": "limit", "type": "int", "default": 8}],

--- a/tests_ha/test_init.py
+++ b/tests_ha/test_init.py
@@ -6,7 +6,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.byonk.const import CONF_ADDON_SLUG, CONF_BASE_URL, DOMAIN
 
 SCREENS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [{"ref": "byonk-builtin/useful/swiss-departure-board",
                                 "title": "Swiss Departure Board", "description": "",
@@ -34,7 +34,7 @@ async def test_setup_entry_creates_hub_and_loads(hass):
         patch("custom_components.byonk.coordinator.ByonkClient.async_get_pending", new=AsyncMock(return_value=[])),
         patch("custom_components.byonk.coordinator.ByonkClient.async_get_screens", new=AsyncMock(return_value=SCREENS)),
         patch("custom_components.byonk.coordinator.ByonkClient.async_get_config", new=AsyncMock(return_value=CONFIG)),
-        patch("custom_components.byonk.coordinator.ByonkClient.async_get_packages", new=AsyncMock(return_value=[])),
+        patch("custom_components.byonk.coordinator.ByonkClient.async_get_screen_repos", new=AsyncMock(return_value=[])),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests_ha/test_param_entities.py
+++ b/tests_ha/test_param_entities.py
@@ -8,7 +8,7 @@ CALIBRATOR_REF = "byonk-builtin/utils/calibrator"
 GPHOTO_REF = "byonk-builtin/demos/gphoto"
 
 SCREENS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [
                       {"ref": TRANSIT_REF, "title": "Swiss Departure Board", "description": "",
@@ -80,7 +80,7 @@ async def test_param_entities_reconcile_on_screen_change(hass, byonk):
 
 
 NUM_SCREENS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [
                       {"ref": TRANSIT_REF, "title": "Swiss Departure Board", "description": "",

--- a/tests_ha/test_screen_repo_button.py
+++ b/tests_ha/test_screen_repo_button.py
@@ -1,14 +1,14 @@
 from tests_ha.conftest import make_hub_entry
 
 
-async def test_update_packages_button(hass, byonk):
-    byonk.packages = [{"handle": "weather", "builtin": False, "status": "ready"}]
+async def test_update_screen_repos_button(hass, byonk):
+    byonk.screen_repos = [{"handle": "weather", "builtin": False, "status": "ready"}]
     hub = make_hub_entry(hass)
     await hass.config_entries.async_setup(hub.entry_id)
     await hass.async_block_till_done()
-    ent = "button.byonk_update_packages"
+    ent = "button.byonk_update_screen_repos"
     assert hass.states.get(ent) is not None
     await hass.services.async_call(
         "button", "press", {"entity_id": ent}, blocking=True
     )
-    assert byonk.update_packages.await_count == 1
+    assert byonk.update_screen_repos.await_count == 1

--- a/tests_ha/test_screen_repo_issues.py
+++ b/tests_ha/test_screen_repo_issues.py
@@ -1,0 +1,42 @@
+"""A failing screen-repo fetch surfaces as a repair issue, and clears on recovery."""
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.byonk.const import DOMAIN
+from tests_ha.conftest import make_hub_entry
+
+ISSUE_ID = "screen_repo_error_weather"
+
+ERR_REPO = {
+    "handle": "weather", "builtin": False, "repo": "https://example.com/w.git",
+    "pin": "main", "status": "error", "resolved_sha": None,
+    "error": "git error: could not resolve host",
+}
+OK_REPO = {**ERR_REPO, "status": "ready", "resolved_sha": "abc123", "error": None}
+
+
+async def test_error_repo_raises_and_clears_issue(hass, byonk):
+    byonk.screen_repos = [ERR_REPO]
+    hub = make_hub_entry(hass)
+    await hass.config_entries.async_setup(hub.entry_id)
+    await hass.async_block_till_done()
+
+    reg = ir.async_get(hass)
+    issue = reg.async_get_issue(DOMAIN, ISSUE_ID)
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.translation_placeholders["error"] == ERR_REPO["error"]
+    assert issue.translation_placeholders["handle"] == "weather"
+
+    # Repo recovers -> issue is cleared.
+    byonk.screen_repos = [OK_REPO]
+    await hub.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+    assert reg.async_get_issue(DOMAIN, ISSUE_ID) is None
+
+
+async def test_ready_repo_has_no_issue(hass, byonk):
+    byonk.screen_repos = [OK_REPO]
+    hub = make_hub_entry(hass)
+    await hass.config_entries.async_setup(hub.entry_id)
+    await hass.async_block_till_done()
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_ID) is None

--- a/tests_ha/test_screen_repo_status.py
+++ b/tests_ha/test_screen_repo_status.py
@@ -1,6 +1,6 @@
 from tests_ha.conftest import make_hub_entry
 
-PKGS = [
+REPOS = [
     {"handle": "byonk-builtin", "builtin": True, "status": "ready"},
     {"handle": "weather", "builtin": False, "repo": "r", "pin": "main",
      "pin_kind": "branch", "resolved_sha": "abc123", "status": "ready",
@@ -8,8 +8,8 @@ PKGS = [
 ]
 
 
-async def test_status_sensor_reflects_package(hass, byonk):
-    byonk.packages = PKGS
+async def test_status_sensor_reflects_screen_repo(hass, byonk):
+    byonk.screen_repos = REPOS
     hub = make_hub_entry(hass)
     await hass.config_entries.async_setup(hub.entry_id)
     await hass.async_block_till_done()
@@ -22,12 +22,12 @@ async def test_status_sensor_reflects_package(hass, byonk):
 
 
 async def test_status_sensor_added_and_removed(hass, byonk):
-    byonk.packages = [PKGS[0]]
+    byonk.screen_repos = [REPOS[0]]
     hub = make_hub_entry(hass)
     await hass.config_entries.async_setup(hub.entry_id)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.byonk_weather_status") is None
-    byonk.packages = PKGS
+    byonk.screen_repos = REPOS
     await hub.runtime_data.async_refresh()
     await hass.async_block_till_done()
     assert hass.states.get("sensor.byonk_weather_status") is not None

--- a/tests_ha/test_select.py
+++ b/tests_ha/test_select.py
@@ -4,7 +4,7 @@ TRANSIT_REF = "byonk-builtin/useful/swiss-departure-board"
 WEATHER_REF = "byonk-builtin/useful/weather"
 DEV = {"key": "AA:BB", "registered": True, "screen": TRANSIT_REF, "dither": "atkinson", "panel": None}
 SCREENS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [
                       {"ref": TRANSIT_REF, "title": "Swiss Departure Board", "description": "",

--- a/tests_ha/test_settings_entities.py
+++ b/tests_ha/test_settings_entities.py
@@ -7,7 +7,7 @@ from tests_ha.conftest import make_hub_entry
 
 TRANSIT_REF = "byonk-builtin/useful/swiss-departure-board"
 SCREENS = {
-    "packages": [{"handle": "byonk-builtin", "name": "byonk-builtin",
+    "screen_repos": [{"handle": "byonk-builtin", "name": "byonk-builtin",
                   "description": "Built-in screens", "author": "Byonk", "license": "MIT",
                   "screens": [{"ref": TRANSIT_REF, "title": "Swiss Departure Board", "description": "",
                                 "params": [], "byonk": "0.15", "compat_warning": None}]}],
@@ -26,7 +26,7 @@ async def test_registration_switch_turns_on(hass):
         patch("custom_components.byonk.coordinator.ByonkClient.async_get_pending", new=AsyncMock(return_value=[])),
         patch("custom_components.byonk.coordinator.ByonkClient.async_get_screens", new=AsyncMock(return_value=SCREENS)),
         patch("custom_components.byonk.coordinator.ByonkClient.async_get_config", new=AsyncMock(return_value=CONFIG)),
-        patch("custom_components.byonk.coordinator.ByonkClient.async_get_packages", new=AsyncMock(return_value=[])),
+        patch("custom_components.byonk.coordinator.ByonkClient.async_get_screen_repos", new=AsyncMock(return_value=[])),
         patch("custom_components.byonk.coordinator.ByonkClient.async_update_settings", new=settings),
     ):
         await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
## Why

A user added a screen repo in the HA add-on, hit refresh, and got "an error but no further information." Two problems surfaced:

1. **Screen-repo fetching was completely broken in the published container.** The release image is built `FROM scratch` and has no `/tmp`; `git_fetch` cloned the intermediate bare repo into `std::env::temp_dir()` (`/tmp/…`), which gix cannot create there — every fetch failed with an opaque `Could not open data at '/tmp/byonk-git-fetch-…'` and showed status `error`.
2. **The concept was called "packages"**, which reads as opaque bundles rather than what they are: git repositories of screens.

## What

- **fix(packages):** clone into a sibling of the destination under the package cache on `/data` (guaranteed to exist and be writable), never `/tmp`. Fetch failures/successes are now logged, so a failing repo is visible in the add-on log — not only in `GET`. Proven under a missing-`/tmp` condition (`TMPDIR=/no/such/tmp` → fetch succeeds) and live on a fresh from-source add-on (`tobitest` repo → `status: ready`).
- **rename "packages" → "screen repos" (everything incl. the API):** `/api/admin/screen-repos*`, the `GET /screens` grouping wrapper field `screen_repos`, config/add-on-option keys (`screen_repos`, `screen_repo_refresh_interval`), env `SCREEN_REPOS_CACHE_DIR`, all internal Rust types/modules, and the whole HA integration. Kept `byonk-builtin` and `byonk-screens.yaml` so device screen paths and repo layout are unchanged.
- **feat(ha): surface fetch failures.** A screen repo in `error` state now raises a Home Assistant **Repair** issue ("Screen repo X failed to update") carrying the real error, auto-cleared on recovery.

## Verification

- Rust: `cargo test`, `clippy -D warnings`, `fmt` — green.
- HA integration: `make ha-check` — ruff + **77 pytest** (incl. new repair-issue tests) green.
- Docs: `mdbook` build clean.
- Live on a from-source add-on in the HAOS test VM: new schema accepted, `/api/admin/screen-repos` serves the repo (`tobitest/hello`, ready), old `/api/admin/packages` is 404.

> **Breaking:** admin API paths, config keys, and add-on option keys are renamed; existing add-on options under `packages` / `package_refresh_interval` must be re-entered under `screen_repos` / `screen_repo_refresh_interval`. No published consumers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)