### PR TITLE
Move the declared engine requirement with the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,4 @@ jobs:
           chmod +x tools/release/*.sh
           tools/release/test-bump-addon-version.sh
           tools/release/test-bump-integration-version.sh
+          tools/release/test-bump-screen-engine.sh

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -218,6 +218,23 @@ jobs:
           chmod +x tools/release/bump-integration-version.sh
           tools/release/bump-integration-version.sh "${VERSION}"
 
+      # A screen's `byonk: "0.17"` is read as `^0.17`, i.e. `<0.18.0`, so a minor
+      # release puts byonk's own screens outside their own declared range and
+      # `GET /api/admin/screens` starts warning on every one of them -- including
+      # the fallback screen, which trains users to ignore the field. That drift
+      # shipped once already, in 0.16.0, and the guard test in
+      # tests/screen_schemas_test.rs fails the release PR when it happens again.
+      #
+      # The tutorial's meta.yaml examples move too, so the docs cannot end up
+      # quoting a version the screens no longer declare.
+      - name: Update the declared engine requirement
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          chmod +x tools/release/bump-screen-engine.sh
+          tools/release/bump-screen-engine.sh "${VERSION}"
+
       # The add-on's `version:` is the tag Supervisor pulls from
       # ghcr.io/oetiker/byonk, so between this PR merging and the publisher pushing
       # the image (~15-20 min) the add-on store advertises a version that is not
@@ -248,6 +265,9 @@ jobs:
           git add Cargo.toml Cargo.lock CHANGES.md \
                   custom_components/byonk/manifest.json \
                   homeassistant/byonk/config.yaml homeassistant/byonk/CHANGELOG.md
+          # -u, not the bare paths: stage modifications to tracked files without
+          # sweeping in anything untracked sitting under these trees.
+          git add -u screens docs/src
 
           if git diff --cached --quiet; then
             echo "::error title=Nothing to commit::No version-bearing file changed"
@@ -284,6 +304,7 @@ jobs:
               "- rolls the \`CHANGES.md\` \`Unreleased\` section into \`## ${VERSION}\`" \
               "- moves \`Cargo.toml\` and \`Cargo.lock\` to \`${VERSION}\`" \
               "- syncs \`custom_components/byonk/manifest.json\`" \
+              "- points every shipped screen and doc example at the \`${VERSION%.*}\` engine series" \
               "- syncs \`homeassistant/byonk/config.yaml\` and its changelog" \
               "" \
               "Review the changelog, then merge. Merging triggers **Release publisher**, which tags \`${TAG}\`, builds the binaries and the container, publishes the GitHub release and deploys the docs." \

--- a/tools/release/bump-screen-engine.sh
+++ b/tools/release/bump-screen-engine.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Points every declared byonk engine requirement at the release's series.
+# Usage: bump-screen-engine.sh <version> [root]
+#
+# A screen declares `byonk: "0.17"`, which the engine reads as `^0.17` -- that
+# is `>=0.17.0, <0.18.0`. So every minor release puts byonk's own screens
+# outside their own declared range, and `GET /api/admin/screens` starts
+# reporting a compat_warning on all of them, including the fallback screen.
+# That drift shipped once already, in 0.16.0.
+#
+# Two places declare it and both must move together, or the docs end up
+# contradicting the screens they quote:
+#   <root>/screens/**/meta.yaml   -- the screens byonk ships
+#   <root>/docs/src/**/*.md       -- the meta.yaml examples the tutorial teaches
+#
+# Only major.minor is written, matching `compat::engine_compat_req()`, which is
+# what a newly scaffolded screen gets. A bugfix release therefore changes
+# nothing, which is correct: 0.17.2 is inside ^0.17.
+#
+# The rewrite is anchored at column 0. In a meta.yaml that skips the nested
+# keys under `params:`; in a Markdown file it confines the change to lines
+# inside a fenced YAML block, which is where these examples live.
+set -euo pipefail
+
+version="${1:?usage: bump-screen-engine.sh <version> [root]}"
+root="${2:-.}"
+
+# major.minor -- the series, not the point release.
+series="${version%.*}"
+if [ "$series" = "$version" ] || [ -z "$series" ]; then
+  echo "bump-screen-engine.sh: cannot derive a major.minor series from '$version'" >&2
+  exit 1
+fi
+
+changed=0
+bump() { # file
+  local before
+  before=$(cat "$1")
+  # `[^"]*`, not `.*`: greedy matching would swallow a trailing comment that
+  # happens to contain a quote, taking the comment with it.
+  perl -i -pe 's/^byonk: *"[^"]*"/byonk: "'"$series"'"/' "$1"
+  if [ "$before" != "$(cat "$1")" ]; then
+    echo "  $1"
+    changed=$((changed + 1))
+  fi
+}
+
+if [ -d "$root/screens" ]; then
+  while IFS= read -r f; do bump "$f"; done \
+    < <(find "$root/screens" -name meta.yaml -type f | sort)
+fi
+
+if [ -d "$root/docs/src" ]; then
+  while IFS= read -r f; do bump "$f"; done \
+    < <(grep -rl '^byonk: *"' "$root/docs/src" --include='*.md' | sort)
+fi
+
+echo "bump-screen-engine.sh: ${changed} file(s) moved to byonk: \"${series}\""

--- a/tools/release/bump-screen-engine.sh
+++ b/tools/release/bump-screen-engine.sh
@@ -18,19 +18,25 @@
 # nothing, which is correct: 0.17.2 is inside ^0.17.
 #
 # The rewrite is anchored at column 0. In a meta.yaml that skips the nested
-# keys under `params:`; in a Markdown file it confines the change to lines
-# inside a fenced YAML block, which is where these examples live.
+# keys under `params:`. In Markdown it is a plain column-0 match and NOT a
+# fenced-block parse: every example lives at column 0 inside a ```yaml fence,
+# but a line of prose beginning `byonk: "x.y"` would be rewritten too. Two doc
+# files have not been worth a Markdown parser.
 set -euo pipefail
 
 version="${1:?usage: bump-screen-engine.sh <version> [root]}"
 root="${2:-.}"
 
 # major.minor -- the series, not the point release.
-series="${version%.*}"
-if [ "$series" = "$version" ] || [ -z "$series" ]; then
-  echo "bump-screen-engine.sh: cannot derive a major.minor series from '$version'" >&2
+#
+# Parsed, not chopped. `${version%.*}` turns a version that is missing its patch
+# component into something plausible and wrong: "0.18" becomes series "0", which
+# no emptiness check catches, and 15 files would silently be stamped `byonk: "0"`.
+if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "bump-screen-engine.sh: expected a x.y.z version, got '$version'" >&2
   exit 1
 fi
+series="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
 
 changed=0
 bump() { # file

--- a/tools/release/test-bump-screen-engine.sh
+++ b/tools/release/test-bump-screen-engine.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fail=0
+
+mkscreen() { # dir, byonk-value
+  mkdir -p "$tmp/screens/$1"
+  cat > "$tmp/screens/$1/meta.yaml" <<EOF
+title: A screen
+description: Something
+byonk: "$2"
+refresh: 900
+params:
+  byonk: not-the-engine-field
+EOF
+}
+
+check() { # file, expected byonk line, label
+  local got
+  got=$(grep '^byonk:' "$tmp/screens/$1/meta.yaml")
+  if [ "$got" = "$2" ]; then
+    echo "  ok: $3"
+  else
+    echo "  FAIL: $3 -- expected '$2', got '$got'"; fail=1
+  fi
+}
+
+echo "feature release 0.17.1 -> 0.18.0"
+mkscreen builtin/default 0.17
+mkscreen examples/hello 0.17
+mkscreen examples/ahead 0.18
+mkdir -p "$tmp/docs/src/tutorial"
+cat > "$tmp/docs/src/tutorial/first-screen.md" <<'EOF'
+# First screen
+
+```yaml
+title: Hello
+byonk: "0.17"       # engine series (caret range)
+```
+
+Prose mentioning byonk: "0.17" stays put.
+EOF
+"$here/bump-screen-engine.sh" "0.18.0" "$tmp" >/dev/null
+check builtin/default 'byonk: "0.18"' "stale screen moved to the new series"
+check examples/hello  'byonk: "0.18"' "every screen in the tree is visited"
+check examples/ahead  'byonk: "0.18"' "an already-current screen is left correct"
+
+echo "the nested key under params: is not the engine field"
+if grep -q '^  byonk: not-the-engine-field$' "$tmp/screens/builtin/default/meta.yaml"; then
+  echo "  ok: indented byonk: untouched"
+else
+  echo "  FAIL: the rewrite reached an indented byonk: key"; fail=1
+fi
+
+echo "the tutorial's meta.yaml example moves with the screens"
+check_doc() { # expected, label
+  local got; got=$(grep '^byonk:' "$tmp/docs/src/tutorial/first-screen.md")
+  if [ "$got" = "$1" ]; then echo "  ok: $2"; else echo "  FAIL: $2 -- expected '$1', got '$got'"; fail=1; fi
+}
+check_doc 'byonk: "0.18"       # engine series (caret range)' "fenced yaml example bumped, trailing comment kept"
+if grep -q '^Prose mentioning byonk: "0.17" stays put.$' "$tmp/docs/src/tutorial/first-screen.md"; then
+  echo "  ok: an indented/inline mention in prose is untouched"
+else
+  echo "  FAIL: the rewrite reached prose"; fail=1
+fi
+
+echo "a quote in the trailing comment is not swallowed"
+mkdir -p "$tmp/screens/quoted"
+printf '%s\n' 'title: Q' 'byonk: "0.17"  # see the "compat" section' > "$tmp/screens/quoted/meta.yaml"
+"$here/bump-screen-engine.sh" "0.18.0" "$tmp" >/dev/null
+got=$(grep '^byonk:' "$tmp/screens/quoted/meta.yaml")
+if [ "$got" = 'byonk: "0.18"  # see the "compat" section' ]; then
+  echo "  ok: comment preserved"
+else
+  echo "  FAIL: expected the comment intact, got '$got'"; fail=1
+fi
+
+echo "idempotent: running it again changes nothing"
+sum_before=$(find "$tmp" -name meta.yaml -exec cat {} + | shasum)
+"$here/bump-screen-engine.sh" "0.18.0" "$tmp" >/dev/null
+sum_after=$(find "$tmp" -name meta.yaml -exec cat {} + | shasum)
+if [ "$sum_before" = "$sum_after" ]; then echo "  ok: no change on a second run"; else echo "  FAIL: not idempotent"; fail=1; fi
+
+echo "bugfix release 0.18.0 -> 0.18.1 stays in the same series"
+"$here/bump-screen-engine.sh" "0.18.1" "$tmp" >/dev/null
+check builtin/default 'byonk: "0.18"' "a patch bump does not move the series"
+
+echo "major release 0.18.1 -> 1.0.0"
+"$here/bump-screen-engine.sh" "1.0.0" "$tmp" >/dev/null
+check builtin/default 'byonk: "1.0"' "major release moves to 1.0"
+
+echo "a version with no minor component is rejected"
+if "$here/bump-screen-engine.sh" "5" "$tmp" >/dev/null 2>&1; then
+  echo "  FAIL: accepted a version with no minor"; fail=1
+else
+  echo "  ok: rejected"
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: bump-screen-engine tests passed"
+else
+  echo "FAIL: bump-screen-engine tests failed"; exit 1
+fi

--- a/tools/release/test-bump-screen-engine.sh
+++ b/tools/release/test-bump-screen-engine.sh
@@ -60,9 +60,20 @@ check_doc() { # expected, label
 }
 check_doc 'byonk: "0.18"       # engine series (caret range)' "fenced yaml example bumped, trailing comment kept"
 if grep -q '^Prose mentioning byonk: "0.17" stays put.$' "$tmp/docs/src/tutorial/first-screen.md"; then
-  echo "  ok: an indented/inline mention in prose is untouched"
+  echo "  ok: a mid-line mention in prose is untouched"
 else
-  echo "  FAIL: the rewrite reached prose"; fail=1
+  echo "  FAIL: the rewrite reached mid-line prose"; fail=1
+fi
+# Pins the limitation the script documents rather than leaving it to a comment:
+# this is a column-0 match, not a fenced-block parse, so a prose line that starts
+# like a YAML key IS rewritten. If that ever stops being true, update both.
+printf '%s\n' 'byonk: "0.17" written at column 0 outside any fence.' \
+  >> "$tmp/docs/src/tutorial/first-screen.md"
+"$here/bump-screen-engine.sh" "0.18.0" "$tmp" >/dev/null
+if grep -q '^byonk: "0.18" written at column 0 outside any fence.$' "$tmp/docs/src/tutorial/first-screen.md"; then
+  echo "  ok: column-0 prose is rewritten too (documented limitation)"
+else
+  echo "  FAIL: the documented column-0 behaviour changed"; fail=1
 fi
 
 echo "a quote in the trailing comment is not swallowed"
@@ -77,9 +88,17 @@ else
 fi
 
 echo "idempotent: running it again changes nothing"
-sum_before=$(find "$tmp" -name meta.yaml -exec cat {} + | shasum)
+# Sorted, so the digest cannot depend on find's unspecified traversal order, and
+# over the .md files too -- the script rewrites those, so leaving them out would
+# let a docs-only regression pass. shasum rather than sha256sum: macOS ships no
+# sha256sum, and this suite has to run on a maintainer's laptop as well as CI.
+digest() {
+  find "$tmp" \( -name meta.yaml -o -name '*.md' \) -type f | sort \
+    | while IFS= read -r f; do cat "$f"; done | shasum
+}
+sum_before=$(digest)
 "$here/bump-screen-engine.sh" "0.18.0" "$tmp" >/dev/null
-sum_after=$(find "$tmp" -name meta.yaml -exec cat {} + | shasum)
+sum_after=$(digest)
 if [ "$sum_before" = "$sum_after" ]; then echo "  ok: no change on a second run"; else echo "  FAIL: not idempotent"; fail=1; fi
 
 echo "bugfix release 0.18.0 -> 0.18.1 stays in the same series"
@@ -90,12 +109,16 @@ echo "major release 0.18.1 -> 1.0.0"
 "$here/bump-screen-engine.sh" "1.0.0" "$tmp" >/dev/null
 check builtin/default 'byonk: "1.0"' "major release moves to 1.0"
 
-echo "a version with no minor component is rejected"
-if "$here/bump-screen-engine.sh" "5" "$tmp" >/dev/null 2>&1; then
-  echo "  FAIL: accepted a version with no minor"; fail=1
-else
-  echo "  ok: rejected"
-fi
+echo "only a x.y.z version is accepted"
+# "0.18" is the dangerous one: chopping the last dot-component off it yields the
+# plausible-looking series "0", which no emptiness check catches.
+for bad in "5" "0.18" "1.2.3.4" "x.y.z" ""; do
+  if "$here/bump-screen-engine.sh" "$bad" "$tmp" >/dev/null 2>&1; then
+    echo "  FAIL: accepted '$bad'"; fail=1
+  else
+    echo "  ok: rejected '$bad'"
+  fi
+done
 
 if [ "$fail" -eq 0 ]; then
   echo "OK: bump-screen-engine tests passed"


### PR DESCRIPTION
The 0.18.0 release PR (#34) fails CI on `every_shipped_screen_is_compatible_with_this_engine`.

## What is wrong

A screen declares `byonk: "0.17"`, which `src/models/compat.rs` reads as `^0.17` — that is `>=0.17.0, <0.18.0`. Bumping the engine to 0.18.0 puts all **13 shipped screens** outside their own declared range, so `GET /api/admin/screens` would warn on every one of them, including `byonk-builtin/default`, the fallback screen. That trains users to ignore the field.

**This is not new.** The guard test's own doc comment records the same drift shipping in 0.16.0, and `compat::engine_compat_req()` exists so newly *scaffolded* screens can never be born stale. Nothing did the same for the screens byonk ships, so every minor release has had to break this test.

## The fix

`tools/release/bump-screen-engine.sh` writes the release's `major.minor` series into every declared requirement, and `Create release PR` runs it alongside the Cargo, integration and add-on bumps.

It covers **two** places, because they have to move together:

| | |
|---|---|
| `screens/**/meta.yaml` | the 13 screens byonk ships |
| `docs/src/**/*.md` | the meta.yaml examples the tutorial teaches — `api/admin-api.md` reproduces `examples/swiss-departure-board/meta.yaml` verbatim, so leaving it would make the docs contradict the screens |

15 files, 17 lines, on a feature release. **A bugfix release changes nothing**, which is correct: 0.17.2 is inside `^0.17`.

## Verification

Reproduced the CI failure locally, then cleared it:

```
RED    engine 0.18.0, screens untouched  -> test result: FAILED. 0 passed; 1 failed
GREEN  after bump-screen-engine.sh 0.18.0 -> test result: ok. 1 passed; 0 failed
```

The script's own tests cover the tree walk, the docs sweep, idempotence, a patch release not moving the series, a major release, and a rejected malformed version. **Sabotage-verified twice**, because a test written after the code has never been shown to fail:

- drop the column-0 anchor → the rewrite reaches a nested `byonk:` key under `params:`, and the suite fails
- make the quoted part greedy (`.*` instead of `[^"]*`) → a trailing comment containing a quote is swallowed, and the suite fails

Wired into the `Release Scripts` CI job next to the two existing bump-script tests.

## Note on the release flow

The old workflow could not have caught this. It pushed the bump and the tag to `main` together, so 0.18.0 would have been **tagged, built and pushed to ghcr** before CI went red. The PR gate stopped it with nothing published.

## To finish the 0.18.0 release

1. Merge this.
2. Close #34 — its branch is left behind on purpose; `Create release PR` now clears a stale `release/v*` branch when no open PR points at it.
3. Re-run **Create release PR → feature**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)