### PR TITLE
ci: check the whole workspace, not just the root package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Run Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     name: Test
@@ -64,7 +64,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --workspace
 
   build:
     name: Build


### PR DESCRIPTION
## What

Two words, two lines:

```diff
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings

-        run: cargo test
+        run: cargo test --workspace
```

## Why

`make check` has been running the wider commands locally all along. CI was running the narrow ones, and the gap is not cosmetic.

**CI never ran the workspace crates' tests.** The workspace has three members:

```toml
members = [".", "crates/eink-dither", "crates/eink-photo"]
```

A bare `cargo test` runs only the root package. So the **337 test functions** in `crates/eink-dither` and `crates/eink-photo` never ran in CI — including the colour-accuracy tests that took real work to land.

**CI never linted test code.** Without `--all-targets`, clippy sees the lib and bins only. The 30 integration-test binaries in `tests/` were never linted, so `-D warnings` did not apply to any of them.

Net effect: a broken `eink-dither` test, or a clippy error in test code, could reach `main` with every check reporting green.

## Cost

The three jobs stay parallel and the `target/` cache stays keyed on `Cargo.lock`, so the extra work is compiling two small crates and the test targets — which the `test` job already compiles anyway. This PR's own CI run is the measurement.

## Not changed

The `build` job stays `cargo build`, matching the Makefile's `debug` target. `cargo fmt --check` already covers the workspace by default.

No `CHANGES.md` entry: nothing here is visible to a byonk user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)