### PR TITLE
Release through a PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -27,7 +27,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -47,13 +47,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -70,13 +70,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -93,7 +93,7 @@ jobs:
     name: HA Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Hassfest
         uses: home-assistant/actions/hassfest@master
@@ -109,7 +109,7 @@ jobs:
     name: Release Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Test bump scripts
         run: |
           chmod +x tools/release/*.sh

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,283 @@
+name: Create release PR
+
+# First half of the release. This prepares a release *proposal* and stops: it
+# opens a PR that rolls CHANGES.md and moves every version-bearing file. Nothing
+# is tagged, no image is pushed and no release exists until that PR is merged.
+# Closing it cancels the release with no cleanup.
+#
+# Merging the PR pushes to main, which triggers `Release publisher` -- the second
+# half, which does the tagging and publishing.
+#
+# Nothing here pushes to main, so no PAT is involved. `main` is protected by the
+# `main-protect` ruleset and GITHUB_TOKEN cannot be granted a bypass (the bypass
+# list takes users, teams and GitHub Apps, not the built-in Actions token), but
+# GITHUB_TOKEN *can* push an ordinary branch and open a PR, which is all this needs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        default: 'bugfix'
+        type: choice
+        options:
+          - bugfix   # x.y.Z
+          - feature  # x.Y.0
+          - major    # X.0.0
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify main is releasable
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Verify main branch
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "::error title=Wrong branch::Releases must be cut from main, not ${{ github.ref }}"
+            exit 1
+          fi
+
+      # An early warning, not the gate: the release PR still has to pass the full
+      # required set (Build, Test, Check & Lint and both CodeQL analyses) before it
+      # can merge. This exists because it is easy to fire a release seconds after a
+      # merge, while that merge's CI is still running -- and then discover the
+      # breakage only after a tag and a container image already exist.
+      - name: Verify CI passed for this commit
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            const short = sha.slice(0, 7);
+            const DEADLINE = Date.now() + 20 * 60 * 1000;
+            const POLL_MS = 15000;
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+            // The newest run for this exact commit is the verdict; a re-run
+            // supersedes an earlier failure.
+            async function latestRun() {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'ci.yml', head_sha: sha, per_page: 50,
+              });
+              if (data.workflow_runs.length === 0) return null;
+              return data.workflow_runs
+                .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0];
+            }
+
+            for (;;) {
+              const run = await latestRun();
+
+              if (run && run.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.notice(`CI passed for ${short}`);
+                  await core.summary
+                    .addRaw(`CI passed for \`${short}\` `)
+                    .addLink('(run)', run.html_url)
+                    .write();
+                  return;
+                }
+                core.setFailed(
+                  `CI concluded "${run.conclusion}" for ${short}. Fix main before releasing: ${run.html_url}`,
+                );
+                return;
+              }
+
+              if (Date.now() > DEADLINE) {
+                core.setFailed(
+                  run
+                    ? `Timed out after 20 minutes with CI still ${run.status}: ${run.html_url}`
+                    : `No CI run found for ${short}. Every push to main runs CI, so this commit reaching main without one means something is wrong.`,
+                );
+                return;
+              }
+
+              core.info(run ? `CI is ${run.status}; waiting...` : 'No CI run yet; waiting...');
+              await sleep(POLL_MS);
+            }
+
+  prepare:
+    name: Prepare release PR
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Calculate new version
+        id: version
+        run: |
+          set -euo pipefail
+          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1)
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+          fi
+          echo "Latest tag: ${LATEST}"
+
+          IFS=. read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
+
+          case "${{ inputs.release_type }}" in
+            major)   NEW_VERSION="$((MAJOR+1)).0.0" ;;
+            feature) NEW_VERSION="${MAJOR}.$((MINOR+1)).0" ;;
+            bugfix)  NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))" ;;
+          esac
+
+          if git rev-parse -q --verify "refs/tags/v${NEW_VERSION}" >/dev/null; then
+            echo "::error title=Tag exists::v${NEW_VERSION} is already tagged"
+            exit 1
+          fi
+
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "::notice title=New version::${LATEST} -> v${NEW_VERSION}"
+
+      - name: Update Cargo.toml and Cargo.lock
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+
+          # Cargo.lock records byonk's own version too, so it has to move with
+          # Cargo.toml. If it does not, the release commit is internally
+          # inconsistent: the tag is dirty the moment anyone builds it.
+          #
+          # Not `--offline`: this job never fetched the registry, and an offline
+          # resolve cannot find a single dependency. `--workspace` keeps the update
+          # to the workspace's own entries, so no dependency is touched -- which is
+          # what makes running it here safe.
+          cargo update --workspace
+
+          # Fail here rather than three jobs later if the lock did not take.
+          if ! grep -A1 '^name = "byonk"$' Cargo.lock | grep -qx "version = \"${VERSION}\""; then
+            echo "::error title=Lockfile not updated::Cargo.lock does not record version ${VERSION}"
+            exit 1
+          fi
+
+      - name: Update CHANGES.md
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          DATE=$(date +%Y-%m-%d)
+
+          # Move the Unreleased content into a new version section and reset
+          # Unreleased to empty subsections.
+          perl -i -0777 -pe '
+            s/## Unreleased\n+(### New\n(.*?))?(\n### Changed\n(.*?))?(\n### Fixed\n(.*?))?\n+(?=##|\z)/
+              "## Unreleased\n\n### New\n\n### Changed\n\n### Fixed\n\n" .
+              "## '"$VERSION"' - '"$DATE"'\n" .
+              ($2 ? "\n### New\n$2" : "") .
+              ($4 ? "\n### Changed\n$4" : "") .
+              ($6 ? "\n### Fixed\n$6" : "") .
+              "\n"
+            /se' CHANGES.md
+
+          # The publisher turns this section into the GitHub release body, so an
+          # empty one ships a release that says nothing about itself.
+          # Subsection headings are not content: a section holding nothing but a
+          # bare `### New` still ships an empty release body. The roll above does
+          # not produce that shape, but a hand-edited changelog can.
+          BODY=$(perl -0777 -ne '
+            my $v = quotemeta $ENV{VERSION};
+            next unless /^\#\# $v [^\n]*\n(.*?)(?=\n\#\# [0-9]|\z)/ms;
+            my $s = $1;
+            $s =~ s/^\#.*$//mg;
+            $s =~ s/\s+//g;
+            print $s;
+          ' CHANGES.md)
+          if [ -z "$BODY" ]; then
+            echo "::error title=Nothing to release::The Unreleased section of CHANGES.md is empty, so ${VERSION} would ship with empty release notes."
+            exit 1
+          fi
+
+      - name: Update Home Assistant integration version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          chmod +x tools/release/bump-integration-version.sh
+          tools/release/bump-integration-version.sh "${VERSION}"
+
+      # The add-on's `version:` is the tag Supervisor pulls from
+      # ghcr.io/oetiker/byonk, so between this PR merging and the publisher pushing
+      # the image (~15-20 min) the add-on store advertises a version that is not
+      # there yet. An HA user who refreshes inside that window gets a pull failure
+      # and succeeds on a later retry. Accepted deliberately in exchange for one PR
+      # per release; the alternative was a second, auto-merged PR after the push.
+      - name: Update Home Assistant add-on version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          chmod +x tools/release/bump-addon-version.sh
+          tools/release/bump-addon-version.sh "${VERSION}" "${{ inputs.release_type }}"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/${TAG}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+
+          git add Cargo.toml Cargo.lock CHANGES.md \
+                  custom_components/byonk/manifest.json \
+                  homeassistant/byonk/config.yaml homeassistant/byonk/CHANGELOG.md
+
+          if git diff --cached --quiet; then
+            echo "::error title=Nothing to commit::No version-bearing file changed"
+            exit 1
+          fi
+
+          git commit -m "Release ${TAG}"
+          git push origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release ${TAG}" \
+            --body "$(printf '%s\n' \
+              "Prepared automatically by the **Create release PR** workflow." \
+              "" \
+              "- rolls the \`CHANGES.md\` \`Unreleased\` section into \`## ${VERSION}\`" \
+              "- moves \`Cargo.toml\` and \`Cargo.lock\` to \`${VERSION}\`" \
+              "- syncs \`custom_components/byonk/manifest.json\`" \
+              "- syncs \`homeassistant/byonk/config.yaml\` and its changelog" \
+              "" \
+              "Review the changelog, then merge. Merging triggers **Release publisher**, which tags \`${TAG}\`, builds the binaries and the container, publishes the GitHub release and deploys the docs." \
+              "" \
+              "Nothing is tagged or published until this is merged; closing it cancels the release." \
+              "" \
+              "The add-on's \`version:\` is the ghcr image tag, so it points at an image that does not exist until the publisher finishes -- roughly 15-20 minutes after the merge.")")
+
+          echo "::notice title=Release PR opened::${PR_URL}"
+          {
+            echo "## Release ${TAG} prepared"
+            echo ""
+            echo "Review and merge to publish: ${PR_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -255,6 +255,23 @@ jobs:
           fi
 
           git commit -m "Release ${TAG}"
+
+          # Cancelling a release means closing its PR, which leaves the branch
+          # behind. The next attempt computes the same version, so it builds the
+          # same branch name from a different base -- and the push is rejected as a
+          # non-fast-forward, with nothing in the Actions UI able to recover it.
+          # Clear the stale branch, but never one that still has an open PR: that
+          # is a live proposal, not litter.
+          OPEN_PR=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
+          if [ -n "$OPEN_PR" ]; then
+            echo "::error title=Release already proposed::${BRANCH} already has an open PR: ${OPEN_PR} -- merge or close it before cutting ${TAG} again."
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::notice title=Clearing stale branch::${BRANCH} is left over from a cancelled release; deleting it"
+            git push origin --delete "$BRANCH"
+          fi
+
           git push origin "$BRANCH"
 
           PR_URL=$(gh pr create \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,13 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !inputs.backfill }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -72,7 +72,7 @@ jobs:
         run: mdbook build
 
       - name: Upload dev docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-dev
           path: docs/book
@@ -87,7 +87,7 @@ jobs:
         version: [v0.8.0, v0.7.1, v0.6.2, v0.5.3]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ matrix.version }}
 
@@ -95,7 +95,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -132,7 +132,7 @@ jobs:
         run: mdbook build
 
       - name: Upload versioned docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-${{ matrix.version }}
           path: docs/book
@@ -144,13 +144,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.backfill }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -181,7 +181,7 @@ jobs:
         run: mdbook build
 
       - name: Upload dev docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-dev
           path: docs/book
@@ -196,12 +196,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: .github/scripts
 
       - name: Download dev docs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-dev
           path: new-docs
@@ -258,16 +258,16 @@ jobs:
           cat site/byonk/versions.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/byonk
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   deploy-backfill:
     name: Deploy Backfill
@@ -278,12 +278,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: .github/scripts
 
       - name: Download all docs artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -327,13 +327,13 @@ jobs:
           cat site/byonk/versions.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/byonk
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -83,13 +83,27 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
           # The release, not the tag, is what says "this version shipped".
-          if gh release view "${TAG}" >/dev/null 2>&1; then
+          #
+          # "No such release" and "could not ask" are different answers, and only
+          # the first one means publish. Treating every failure as "not released"
+          # would let a transient API error start a second publish of a version
+          # that already shipped -- re-pushing its images and rewriting its
+          # release assets.
+          set +e
+          ERR=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1 >/dev/null)
+          RC=$?
+          set -e
+
+          if [ "$RC" -eq 0 ]; then
             echo "publish=false" >> "$GITHUB_OUTPUT"
             echo "::notice title=Already released::${TAG} already has a GitHub release - nothing to do"
             echo "Nothing to publish: \`${TAG}\` is already released." >> "$GITHUB_STEP_SUMMARY"
-          else
+          elif printf '%s' "$ERR" | grep -q 'HTTP 404'; then
             echo "publish=true" >> "$GITHUB_OUTPUT"
             echo "::notice title=Publishing::${TAG}"
+          else
+            echo "::error title=Cannot determine release state::Asking whether ${TAG} is released failed with something other than a 404: ${ERR}"
+            exit 1
           fi
 
   tag:

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -1,123 +1,130 @@
-name: Release
+name: Release publisher
+
+# Second half of the release. `Create release PR` prepares a PR; merging it lands
+# the rolled CHANGES.md and every version bump on main, and that merge triggers
+# this workflow, which tags, builds, publishes and deploys.
+#
+# Nothing here pushes to a branch. `main` is protected by the `main-protect`
+# ruleset and GITHUB_TOKEN cannot be granted a bypass, so no PAT is needed or used.
+# Tagging is unaffected: the ruleset targets branches, and tags are a separate ref
+# namespace.
+#
+# The version is read back out of the repository rather than passed in, which is
+# what makes this safe to fire on any push. An unrelated commit that touches
+# Cargo.toml -- a dependency bump, say -- starts this workflow, finds the release
+# already published and exits in seconds.
+#
+# There is deliberately no workflow_dispatch: publishing should be a consequence of
+# merging a release PR, never something started by hand. Recovery does not need one
+# either. The guard below asks whether the *GitHub release* exists, not whether the
+# tag exists, so a run that died after tagging can simply be re-run from the
+# Actions UI and will pick up where it failed.
 
 on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: 'Release type'
-        required: true
-        type: choice
-        options:
-          - bugfix
-          - feature
-          - major
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+
+concurrency:
+  group: release-publisher
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
   PAGES_URL: "https://oetiker.github.io/byonk"
 
-# Least-privilege default. Jobs that need more (write/push, publish container,
-# create release, deploy pages) declare their own block below, which fully
-# overrides this default for that job — so this only tightens the two jobs that
-# otherwise ran with broad scopes: build-binaries and build-docs (checkout +
-# build + upload-artifact, all read-only).
 permissions:
   contents: read
 
 jobs:
-  version:
-    name: Bump Version
+  guard:
+    name: Decide whether to publish
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    timeout-minutes: 10
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      tag: ${{ steps.version.outputs.tag }}
+      publish: ${{ steps.decide.outputs.publish }}
+      version: ${{ steps.decide.outputs.version }}
+      tag: ${{ steps.decide.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          # This job pushes the version-bump commit + tag to the protected
-          # `main` branch. The default GITHUB_TOKEN cannot push under the
-          # `main-protect` ruleset, so use RELEASE_TOKEN — a PAT whose owner is
-          # on the ruleset's bypass list. See docs/superpowers/ha-publishing.md.
-          token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Verify main branch
+      - name: Read and cross-check the version
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
-            echo "::error::Releases must be created from the main branch"
+          set -euo pipefail
+
+          # Cargo.toml is the source of truth. The two Home Assistant manifests are
+          # bumped in the same release commit, so a disagreement means a hand edit
+          # went wrong -- and shipping it would point the add-on at the wrong image.
+          VERSION=$(sed -n '/^\[package\]/,/^\[/ s/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          INTEGRATION=$(jq -r '.version' custom_components/byonk/manifest.json)
+          ADDON=$(sed -n 's/^version: *"\(.*\)"/\1/p' homeassistant/byonk/config.yaml | head -1)
+
+          echo "Cargo.toml:  ${VERSION}"
+          echo "integration: ${INTEGRATION}"
+          echo "add-on:      ${ADDON}"
+
+          if [ -z "$VERSION" ]; then
+            echo "::error title=No version::Could not read the package version from Cargo.toml"
+            exit 1
+          fi
+          if [ "$INTEGRATION" != "$VERSION" ] || [ "$ADDON" != "$VERSION" ]; then
+            echo "::error title=Version drift::Cargo.toml says ${VERSION}, integration says ${INTEGRATION}, add-on says ${ADDON}"
             exit 1
           fi
 
-      - name: Calculate new version
-        id: version
-        run: |
-          # Get latest tag or default to v0.0.0
-          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1 || echo "v0.0.0")
-          if [ -z "$LATEST" ]; then
-            LATEST="v0.0.0"
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          # The release, not the tag, is what says "this version shipped".
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Already released::${TAG} already has a GitHub release - nothing to do"
+            echo "Nothing to publish: \`${TAG}\` is already released." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Publishing::${TAG}"
           fi
 
-          # Parse version components
-          MAJOR=$(echo "$LATEST" | sed 's/v\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/')
-          MINOR=$(echo "$LATEST" | sed 's/v\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/')
-          PATCH=$(echo "$LATEST" | sed 's/v\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\3/')
+  tag:
+    name: Tag ${{ needs.guard.outputs.tag }}
+    needs: guard
+    if: needs.guard.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
-          # Calculate new version based on release type
-          case "${{ inputs.release_type }}" in
-            major)
-              NEW_VERSION="$((MAJOR+1)).0.0"
-              ;;
-            feature)
-              NEW_VERSION="${MAJOR}.$((MINOR+1)).0"
-              ;;
-            bugfix)
-              NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))"
-              ;;
-          esac
-
-          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
-          echo "tag=v${NEW_VERSION}" >> $GITHUB_OUTPUT
-          echo "New version: ${NEW_VERSION}"
-
-      - name: Update Cargo.toml version
+      - name: Create and push the tag
+        env:
+          TAG: ${{ needs.guard.outputs.tag }}
         run: |
-          sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.version }}"/' Cargo.toml
-
-      - name: Update CHANGES.md
-        run: |
-          DATE=$(date +%Y-%m-%d)
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # Update changelog: move Unreleased content to new version section
-          perl -i -0777 -pe '
-            s/## Unreleased\n+(### New\n(.*?))?(\n### Changed\n(.*?))?(\n### Fixed\n(.*?))?\n+(?=##|\z)/
-              "## Unreleased\n\n### New\n\n### Changed\n\n### Fixed\n\n" .
-              "## '"$VERSION"' - '"$DATE"'\n" .
-              ($2 ? "\n### New\n$2" : "") .
-              ($4 ? "\n### Changed\n$4" : "") .
-              ($6 ? "\n### Fixed\n$6" : "") .
-              "\n"
-            /se' CHANGES.md
-
-      - name: Update integration manifest version
-        run: |
-          chmod +x tools/release/bump-integration-version.sh
-          tools/release/bump-integration-version.sh "${{ steps.version.outputs.version }}"
-
-      - name: Commit and tag
-        run: |
+          set -euo pipefail
+          # Create-if-missing rather than fail-if-present: a re-run after a failed
+          # build must be able to get past this step.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::notice title=Tag exists::${TAG} is already tagged; continuing"
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml CHANGES.md custom_components/byonk/manifest.json
-          git commit -m "Release ${{ steps.version.outputs.tag }}"
-          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin main --tags
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+          echo "::notice title=Tagged::${TAG}"
 
   build-binaries:
     name: Build ${{ matrix.target }}
-    needs: version
+    needs: [guard, tag]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -140,9 +147,9 @@ jobs:
             os: windows-latest
             archive: zip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.guard.outputs.tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -172,10 +179,12 @@ jobs:
 
       - name: Create archive (Unix)
         if: matrix.archive == 'tar.gz'
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
         run: |
           mkdir -p dist
           BINARY="target/${{ matrix.target }}/release/byonk"
-          ARCHIVE="byonk-${{ needs.version.outputs.version }}-${{ matrix.target }}.tar.gz"
+          ARCHIVE="byonk-${VERSION}-${{ matrix.target }}.tar.gz"
 
           # Create staging directory
           mkdir -p staging/byonk
@@ -187,15 +196,16 @@ jobs:
           cp LICENSE staging/byonk/
 
           tar -czvf "dist/${ARCHIVE}" -C staging byonk
-          echo "ARCHIVE=${ARCHIVE}" >> $GITHUB_ENV
         shell: bash
 
       - name: Create archive (Windows)
         if: matrix.archive == 'zip'
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
         run: |
           mkdir dist
           $BINARY = "target/${{ matrix.target }}/release/byonk.exe"
-          $ARCHIVE = "byonk-${{ needs.version.outputs.version }}-${{ matrix.target }}.zip"
+          $ARCHIVE = "byonk-$env:VERSION-${{ matrix.target }}.zip"
 
           # Create staging directory
           mkdir staging/byonk
@@ -207,35 +217,35 @@ jobs:
           Copy-Item LICENSE staging/byonk/
 
           Compress-Archive -Path staging/byonk -DestinationPath "dist/$ARCHIVE"
-          echo "ARCHIVE=$ARCHIVE" >> $env:GITHUB_ENV
         shell: pwsh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: byonk-${{ matrix.target }}
           path: dist/*
 
   build-container:
     name: Build Container
-    needs: [version, build-binaries]
+    needs: [guard, tag, build-binaries]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.guard.outputs.tag }}
 
       - name: Download Linux AMD64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: byonk-x86_64-unknown-linux-musl
           path: artifacts/amd64
 
       - name: Download Linux ARM64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: byonk-aarch64-unknown-linux-musl
           path: artifacts/arm64
@@ -247,13 +257,13 @@ jobs:
           tar -xzf artifacts/arm64/byonk-*-aarch64-unknown-linux-musl.tar.gz -C binaries/arm64 --strip-components=1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -261,15 +271,16 @@ jobs:
 
       - name: Calculate version tags
         id: tags
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
         run: |
-          VERSION="${{ needs.version.outputs.version }}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f1-2)
-          echo "major=$MAJOR" >> $GITHUB_OUTPUT
-          echo "minor=$MINOR" >> $GITHUB_OUTPUT
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.release
@@ -277,71 +288,48 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ needs.version.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ needs.guard.outputs.version }}
             ghcr.io/${{ github.repository }}:${{ steps.tags.outputs.minor }}
             ghcr.io/${{ github.repository }}:${{ steps.tags.outputs.major }}
           build-args: |
             BINARY_DIR=binaries
 
-  update-addon-version:
-    name: Bump Add-on Version
-    needs: [version, build-container]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          # Pushes the add-on version bump to protected `main`; needs the
-          # bypass PAT, same as the version job above.
-          token: ${{ secrets.RELEASE_TOKEN }}
-
-      - name: Bump add-on config + changelog
-        run: |
-          chmod +x tools/release/bump-addon-version.sh
-          tools/release/bump-addon-version.sh \
-            "${{ needs.version.outputs.version }}" \
-            "${{ inputs.release_type }}"
-
-      - name: Commit and push to main
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add homeassistant/byonk/config.yaml homeassistant/byonk/CHANGELOG.md
-          git commit -m "Bump add-on to ${{ needs.version.outputs.version }}"
-          git pull --rebase origin main
-          git push origin main
-
   create-release:
     name: Create GitHub Release
-    needs: [version, build-binaries, build-container]
+    needs: [guard, tag, build-binaries, build-container]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.guard.outputs.tag }}
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: byonk-*
           merge-multiple: true
 
       - name: Extract release notes
-        id: changelog
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
         run: |
-          # Extract the changelog section for this version
-          VERSION="${{ needs.version.outputs.version }}"
-          NOTES=$(sed -n "/^## ${VERSION}/,/^## [0-9]/p" CHANGES.md | sed '$d')
-
-          # Write to file for the release
-          echo "$NOTES" > release-notes.md
-
-          # Also output for debugging
+          set -euo pipefail
+          # This version's section, heading included, up to the next `## <version>`
+          # heading or EOF. Perl rather than a sed range because the range form has
+          # to strip a trailing heading that is only sometimes there, and the idiom
+          # that does it is GNU-only -- untestable on a maintainer's Mac.
+          perl -0777 -ne '
+            my $v = quotemeta $ENV{VERSION};
+            if (/^(\#\# $v [^\n]*\n.*?)(?=\n\#\# [0-9]|\z)/ms) {
+              my $s = $1; $s =~ s/\s+$//; print "$s\n";
+            } else {
+              die "no section for $ENV{VERSION} in CHANGES.md\n";
+            }
+          ' CHANGES.md > release-notes.md
           echo "Release notes:"
           cat release-notes.md
 
@@ -349,10 +337,10 @@ jobs:
         run: ls -la artifacts/
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          name: Byonk ${{ needs.version.outputs.tag }}
+          tag_name: ${{ needs.guard.outputs.tag }}
+          name: Byonk ${{ needs.guard.outputs.tag }}
           body_path: release-notes.md
           files: artifacts/*
           fail_on_unmatched_files: true
@@ -361,18 +349,19 @@ jobs:
 
   build-docs:
     name: Build Release Documentation
-    needs: version
+    needs: [guard, tag]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.version.outputs.tag }}
+          ref: ${{ needs.guard.outputs.tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -393,7 +382,7 @@ jobs:
           mkdir -p ~/bin
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C ~/bin
           curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.17.0/mdbook-mermaid-v0.17.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C ~/bin
-          echo "$HOME/bin" >> $GITHUB_PATH
+          echo "$HOME/bin" >> "$GITHUB_PATH"
 
       - name: Setup mermaid assets
         run: mdbook-mermaid install docs
@@ -403,7 +392,7 @@ jobs:
         run: mdbook build
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-release
           path: docs/book
@@ -411,8 +400,9 @@ jobs:
 
   deploy-docs:
     name: Deploy Release Documentation
-    needs: [version, build-docs, create-release]
+    needs: [guard, tag, build-docs, create-release]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pages: write
@@ -421,12 +411,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: .github/scripts
 
       - name: Download docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-release
           path: new-docs
@@ -449,11 +439,12 @@ jobs:
           ls -la site/byonk/ 2>/dev/null || echo "(empty or no byonk dir)"
 
       - name: Add new version to site
+        env:
+          TAG: ${{ needs.guard.outputs.tag }}
         run: |
-          VERSION="${{ needs.version.outputs.tag }}"
-          mkdir -p "site/byonk/$VERSION"
-          cp -r new-docs/* "site/byonk/$VERSION/"
-          echo "Added version $VERSION"
+          mkdir -p "site/byonk/${TAG}"
+          cp -r new-docs/* "site/byonk/${TAG}/"
+          echo "Added version ${TAG}"
 
       - name: Update versions and redirect
         run: |
@@ -471,13 +462,13 @@ jobs:
           cat site/byonk/versions.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/byonk
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This morning's 0.18.0 release died on its first step: `actions/checkout` could not
authenticate, because `RELEASE_TOKEN` — the PAT that let the release push to
protected `main` — expired 32 days after it was created.

This removes the PAT rather than renewing it, following the split
[oposs/mkp-builder](https://github.com/oposs/mkp-builder) uses.

## The two halves

| Workflow | Trigger | Does |
|---|---|---|
| **Create release PR** | `workflow_dispatch` + release type | verifies CI is green for this exact commit, rolls `CHANGES.md`, moves every version-bearing file, opens a `release/vX.Y.Z` PR. Nothing tagged, nothing published. |
| **Release publisher** | the merge of that PR | tags, builds 5 binaries and the multi-arch container, publishes the release, deploys the docs. No `workflow_dispatch` — publishing is only ever a consequence of merging. |

No PAT anywhere. `GITHUB_TOKEN` cannot push to protected `main`, but it can push an
ordinary branch, open a PR, and push a **tag** — the ruleset targets branches, and
tags are a separate ref namespace.

The CI check is worth calling out: the failed run was fired seconds after a merge,
while that merge's CI was still running. `Create release PR` now waits for it.

## Two defects fixed on the way

- **`Cargo.lock` never moved with `Cargo.toml`.** It records byonk's own version, so
  every release commit so far has been internally inconsistent — dirty the moment
  anyone builds the tag. Now bumped with `cargo update --workspace` and verified.
- **Release-note extraction deleted the changelog's last line** whenever the released
  section was the final one in the file, because it stripped the trailing heading
  unconditionally.

## Design decisions

- **The add-on bump stays in the release PR.** `homeassistant/byonk/config.yaml`'s
  `version:` *is* the ghcr image tag, so for the ~15–20 min between merge and the
  container push the store advertises an image that is not there yet. Accepted
  deliberately, in exchange for one PR per release; the alternative was a second,
  auto-merged PR after the push.
- **The publisher's guard asks whether the GitHub *release* exists, not the tag.**
  Guarding on the tag would make a run that died after tagging unrecoverable.
- **The version is read back out of `Cargo.toml`** and cross-checked against both HA
  manifests, so a drift fails loudly instead of shipping a mismatched add-on.

## Actions

All bumped to their current major, in `ci.yml` and `docs.yml` too — the failed run
already warned that `checkout@v4` is forced onto Node 24.

checkout v4→v7 · cache v4→v6 · upload-artifact v4→v7 · download-artifact v4→v8 ·
gh-release v2→v3 · configure-pages v4→v6 · deploy-pages v4→v5 ·
upload-pages-artifact v3→v5 · docker setup-qemu/setup-buildx v3→v4 · docker login
v3→v4 · docker build-push v5→v7

## Verification

- `actionlint` **with shellcheck**, clean on both new workflows.
- Version arithmetic against the real tag list; the `CHANGES.md` roll against the
  real file; release-note extraction for a middle section, the EOF section, and a
  missing version (dies loudly).
- The empty-notes guard, four cases including a hand-edited changelog holding only
  a bare `### New`.
- The `Cargo.lock` bump run for real: exactly one line changes. **Sabotage-verified**
  — with a stale lock the check fails, so it is not decorative.

**Not verified end to end, and it cannot be:** the first real proof is the next
release. Everything before the merge is reversible by closing the PR.

## After the first successful release

`RELEASE_TOKEN` is unused — delete the secret and revoke the PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)