### PR TITLE
fix(lua): make the screen sandbox withhold what the docs promised

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `os.difftime` — are untouched, as are `require`, `read_asset` and the HTTP
   functions. The Lua API reference now lists exactly what is withheld.
 
+- **Errors from a screen script now name the screen.** They used to be labelled
+  with a line inside byonk's own Rust source — `[string
+  "src/services/lua_runtime.rs:1031:33"]:1: boom` — which read as though byonk
+  had broken rather than the script. The screen's name appears instead.
+
 ## 0.18.0 - 2026-08-18
 
 ### New

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Screen scripts can no longer reach the filesystem or the process.** The Lua
+  API reference has always said file I/O and OS functions were unavailable, but
+  the sandbox did not actually withhold them: a script could call `io.open` and
+  write anywhere byonk could, `os.getenv` to read byonk's own environment, or
+  `os.exit` to stop the server. That reach is now gone — `io`, `package`,
+  `dofile`, `loadfile`, `load`, `debug` and the dangerous half of `os` all
+  evaluate to `nil`. It matters because byonk re-fetches screen repositories on
+  a timer, so an upstream change runs new Lua on your server unreviewed. The
+  clock functions screens do use — `os.time`, `os.date`, `os.clock`,
+  `os.difftime` — are untouched, as are `require`, `read_asset` and the HTTP
+  functions. The Lua API reference now lists exactly what is withheld.
+
 ## 0.18.0 - 2026-08-18
 
 ### New

--- a/docs/src/api/lua-api.md
+++ b/docs/src/api/lua-api.md
@@ -1497,8 +1497,35 @@ Byonk uses Lua 5.4. Standard library functions available include:
 - `math.min`, `math.max`
 - `math.random`
 
+### Time
+- `os.time`, `os.date`, `os.clock`, `os.difftime`
+
+(For formatting and parsing, prefer byonk's own
+[`time_format`](#time_formattimestamp-format) and
+[`time_parse`](#time_parsestr-format), which take a timezone.)
+
 ### Other
 - `tonumber`, `tostring`, `type`
 - `pcall` (for error handling)
 
-**Not available:** File I/O, OS functions, network (except `http_get`)
+### Not available
+
+A screen script runs in a sandbox. It gets no filesystem, no subprocess and no
+environment — the only ways out are the HTTP functions above and
+[`read_asset`](#read_assetpath), which stays inside the screen's own folder.
+
+The following are removed and evaluate to `nil`:
+
+| Removed | Why |
+|---------|-----|
+| the whole `io` library | file access |
+| the whole `package` library | `require` still works, but is a byonk resolver limited to the screen's own repo and `byonk-base` |
+| `dofile`, `loadfile` | file access |
+| `load` | compiles arbitrary bytecode, which can escape the VM |
+| `os.execute`, `os.exit` | run programs / stop the server |
+| `os.getenv`, `os.setlocale` | read the server's environment / change its global state |
+| `os.remove`, `os.rename`, `os.tmpname` | file access |
+| `debug` | Lua's introspection escape hatch |
+
+This matters because a screen repo is re-fetched on a timer: an upstream change
+runs new Lua on your server without anyone reading it first.

--- a/src/services/lua_runtime.rs
+++ b/src/services/lua_runtime.rs
@@ -912,6 +912,11 @@ const DENIED_OS_MEMBERS: [&str; 7] = [
 /// the mapped host directories. So the library set is named explicitly and the
 /// leftover sharp edges are removed from the globals.
 fn new_sandboxed_lua() -> LuaResult<Lua> {
+    // These are the *optional* libraries. Lua's base library — `pcall`,
+    // `type`, `tostring`, `pairs` — is not among them and cannot be opted out
+    // of: mlua opens it at state creation, outside this bitmask. Its sharp
+    // edges are taken off below instead.
+    //
     // `io` and `package` are left out wholesale. `package` costs nothing:
     // `install_require` supplies `require`, and mlua's safe mode already
     // refuses `package.loadlib` and C modules.
@@ -1028,7 +1033,15 @@ impl LuaRuntime {
         // screen repo could ship crafted bytecode and walk straight out of the
         // VM. A screen's script.lua is source code; refuse to read it as
         // anything else. Same reasoning in `install_require`.
-        let result: Table = lua.load(script_src).set_mode(ChunkMode::Text).eval()?;
+        // `set_name` matters for the same reason: mlua otherwise labels the
+        // chunk with the Rust call site, so a screen's own error came back
+        // reading `src/services/lua_runtime.rs:<line>` — byonk taking the
+        // blame for the author's typo.
+        let result: Table = lua
+            .load(script_src)
+            .set_name(screen_name)
+            .set_mode(ChunkMode::Text)
+            .eval()?;
 
         // Extract data, refresh_rate, skip_update, and colors
         let data = self.table_to_json(&lua, result.get::<Table>("data")?)?;

--- a/src/services/lua_runtime.rs
+++ b/src/services/lua_runtime.rs
@@ -1,7 +1,10 @@
 // Arc<Html> is used in single-threaded Lua context, so Send+Sync not required
 #![allow(clippy::arc_with_non_send_sync)]
 
-use mlua::{Lua, Result as LuaResult, Table, UserData, UserDataMethods, Value};
+use mlua::{
+    ChunkMode, Lua, LuaOptions, Result as LuaResult, StdLib, Table, UserData, UserDataMethods,
+    Value,
+};
 use scraper::{Html, Selector};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -878,6 +881,60 @@ impl ScreenRepoSource for AssetScreensSource {
     }
 }
 
+/// Base-library globals a screen script has no business calling. Each one
+/// opens a file by name, which is the reach this sandbox exists to deny;
+/// `load` additionally compiles attacker-chosen bytecode, and crafted bytecode
+/// escapes the VM outright. `require` is not among them — `install_require`
+/// replaces it with a resolver confined to the screen repo and `byonk-base`.
+const DENIED_BASE_GLOBALS: [&str; 3] = ["dofile", "loadfile", "load"];
+
+/// `os` members a screen script has no business calling. `exit` would take the
+/// whole server down with one screen; `getenv` reads the process environment,
+/// which under the Home Assistant app is where byonk's own configuration
+/// lives. What stays is the clock: `time`, `date`, `clock`, `difftime`.
+const DENIED_OS_MEMBERS: [&str; 7] = [
+    "execute",
+    "exit",
+    "getenv",
+    "remove",
+    "rename",
+    "setlocale",
+    "tmpname",
+];
+
+/// Build the Lua VM a screen script runs in.
+///
+/// `Lua::new()` loads `StdLib::ALL_SAFE`, and "safe" there means only that
+/// `debug` and `ffi` stay out — `io`, `os` and `package` are all in. Screens
+/// come from screen repos that byonk re-fetches on a timer, so an upstream
+/// change runs new Lua unreviewed; a screen that can call `io.open` can write
+/// anywhere the byonk process can, which under the Home Assistant app means
+/// the mapped host directories. So the library set is named explicitly and the
+/// leftover sharp edges are removed from the globals.
+fn new_sandboxed_lua() -> LuaResult<Lua> {
+    // `io` and `package` are left out wholesale. `package` costs nothing:
+    // `install_require` supplies `require`, and mlua's safe mode already
+    // refuses `package.loadlib` and C modules.
+    let libs = StdLib::COROUTINE
+        | StdLib::TABLE
+        | StdLib::STRING
+        | StdLib::UTF8
+        | StdLib::MATH
+        | StdLib::OS;
+    let lua = Lua::new_with(libs, LuaOptions::default())?;
+
+    let globals = lua.globals();
+    for name in DENIED_BASE_GLOBALS {
+        globals.set(name, Value::Nil)?;
+    }
+    let os: Table = globals.get("os")?;
+    for name in DENIED_OS_MEMBERS {
+        os.set(name, Value::Nil)?;
+    }
+
+    Ok(lua)
+}
+
 /// Lua runtime for executing screen scripts
 pub struct LuaRuntime {
     asset_loader: Arc<AssetLoader>,
@@ -935,7 +992,7 @@ impl LuaRuntime {
         timestamp_override: Option<i64>,
         caller_log_sink: Option<&Arc<Mutex<Vec<String>>>>,
     ) -> Result<ScriptResult, ScriptError> {
-        let lua = Lua::new();
+        let lua = new_sandboxed_lua()?;
         // Captures log_info/log_warn/log_error output for this run, in
         // addition to the tracing calls those hooks already make (see
         // `ScriptResult::logs`). Uses the caller's sink when given (see
@@ -965,8 +1022,13 @@ impl LuaRuntime {
         // Install the sandboxed `require()` scoped to this screen repo + byonk-base.
         self.install_require(&lua, source)?;
 
-        // Execute the script
-        let result: Table = lua.load(script_src).eval()?;
+        // Execute the script. `set_mode(Text)` is part of the sandbox, not a
+        // formality: mlua sniffs the source and switches to the bytecode
+        // loader by itself, and that loader trusts what it is given, so a
+        // screen repo could ship crafted bytecode and walk straight out of the
+        // VM. A screen's script.lua is source code; refuse to read it as
+        // anything else. Same reasoning in `install_require`.
+        let result: Table = lua.load(script_src).set_mode(ChunkMode::Text).eval()?;
 
         // Extract data, refresh_rate, skip_update, and colors
         let data = self.table_to_json(&lua, result.get::<Table>("data")?)?;
@@ -1145,7 +1207,12 @@ impl LuaRuntime {
                 code.ok_or_else(|| mlua::Error::external(format!("module '{name}' not found")))?;
 
             // 5. Evaluate, cache, return.
-            let value: Value = lua.load(&code).set_name(&name).eval()?;
+            // Text only — see the `set_mode` note in `run_script`.
+            let value: Value = lua
+                .load(&code)
+                .set_name(&name)
+                .set_mode(ChunkMode::Text)
+                .eval()?;
             cache.set(name.clone(), value.clone())?;
             Ok(value)
         })?;

--- a/tests/lua_sandbox_test.rs
+++ b/tests/lua_sandbox_test.rs
@@ -1,0 +1,194 @@
+//! Tests for the Lua sandbox boundary.
+//!
+//! Screen scripts come from screen repos that byonk re-fetches on a timer, so
+//! an upstream change runs new Lua without anyone looking at it. The VM must
+//! therefore not hand a script the filesystem or the process: no `io`, no
+//! `os.execute`, no `os.exit`. The time helpers screens actually use stay.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use byonk::assets::AssetLoader;
+use byonk::services::LuaRuntime;
+use tempfile::TempDir;
+
+/// Create a screens dir holding `scripts`, plus a loader that reads from it.
+fn setup_test_env(scripts: &[(&str, &str)]) -> (TempDir, Arc<AssetLoader>) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let screens_dir = temp_dir.path().to_path_buf();
+
+    for (name, content) in scripts {
+        std::fs::write(screens_dir.join(name), content).expect("Failed to write test script");
+    }
+
+    let asset_loader = Arc::new(AssetLoader::new(Some(screens_dir), None, None));
+    (temp_dir, asset_loader)
+}
+
+/// The one that matters: a script must not be able to create a file. With the
+/// `io` library loaded this wrote "pwned" to disk; the add-on maps host
+/// directories, so that reach is a real escape, not a theoretical one.
+#[test]
+fn a_screen_script_cannot_write_a_file() {
+    let target_dir = TempDir::new().expect("Failed to create target dir");
+    let target = target_dir.path().join("escaped.txt");
+
+    let script = format!(
+        r#"
+        local ok, err = pcall(function()
+            local f = io.open([[{}]], "w")
+            f:write("pwned")
+            f:close()
+        end)
+        return {{ data = {{ ok = ok, err = tostring(err) }}, refresh_rate = 60 }}
+        "#,
+        target.display()
+    );
+
+    let (_temp_dir, asset_loader) = setup_test_env(&[("escape.lua", script.as_str())]);
+    let runtime = LuaRuntime::new(asset_loader);
+
+    let result = runtime
+        .run_script_from_asset(
+            std::path::Path::new("escape.lua"),
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .expect("the script guards its own failure with pcall, so the run succeeds");
+
+    assert_eq!(
+        result.data["ok"], false,
+        "opening a file for writing must fail, got: {}",
+        result.data["err"]
+    );
+    assert!(
+        !target.exists(),
+        "a screen script wrote {} — the sandbox leaks the filesystem",
+        target.display()
+    );
+}
+
+/// Every name a script could use to reach the filesystem, the environment or
+/// the process is gone. `os.exit` alone would let one screen kill the server.
+#[test]
+fn dangerous_stdlib_entries_are_absent_from_a_screen_script() {
+    let script = r#"
+        local function gone(v) return v == nil end
+        return {
+            data = {
+                io = gone(io),
+                package = gone(package),
+                dofile = gone(dofile),
+                loadfile = gone(loadfile),
+                load = gone(load),
+                os_execute = gone(os.execute),
+                os_exit = gone(os.exit),
+                os_getenv = gone(os.getenv),
+                os_remove = gone(os.remove),
+                os_rename = gone(os.rename),
+                os_setlocale = gone(os.setlocale),
+                os_tmpname = gone(os.tmpname),
+            },
+            refresh_rate = 60
+        }
+    "#;
+
+    let (_temp_dir, asset_loader) = setup_test_env(&[("probe.lua", script)]);
+    let runtime = LuaRuntime::new(asset_loader);
+
+    let result = runtime
+        .run_script_from_asset(
+            std::path::Path::new("probe.lua"),
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .expect("the probe script only reads globals");
+
+    for name in [
+        "io",
+        "package",
+        "dofile",
+        "loadfile",
+        "load",
+        "os_execute",
+        "os_exit",
+        "os_getenv",
+        "os_remove",
+        "os_rename",
+        "os_setlocale",
+        "os_tmpname",
+    ] {
+        assert_eq!(
+            result.data[name], true,
+            "`{name}` is still reachable from a screen script"
+        );
+    }
+}
+
+/// Taking `load` away from scripts is pointless if byonk itself will load a
+/// precompiled chunk: mlua sniffs the source and switches to binary mode on
+/// its own, and crafted bytecode escapes the VM whatever the globals say. A
+/// `script.lua` is source code, so byonk must load it as text and say so.
+#[test]
+fn a_screen_script_is_loaded_as_text_never_as_bytecode() {
+    // The Lua bytecode signature, ESC "Lua". Valid UTF-8, so it survives the
+    // read; what follows does not matter, only which loader gets it.
+    let script = "\u{1b}Lua not really bytecode";
+
+    let (_temp_dir, asset_loader) = setup_test_env(&[("bytecode.lua", script)]);
+    let runtime = LuaRuntime::new(asset_loader);
+
+    let err = runtime
+        .run_script_from_asset(
+            std::path::Path::new("bytecode.lua"),
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .expect_err("a chunk that claims to be bytecode must not load");
+
+    assert!(
+        err.to_string().contains("attempt to load a binary chunk"),
+        "byonk fed the chunk to the bytecode loader instead of refusing it: {err}"
+    );
+}
+
+/// The counterweight to the test above: the clock functions screens do use
+/// (`screens/examples/gphoto/script.lua` calls `os.time`) must survive.
+#[test]
+fn the_time_functions_screens_use_still_work() {
+    let script = r#"
+        local t = os.time()
+        local d = os.date("!%Y", 0)
+        return {
+            data = {
+                time_is_number = type(t) == "number",
+                time_is_positive = t > 0,
+                date_of_epoch = d,
+                difftime = os.difftime(10, 4),
+                clock_is_number = type(os.clock()) == "number",
+            },
+            refresh_rate = 60
+        }
+    "#;
+
+    let (_temp_dir, asset_loader) = setup_test_env(&[("clock.lua", script)]);
+    let runtime = LuaRuntime::new(asset_loader);
+
+    let result = runtime
+        .run_script_from_asset(
+            std::path::Path::new("clock.lua"),
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .expect("the clock functions must stay available to screens");
+
+    assert_eq!(result.data["time_is_number"], true);
+    assert_eq!(result.data["time_is_positive"], true);
+    assert_eq!(result.data["date_of_epoch"], "1970");
+    assert_eq!(result.data["difftime"], 6.0);
+    assert_eq!(result.data["clock_is_number"], true);
+}

--- a/tests/lua_sandbox_test.rs
+++ b/tests/lua_sandbox_test.rs
@@ -79,6 +79,7 @@ fn dangerous_stdlib_entries_are_absent_from_a_screen_script() {
             data = {
                 io = gone(io),
                 package = gone(package),
+                debug = gone(debug),
                 dofile = gone(dofile),
                 loadfile = gone(loadfile),
                 load = gone(load),
@@ -109,6 +110,7 @@ fn dangerous_stdlib_entries_are_absent_from_a_screen_script() {
     for name in [
         "io",
         "package",
+        "debug",
         "dofile",
         "loadfile",
         "load",
@@ -152,6 +154,41 @@ fn a_screen_script_is_loaded_as_text_never_as_bytecode() {
     assert!(
         err.to_string().contains("attempt to load a binary chunk"),
         "byonk fed the chunk to the bytecode loader instead of refusing it: {err}"
+    );
+}
+
+/// A sandbox that refuses things has to say whose script it refused. Without a
+/// chunk name mlua labels the chunk with the Rust call site, so every screen
+/// error read `src/services/lua_runtime.rs:<line>` — byonk blaming itself for
+/// the author's typo.
+#[test]
+fn a_script_error_names_the_screen_not_byonks_own_source() {
+    let script = r#"error("boom")"#;
+
+    let (_temp_dir, asset_loader) = setup_test_env(&[("broken.lua", script)]);
+    let runtime = LuaRuntime::new(asset_loader);
+
+    let err = runtime
+        .run_script_from_asset(
+            std::path::Path::new("broken.lua"),
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .expect_err("the script raises");
+    let message = err.to_string();
+
+    assert!(
+        message.contains("boom"),
+        "the author's own message must survive: {message}"
+    );
+    assert!(
+        message.contains("broken"),
+        "the error must name the screen it came from: {message}"
+    );
+    assert!(
+        !message.contains("lua_runtime.rs"),
+        "the error points at byonk's source instead of the screen: {message}"
     );
 }
 


### PR DESCRIPTION
## What

The Lua API reference has always said **"Not available: File I/O, OS functions"**. The VM never withheld them.

`Lua::new()` loads `StdLib::ALL_SAFE`, and *safe* there means only that `debug` and `ffi` stay out — `io`, `os` and `package` are all in. So a screen script could:

- `io.open(path, "w")` and write anywhere the byonk process can,
- `os.getenv` to read byonk's own environment,
- `os.exit` to stop the server.

The first test in this PR proved it by actually writing a file to disk.

A second hole in the same class: mlua auto-detects the chunk mode and switches to the **bytecode** loader by itself, and that loader trusts its input. Crafted bytecode escapes the VM whatever the globals say — so taking `load` away from scripts while byonk itself sniffed the mode would have been theatre. The failing test got `bad binary format (version mismatch)` back, which is the undumper speaking.

## Why it matters

A screen repo is re-fetched on a timer, so an upstream change runs new Lua on the server with nobody reading it first. Under the Home Assistant app the container also maps host directories, which widens the blast radius.

## The change

In `src/services/lua_runtime.rs`:

- `new_sandboxed_lua()` names the library set explicitly — `coroutine`, `table`, `string`, `utf8`, `math`, `os` — then nils `dofile`, `loadfile`, `load` and `os.execute` / `exit` / `getenv` / `remove` / `rename` / `setlocale` / `tmpname`.
- `set_mode(ChunkMode::Text)` on both places byonk loads screen-repo Lua (`run_script` and `install_require`).

Dropping `package` costs nothing: `install_require` already supplies a `require` confined to the screen's own repo and `byonk-base`, and mlua's safe mode already refused `package.loadlib`.

## What still works

`os.time`, `os.date`, `os.clock`, `os.difftime`, `require`, `read_asset` and the HTTP functions. The only standard-library call anywhere in `screens/` or `byonk-base/` is `os.time` in `screens/examples/gphoto/script.lua:90`; a test guards it against over-removal.

## Tests

`tests/lua_sandbox_test.rs`, four tests, each written before the fix and watched fail (except the guard, which passed before and after by design):

| Test | Proves |
|---|---|
| `a_screen_script_cannot_write_a_file` | `io.open` no longer creates a file on disk |
| `dangerous_stdlib_entries_are_absent_from_a_screen_script` | all 12 removed names evaluate to `nil` |
| `a_screen_script_is_loaded_as_text_never_as_bytecode` | a chunk claiming to be bytecode is refused, not undumped |
| `the_time_functions_screens_use_still_work` | the clock survives |

`make check` passes: fmt, `clippy --workspace --all-targets -D warnings`, and the full suite.

## Docs

`docs/src/api/lua-api.md` now lists exactly what is withheld and why, instead of the one-line claim it was not honouring. The MCP resource `byonk://reference/lua-api` serves that same file, so screen-authoring agents get it too.

## Left out on purpose

`src/services/screen_store.rs:997` builds a plain `Lua::new()` to *compile* a script during validation. It never executes, and its reader rejects non-UTF-8 before the compile step, so bytecode cannot realistically reach it. Aligning it would be production code with no test behind it — happy to add it with a test if you want the symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)