### PR TITLE
docs(ha): rename "add-on" to "app" per Home Assistant 2026.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,11 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **"Add-on" is now "app" everywhere**, following Home Assistant 2026.2, which
-  renamed add-ons to apps in its UI (**Settings → Apps → App store**). The Byonk
-  documentation, the integration's messages, and the name of the Byonk repository
-  in the app store use the new wording. Nothing functional changed — the same
-  app, under a new label.
+- **Home Assistant "add-ons" are now called "apps".** Home Assistant 2026.2 renamed
+  add-ons to apps in its UI (**Settings → Apps → App store**). Byonk's Home Assistant
+  documentation, the integration's messages, and the Supervisor repository name now
+  use the new wording. Nothing functional changed — it's the same add-on/app.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **"Add-on" is now "app" everywhere**, following Home Assistant 2026.2, which
+  renamed add-ons to apps in its UI (**Settings → Apps → App store**). The Byonk
+  documentation, the integration's messages, and the name of the Byonk repository
+  in the app store use the new wording. Nothing functional changed — the same
+  app, under a new label.
+
 ### Fixed
 
 ## 0.17.1 - 2026-07-17

--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ docker run --rm -it --pull always -p 3000:3000 ghcr.io/oetiker/byonk:latest
 
 Point your TRMNL device to `http://your-server:3000` and it will start displaying content.
 
+## Home Assistant
+
+Byonk runs on Home Assistant in two parts — install both:
+
+- **The Byonk app** (formerly "add-on") — the server itself, running under
+  Supervisor and serving your TRMNL devices on host port 3000.
+- **The Byonk integration** (via HACS) — onboards TRMNL devices as Home Assistant
+  devices with entities for screen selection, battery, signal and screen
+  parameters, and provisions the admin token automatically.
+
+Install the integration first and it installs and starts the app for you,
+zero-touch:
+
+1. **HACS → Integrations → ⋮ → Custom repositories**, add
+   `https://github.com/oetiker/byonk` as an **Integration**, install it and
+   restart Home Assistant.
+2. **Settings → Devices & Services → Add Integration** → *Byonk*.
+
+See the [Home Assistant App](https://oetiker.github.io/byonk/dev/guide/ha-addon.html)
+and [Home Assistant Integration](https://oetiker.github.io/byonk/dev/guide/ha-integration.html)
+guides for details.
+
 ## Dev Mode
 
 Byonk includes a development mode with a web-based device simulator for creating and testing screens:
@@ -33,8 +55,13 @@ Then open `http://localhost:3000/dev` in your browser:
 Full documentation is available at **[oetiker.github.io/byonk](https://oetiker.github.io/byonk)**:
 
 - [Installation Guide](https://oetiker.github.io/byonk/dev/guide/installation.html)
+- [Home Assistant App](https://oetiker.github.io/byonk/dev/guide/ha-addon.html)
+- [Home Assistant Integration](https://oetiker.github.io/byonk/dev/guide/ha-integration.html)
+- [Configuration](https://oetiker.github.io/byonk/dev/guide/configuration.html)
 - [Creating Your First Screen](https://oetiker.github.io/byonk/dev/tutorial/first-screen.html)
 - [Lua API Reference](https://oetiker.github.io/byonk/dev/api/lua-api.html)
+- [HTTP API](https://oetiker.github.io/byonk/dev/api/http-api.html)
+- [Admin API](https://oetiker.github.io/byonk/dev/api/admin-api.html)
 - [Dev Mode](https://oetiker.github.io/byonk/dev/guide/dev-mode.html)
 
 ## License

--- a/custom_components/byonk/strings.json
+++ b/custom_components/byonk/strings.json
@@ -21,7 +21,7 @@
       "single_instance_allowed": "Byonk is already configured.",
       "already_configured": "This device is already set up.",
       "no_hub": "The Byonk hub is not set up yet. Set up the Byonk integration first.",
-      "addon_error": "Could not install or start the Byonk app automatically. Add the Byonk app repository to the app store, install the Byonk app, then retry.",
+      "addon_error": "Could not install or start the Byonk app automatically. Add the Byonk app repository to the App store, install the Byonk app, then retry.",
       "addon_unhealthy": "The Byonk app started, but its management API did not respond as expected. Make sure the Byonk app is up to date (a version that supports the admin API), then retry.",
       "add_failed": "Could not add the device to Byonk."
     },

--- a/custom_components/byonk/strings.json
+++ b/custom_components/byonk/strings.json
@@ -17,12 +17,12 @@
       }
     },
     "abort": {
-      "not_hassio": "Byonk requires the Byonk add-on, which needs a Home Assistant Supervised or HAOS installation.",
+      "not_hassio": "Byonk requires the Byonk app, which needs a Home Assistant Supervised or HAOS installation.",
       "single_instance_allowed": "Byonk is already configured.",
       "already_configured": "This device is already set up.",
       "no_hub": "The Byonk hub is not set up yet. Set up the Byonk integration first.",
-      "addon_error": "Could not install or start the Byonk add-on automatically. Add the Byonk add-on repository to the add-on store, install the Byonk add-on, then retry.",
-      "addon_unhealthy": "The Byonk add-on started, but its management API did not respond as expected. Make sure the Byonk add-on is up to date (a version that supports the admin API), then retry.",
+      "addon_error": "Could not install or start the Byonk app automatically. Add the Byonk app repository to the app store, install the Byonk app, then retry.",
+      "addon_unhealthy": "The Byonk app started, but its management API did not respond as expected. Make sure the Byonk app is up to date (a version that supports the admin API), then retry.",
       "add_failed": "Could not add the device to Byonk."
     },
     "error": {
@@ -76,7 +76,7 @@
   "issues": {
     "screen_repo_error": {
       "title": "Screen repo \"{handle}\" failed to update",
-      "description": "Byonk could not fetch the screen repo \"{handle}\" ({repo}).\n\nError: {error}\n\nCheck the repo URL, pin (branch/tag/commit) and access token in the Byonk add-on configuration, then use the \"Update screen repos\" button to retry."
+      "description": "Byonk could not fetch the screen repo \"{handle}\" ({repo}).\n\nError: {error}\n\nCheck the repo URL, pin (branch/tag/commit) and access token in the Byonk app configuration, then use the \"Update screen repos\" button to retry."
     }
   }
 }

--- a/custom_components/byonk/translations/en.json
+++ b/custom_components/byonk/translations/en.json
@@ -21,7 +21,7 @@
       "single_instance_allowed": "Byonk is already configured.",
       "already_configured": "This device is already set up.",
       "no_hub": "The Byonk hub is not set up yet. Set up the Byonk integration first.",
-      "addon_error": "Could not install or start the Byonk app automatically. Add the Byonk app repository to the app store, install the Byonk app, then retry.",
+      "addon_error": "Could not install or start the Byonk app automatically. Add the Byonk app repository to the App store, install the Byonk app, then retry.",
       "addon_unhealthy": "The Byonk app started, but its management API did not respond as expected. Make sure the Byonk app is up to date (a version that supports the admin API), then retry.",
       "add_failed": "Could not add the device to Byonk."
     },

--- a/custom_components/byonk/translations/en.json
+++ b/custom_components/byonk/translations/en.json
@@ -17,12 +17,12 @@
       }
     },
     "abort": {
-      "not_hassio": "Byonk requires the Byonk add-on, which needs a Home Assistant Supervised or HAOS installation.",
+      "not_hassio": "Byonk requires the Byonk app, which needs a Home Assistant Supervised or HAOS installation.",
       "single_instance_allowed": "Byonk is already configured.",
       "already_configured": "This device is already set up.",
       "no_hub": "The Byonk hub is not set up yet. Set up the Byonk integration first.",
-      "addon_error": "Could not install or start the Byonk add-on automatically. Add the Byonk add-on repository to the add-on store, install the Byonk add-on, then retry.",
-      "addon_unhealthy": "The Byonk add-on started, but its management API did not respond as expected. Make sure the Byonk add-on is up to date (a version that supports the admin API), then retry.",
+      "addon_error": "Could not install or start the Byonk app automatically. Add the Byonk app repository to the app store, install the Byonk app, then retry.",
+      "addon_unhealthy": "The Byonk app started, but its management API did not respond as expected. Make sure the Byonk app is up to date (a version that supports the admin API), then retry.",
       "add_failed": "Could not add the device to Byonk."
     },
     "error": {
@@ -76,7 +76,7 @@
   "issues": {
     "screen_repo_error": {
       "title": "Screen repo \"{handle}\" failed to update",
-      "description": "Byonk could not fetch the screen repo \"{handle}\" ({repo}).\n\nError: {error}\n\nCheck the repo URL, pin (branch/tag/commit) and access token in the Byonk add-on configuration, then use the \"Update screen repos\" button to retry."
+      "description": "Byonk could not fetch the screen repo \"{handle}\" ({repo}).\n\nError: {error}\n\nCheck the repo URL, pin (branch/tag/commit) and access token in the Byonk app configuration, then use the \"Update screen repos\" button to retry."
     }
   }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,7 +5,7 @@
 # Getting Started
 
 - [Installation](guide/installation.md)
-- [Home Assistant Add-on](guide/ha-addon.md)
+- [Home Assistant App](guide/ha-addon.md)
 - [Home Assistant Integration](guide/ha-integration.md)
 - [Configuration](guide/configuration.md)
 - [Dev Mode](guide/dev-mode.md)

--- a/docs/src/guide/ha-addon.md
+++ b/docs/src/guide/ha-addon.md
@@ -1,34 +1,36 @@
-# Home Assistant Add-on
+# Home Assistant App
 
-Byonk can run as a Home Assistant Supervisor add-on. The add-on runs the same
+Byonk can run as a Home Assistant Supervisor app. The app runs the same
 prebuilt `ghcr.io/oetiker/byonk` image, stores its configuration in a persistent,
 editable folder, and exposes Byonk on a host port so your TRMNL devices can reach
 it directly on your LAN.
 
 > Requires a Supervisor-managed install (Home Assistant OS or Supervised).
 
+> Apps were called *add-ons* before Home Assistant 2026.2 — same thing, new name.
+
 ## Install
 
-A full Home Assistant setup is **two parts**: this add-on (the server) and the
+A full Home Assistant setup is **two parts**: this app (the server) and the
 [Byonk integration](ha-integration.md) (device onboarding, entities, automatic
 token provisioning). Install both.
 
 **Recommended — integration first.** Installing the
-[integration](ha-integration.md) installs and starts this add-on for you, and
+[integration](ha-integration.md) installs and starts this app for you, and
 provisions the admin token automatically. See
 [its install steps](ha-integration.md#installation-via-hacs).
 
-**Add-on only** (server without Home Assistant device entities):
+**App only** (server without Home Assistant device entities):
 
-1. **Settings → Add-ons → Add-on Store**.
-2. **⋮ → Repositories**, add `https://github.com/oetiker/byonk`, then close.
+1. **Settings → Apps → App store**.
+2. **⋮ → Repositories**, add `https://github.com/oetiker/byonk`, select **Add**.
 3. Open **Byonk** in the store, **Install**, then **Start**.
 
-You can add the integration later — it picks up the running add-on.
+You can add the integration later — it picks up the running app.
 
 ## Point your TRMNL device at Byonk
 
-The add-on publishes Byonk on host port **3000**. Set your TRMNL device's server
+The app publishes Byonk on host port **3000**. Set your TRMNL device's server
 to `http://<your-home-assistant-host>:3000`.
 
 ## Options
@@ -48,13 +50,13 @@ configuration** — `auth_mode`, `screen_repo_refresh_interval`, and the screen 
 registry. Home Assistant Supervisor writes your changes to `/data/options.json`,
 and Byonk reads them back on startup.
 
-**Changes apply on add-on restart** — there is no live-reload for add-on options
+**Changes apply on app restart** — there is no live-reload for app options
 (this is a Home Assistant Supervisor limitation, not a Byonk one). Restart the
-add-on after saving to apply a change. The restart is quick, per-device screen
+app after saving to apply a change. The restart is quick, per-device screen
 mappings are unaffected (they're Byonk's own persisted state), and already-fetched
 screen repo checkouts are cached on disk, so unchanged screen repos are not re-fetched.
 
-While running as the add-on, these settings are **read-only over the admin API** —
+While running as the app, these settings are **read-only over the admin API** —
 attempts to change them there (including from the Byonk integration) are rejected
 with a 409 pointing back to this Configuration tab. This tab is the only editor.
 Per-device screen/dither/panel assignment and the two live operational controls
@@ -63,13 +65,13 @@ continue to work from the [Byonk integration](ha-integration.md).
 
 ## Configuration, screens, and fonts
 
-The add-on maps an editable, persistent folder to `/config` inside the container,
+The app maps an editable, persistent folder to `/config` inside the container,
 holding `config.yaml`, `screens/`, and `fonts/`. Edit these with the **File
-editor** or **Studio Code Server** add-on. Empty folders are seeded with the
+editor** or **Studio Code Server** app. Empty folders are seeded with the
 embedded defaults on first start. Edits to `config.yaml` are applied without a
 restart.
 
-> **Note:** while running as the add-on, the `screen_repos:` section and the
+> **Note:** while running as the app, the `screen_repos:` section and the
 > `auth_mode` / `screen_repo_refresh_interval` settings in `config.yaml` are
 > **ignored** — those come from the Configuration tab above instead. `config.yaml`
 > still supplies everything else: per-device mappings (`devices:`, normally
@@ -82,14 +84,14 @@ restart.
 
 If the `screen_repos` list in the Configuration tab above references remote
 (git-backed) screen repos, their fetched git checkouts are cached on disk.
-The add-on ships with `SCREEN_REPOS_CACHE_DIR=/data/packages` set in its manifest —
-`/data` is the add-on's automatically-persistent private storage — so the cache
+The app ships with `SCREEN_REPOS_CACHE_DIR=/data/packages` set in its manifest —
+`/data` is the app's automatically-persistent private storage — so the cache
 survives restarts and rebuilds and screen repos are not re-fetched every boot. You
 do not need to configure anything.
 
 (For reference: when `SCREEN_REPOS_CACHE_DIR` is unset, byonk falls back to a
 temp directory, so every fetched checkout would be lost and re-fetched on each
-restart. The shipped add-on sets it, so this caveat does not apply here.)
+restart. The shipped app sets it, so this caveat does not apply here.)
 
 ## How it relates to the Byonk integration
 
@@ -100,4 +102,4 @@ It also surfaces read-only monitoring for the config you set here (per-screen-re
 status sensors) and two live operational controls (a registration switch and an
 "Update screen repos" button). It does **not** edit `auth_mode`,
 `screen_repo_refresh_interval`, or the screen repo registry — those are only editable
-here, in the add-on's Configuration tab.
+here, in the app's Configuration tab.

--- a/docs/src/guide/ha-integration.md
+++ b/docs/src/guide/ha-integration.md
@@ -1,12 +1,12 @@
 # Home Assistant Integration
 
 The Byonk Home Assistant integration connects Home Assistant to a Byonk server running
-as a Supervisor add-on. It manages the add-on lifecycle, provisions authentication
+as a Supervisor app. It manages the app lifecycle, provisions authentication
 automatically, and exposes Byonk devices as Home Assistant entities.
 
 Byonk's server-**global** configuration — `auth_mode`, `screen_repo_refresh_interval`,
 and the screen repo registry — is edited in the
-**[Byonk add-on's Configuration tab](ha-addon.md)**, not here. This integration is
+**[Byonk app's Configuration tab](ha-addon.md)**, not here. This integration is
 read-only monitoring for that global config (per-screen-repo status sensors), plus two
 live operational controls (a registration switch and an "Update screen repos" button)
 and full read/write control over **per-device** screen/dither/panel/parameter
@@ -14,9 +14,9 @@ assignment.
 
 ## Requirements
 
-- Home Assistant Supervised or HAOS (the integration controls the Byonk add-on via
+- Home Assistant Supervised or HAOS (the integration controls the Byonk app via
   the Supervisor API and will not work on plain Home Assistant Core or Container).
-- The [Byonk add-on](ha-addon.md) does **not** need to be pre-installed — the
+- The [Byonk app](ha-addon.md) does **not** need to be pre-installed — the
   integration installs and starts it automatically.
 
 ## Installation via HACS
@@ -35,8 +35,8 @@ assignment.
 
 1. Go to **Settings → Devices & Services → Add Integration** and search for *Byonk*.
 2. The integration will:
-   - Add the Byonk add-on repository to Supervisor.
-   - Install and start the Byonk add-on.
+   - Add the Byonk app repository to Supervisor.
+   - Install and start the Byonk app.
    - Generate and store an admin token automatically (zero-touch — you never enter a
      token).
 3. A *Byonk Server* hub device appears once setup completes.
@@ -53,7 +53,7 @@ assignment.
 
 The remaining server-global settings — `auth_mode` and `screen_repo_refresh_interval` —
 are **not** exposed as entities here; they're edited in the
-[Byonk add-on's Configuration tab](ha-addon.md) (changes apply on add-on restart).
+[Byonk app's Configuration tab](ha-addon.md) (changes apply on app restart).
 
 ### Byonk Default device
 
@@ -124,7 +124,7 @@ when you rename the device in Home Assistant. No changes are needed in byonk's c
 
 Screen repos (see [Screen Repos Section](configuration.md#screen-repos-section) in
 the Configuration guide) are **added, edited, and removed in the
-[Byonk add-on's Configuration tab](ha-addon.md)** — not here. This integration
+[Byonk app's Configuration tab](ha-addon.md)** — not here. This integration
 gives you read-only monitoring and one operational control:
 
 Each screen repo gets a diagnostic **status sensor** (e.g.
@@ -141,14 +141,14 @@ successfully again.
 
 Press the hub device's **Update screen repos** button to trigger an immediate
 content refresh of every already-configured screen repo (a git pull on the existing
-pin — equivalent to waiting for the `screen_repo_refresh_interval` set in the add-on's
+pin — equivalent to waiting for the `screen_repo_refresh_interval` set in the app's
 Configuration tab); the status sensors update once the fetch completes. This
-button does not add, remove, or repin screen repos — only the add-on Configuration
+button does not add, remove, or repin screen repos — only the app's Configuration
 tab does that.
 
 ## Re-authentication
 
-If the admin token stored in the add-on options becomes invalid (for example after
-reinstalling the add-on), Home Assistant will raise a *Re-authentication required*
+If the admin token stored in the app options becomes invalid (for example after
+reinstalling the app), Home Assistant will raise a *Re-authentication required*
 notification.  Click **Re-authenticate**, and the integration will read or
 re-provision the token automatically — no manual input is needed.

--- a/homeassistant/byonk/DOCS.md
+++ b/homeassistant/byonk/DOCS.md
@@ -1,11 +1,13 @@
 # Byonk
 
-Self-hosted content server for TRMNL e-ink devices. This add-on runs the prebuilt
+Self-hosted content server for TRMNL e-ink devices. This app runs the prebuilt
 `ghcr.io/oetiker/byonk` image under Home Assistant Supervisor.
+
+(Apps were called *add-ons* before Home Assistant 2026.2 — same thing, new name.)
 
 Byonk on Home Assistant comes in **two parts**, and you want both:
 
-- **This add-on** — the Byonk server itself: it serves screens to your TRMNL
+- **This app** — the Byonk server itself: it serves screens to your TRMNL
   devices on host port **3000**, and its Configuration tab holds Byonk's
   server-global settings (auth mode, screen repos).
 - **The Byonk integration** (a HACS custom integration) — onboards your TRMNL
@@ -16,7 +18,7 @@ Byonk on Home Assistant comes in **two parts**, and you want both:
 ## Installation
 
 The easiest path is to **install the integration first — it installs and starts
-this add-on for you**, fully zero-touch.
+this app for you**, fully zero-touch.
 
 1. In Home Assistant, open **HACS → Integrations**.
 2. Three-dot menu (top right) → **Custom repositories**, add
@@ -24,25 +26,25 @@ this add-on for you**, fully zero-touch.
    (Once Byonk is in the HACS default store you can skip this and just search.)
 3. Search for *Byonk* in HACS, install it, and **restart Home Assistant**.
 4. Go to **Settings → Devices & Services → Add Integration** and search for
-   *Byonk*. It adds the Byonk add-on repository, installs and starts this add-on,
+   *Byonk*. It adds the Byonk app repository, installs and starts this app,
    and generates the admin token itself.
 
-### Installing the add-on on its own
+### Installing the app on its own
 
 If you would rather run the server without the integration (no Home Assistant
 device entities, manual `config.yaml` editing):
 
-1. **Settings → Add-ons → Add-on Store**.
-2. **⋮** menu (top right) → **Repositories**, add
-   `https://github.com/oetiker/byonk`, and close.
+1. **Settings → Apps → App store**.
+2. Three-dot menu (top right) → **Repositories**, add
+   `https://github.com/oetiker/byonk`, and select **Add**.
 3. Find **Byonk** in the store, click **Install**, then **Start**.
 
-You can add the integration later at any time — it will pick up the add-on you
+You can add the integration later at any time — it will pick up the app you
 already have running.
 
 ## Pointing your TRMNL device at Byonk
 
-The add-on publishes Byonk on host port **3000**. Configure your TRMNL device to
+The app publishes Byonk on host port **3000**. Configure your TRMNL device to
 use `http://<your-home-assistant-host>:3000` as its server.
 
 A newly booted device shows a **registration code** on its screen and appears as a
@@ -53,7 +55,7 @@ instead.)
 ## Configuration
 
 This Configuration tab is the source of truth for Byonk's server-global settings.
-**Changes apply on add-on restart.**
+**Changes apply on app restart.**
 
 - **Admin token** — leave blank. The Byonk integration provisions and manages it
   automatically. While blank, the management API is disabled (this does not affect
@@ -72,9 +74,9 @@ does not edit them, so this tab stays the single editor.
 
 ## Editing screens and config
 
-Your configuration, screens, and fonts live in the add-on's config folder
-(mapped to `/config` inside the add-on). Edit them with the **File editor** or
-**Studio Code Server** add-on. Empty folders are seeded with sensible defaults on
+Your configuration, screens, and fonts live in the app's config folder
+(mapped to `/config` inside the app). Edit them with the **File editor** or
+**Studio Code Server** app. Empty folders are seeded with sensible defaults on
 first start. Edits to `config.yaml` are picked up without a restart.
 
 Per-device screen mappings are best managed through the Byonk integration; manual

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: Byonk Add-ons
+name: Byonk Apps
 url: https://github.com/oetiker/byonk
 maintainer: Tobias Oetiker <tobi@oetiker.ch>


### PR DESCRIPTION
Home Assistant 2026.2 renamed add-ons to **apps** in its UI (**Settings → Apps → App store**). This updates everything user-facing to match.

## Changed

- `homeassistant/byonk/DOCS.md` — app wording, correct menu path, plus a "formerly add-ons" note for existing users
- `docs/src/guide/ha-addon.md` (now titled "Home Assistant App"), `ha-integration.md`, `docs/src/SUMMARY.md` — filenames and URLs kept as `ha-addon.md` so existing links don't break
- `custom_components/byonk/strings.json` + `translations/en.json` — the four user-facing strings (`not_hassio`, `addon_error`, `addon_unhealthy`, screen-repo repair issue); both files verified in sync
- `repository.yaml` — store repo name `Byonk Add-ons` → `Byonk Apps`
- Fixed the stale "add the repository, then close" step to the current "select **Add**" flow
- `README.md` — new Home Assistant section (app + integration, zero-touch install order) and the missing doc links (HA guides, Configuration, HTTP API, Admin API)

## Not changed

UI labels only. Slugs, `config.yaml`, `addon.py`, the Supervisor API and all other code keep their existing add-on naming, as do historical changelog entries and dev-only files (`tools/ha-vm/`, `CLAUDE.md`, tests).

## Verification

- `mdbook build` clean
- Both translation JSON files parse and compare equal
- All README links return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)